### PR TITLE
Bug 2082151: Fix scanner pod script mount permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
--
+- Fix OpenScap scanner container crashloop caused by script mount permission issue
+  on a security envronment where DAC_OVERRIDE capability is dropped. This PR chanes
+  script mount permission to give excute permission to all users.
+  [bug](https://bugzilla.redhat.com/show_bug.cgi?id=2082151) for more information.
 
 ### Internal Changes
 

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -274,7 +274,7 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 }
 
 func (r *ReconcileComplianceScan) newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Logger) *corev1.Pod {
-	mode := int32(0744)
+	mode := int32(0755)
 	podName := getPodForNodeName(scanInstance.Name, PlatformScanName)
 	cmName := getConfigMapForNodeName(scanInstance.Name, PlatformScanName)
 	podLabels := map[string]string{


### PR DESCRIPTION
Fix OpenScap scanner container crashloop caused by script mount permission issue on a security envronment where DAC_OVERRIDE capability is dropped. This PR chanes script mount permission to give excute permission to all users. [bug](https://bugzilla.redhat.com/show_bug.cgi?id=2082151) for more information.