### PR TITLE
Add manualRules to tailoredProfile CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Enhancements
 
--
+- Added `maunalRules` to `TailoredProfile` CRD, user can choose to add the rule
+  there so that those rules will show Manual as results and remediations will not be 
+  created.
 
 ### Fixes
 

--- a/deploy/compliance-operator-chart/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
+++ b/deploy/compliance-operator-chart/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
@@ -82,6 +82,25 @@ spec:
               extends:
                 description: Points to the name of the profile to extend
                 type: string
+              manualRules:
+                description: Disables the automated check on referenced rules for
+                  manual check
+                items:
+                  description: RuleReferenceSpec specifies a rule to be selected/deselected,
+                    as well as the reason why
+                  properties:
+                    name:
+                      description: Name of the rule that's being referenced
+                      type: string
+                    rationale:
+                      description: Rationale of why this rule is being selected/deselected
+                      type: string
+                  required:
+                  - name
+                  - rationale
+                  type: object
+                nullable: true
+                type: array
               setValues:
                 description: Sets the referenced variables to selected values
                 items:

--- a/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
+++ b/deploy/crds/compliance.openshift.io_tailoredprofiles_crd.yaml
@@ -82,6 +82,25 @@ spec:
               extends:
                 description: Points to the name of the profile to extend
                 type: string
+              manualRules:
+                description: Disables the automated check on referenced rules for
+                  manual check
+                items:
+                  description: RuleReferenceSpec specifies a rule to be selected/deselected,
+                    as well as the reason why
+                  properties:
+                    name:
+                      description: Name of the rule that's being referenced
+                      type: string
+                    rationale:
+                      description: Rationale of why this rule is being selected/deselected
+                      type: string
+                  required:
+                  - name
+                  - rationale
+                  type: object
+                nullable: true
+                type: array
               setValues:
                 description: Sets the referenced variables to selected values
                 items:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -338,6 +338,12 @@ rules:
   - get
   - update
   - patch
+- apiGroups:
+  - compliance.openshift.io
+  resources:
+  - tailoredprofiles
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -271,6 +271,11 @@ Notable attributes:
 * **spec.disableRules**: A list of `name` and `rationale` pairs. Each name refers to a name
   of a `Rule` object that is supposed to be disabled. `Rationale` is a human-readable text
   describing why the rule is disabled.
+* **spec.manualRules**: A list of `name` and `rationale` pairs. Each name refers to a name
+  of a `Rule` object that is supposed to be disabled for its automated check. `Rationale` 
+  is a human-readable text describing why the rule is disabled for manual checks. When `rule`
+  is added as manual rule, it will always show `MANUAL` as check result status, and remediation
+  will not be generated.
 * **spec.enableRules**: Equivalent of `disableRules`, except enables rules that might be
   disabled by default.
 * **spec.setValues**: Allows for setting specific values to something other

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -1,8 +1,6 @@
 package v1alpha1
 
 import (
-	"strings"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -95,15 +93,6 @@ type ComplianceCheckResult struct {
 	Warnings []string `json:"warnings,omitempty"`
 	// It stores a list of values used by the check
 	ValuesUsed []string `json:"valuesUsed,omitempty"`
-}
-
-// IDToDNSFriendlyName gets the ID from the scan and returns a DNS
-// friendly name
-func (ccr *ComplianceCheckResult) IDToDNSFriendlyName() string {
-	const rulePrefix = "xccdf_org.ssgproject.content_rule_"
-	ruleName := strings.TrimPrefix(ccr.ID, rulePrefix)
-	dnsFriendlyFixID := strings.ReplaceAll(ruleName, "_", "-")
-	return strings.ToLower(dnsFriendlyFixID)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
+++ b/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
@@ -43,6 +43,10 @@ type TailoredProfileSpec struct {
 	// +optional
 	// +nullable
 	DisableRules []RuleReferenceSpec `json:"disableRules,omitempty"`
+	// Disables the automated check on referenced rules for manual check
+	// +optional
+	// +nullable
+	ManualRules []RuleReferenceSpec `json:"manualRules,omitempty"`
 	// Sets the referenced variables to selected values
 	// +optional
 	// +nullable

--- a/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
@@ -1158,6 +1158,11 @@ func (in *TailoredProfileSpec) DeepCopyInto(out *TailoredProfileSpec) {
 		*out = make([]RuleReferenceSpec, len(*in))
 		copy(*out, *in)
 	}
+	if in.ManualRules != nil {
+		in, out := &in.ManualRules, &out.ManualRules
+		*out = make([]RuleReferenceSpec, len(*in))
+		copy(*out, *in)
+	}
 	if in.SetValues != nil {
 		in, out := &in.SetValues, &out.SetValues
 		*out = make([]VariableValueSpec, len(*in))

--- a/pkg/controller/tailoredprofile/tailoredprofile_controller_test.go
+++ b/pkg/controller/tailoredprofile/tailoredprofile_controller_test.go
@@ -3,6 +3,7 @@ package tailoredprofile
 import (
 	"context"
 	"fmt"
+
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/openshift/compliance-operator/pkg/controller/metrics"
@@ -144,6 +145,12 @@ var _ = Describe("TailoredprofileController", func() {
 							Rationale: "Why not",
 						},
 					},
+					ManualRules: []compv1alpha1.RuleReferenceSpec{
+						{
+							Name:      "rule-1",
+							Rationale: "Why not",
+						},
+					},
 				},
 			}
 
@@ -198,6 +205,7 @@ var _ = Describe("TailoredprofileController", func() {
 			Expect(data).To(ContainSubstring(`extends="profile_1"`))
 			Expect(data).To(ContainSubstring(`select idref="rule_3" selected="true"`))
 			Expect(data).To(ContainSubstring(`select idref="rule_2" selected="false"`))
+			Expect(data).To(ContainSubstring(`select idref="rule_1" selected="true"`))
 		})
 		It("Updates a configMap when the TP is updated", func() {
 			tpKey := types.NamespacedName{

--- a/pkg/profileparser/profileparser_suite_test.go
+++ b/pkg/profileparser/profileparser_suite_test.go
@@ -1,9 +1,9 @@
 package profileparser
 
 import (
-	"testing"
-	"os"
 	"fmt"
+	"os"
+	"testing"
 
 	compapis "github.com/openshift/compliance-operator/pkg/apis"
 	cmpv1alpha1 "github.com/openshift/compliance-operator/pkg/apis/compliance/v1alpha1"

--- a/pkg/utils/nameutils.go
+++ b/pkg/utils/nameutils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"io"
+	"strings"
 )
 
 // LengthName creates a string of maximum defined length.
@@ -35,4 +36,13 @@ func DNSLengthName(hashPrefix string, format string, a ...interface{}) string {
 	// TODO(jaosorior): Handle error
 	name, _ := LengthName(maxDNSLen, hashPrefix, format, a...)
 	return name
+}
+
+// IDToDNSFriendlyName gets the ID from the scan and returns a DNS
+// friendly name
+func IDToDNSFriendlyName(ruleIdRef string) string {
+	const rulePrefix = "xccdf_org.ssgproject.content_rule_"
+	ruleName := strings.TrimPrefix(ruleIdRef, rulePrefix)
+	dnsFriendlyFixID := strings.ReplaceAll(ruleName, "_", "-")
+	return strings.ToLower(dnsFriendlyFixID)
 }

--- a/pkg/xccdf/tailoring.go
+++ b/pkg/xccdf/tailoring.go
@@ -118,7 +118,32 @@ func getSelections(tp *cmpv1alpha1.TailoredProfile, rules map[string]*cmpv1alpha
 		rule := rules[selection.Name]
 		selections = append(selections, getSelectElementFromCRRule(rule, false))
 	}
+
+	for _, selection := range tp.Spec.ManualRules {
+		rule := rules[selection.Name]
+		selections = append(selections, getSelectElementFromCRRule(rule, true))
+	}
 	return selections
+}
+
+func GetManualRules(tp *cmpv1alpha1.TailoredProfile) []string {
+	ruleList := []string{}
+	for _, selection := range tp.Spec.ManualRules {
+		ruleList = append(ruleList, selection.Name)
+	}
+	return ruleList
+}
+
+func IsManualRule(ruleName string, manualRules []string) bool {
+	if manualRules == nil {
+		return false
+	}
+	for _, manualRule := range manualRules {
+		if strings.HasSuffix(manualRule, ruleName) {
+			return true
+		}
+	}
+	return false
 }
 
 func getValuesFromVariables(variables []*cmpv1alpha1.Variable) []SetValueElement {


### PR DESCRIPTION
This PR enables users to disable automated checks on rules so that they can check those rules manually. They can do that by adding rules under manualRules in TailoredProfile Spec.
ex.
```
apiVersion: compliance.openshift.io/v1alpha1
kind: TailoredProfile
metadata:
  name: mod-node
spec:
  title: My modified profile with manual rules
  manualRules:
  - name: ocp4-kubelet-eviction-thresholds-set-soft-imagefs-available
    rationale: test
  description: test
```