### PR TITLE
Add container release jobs

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -1,0 +1,17 @@
+name: Release latest
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Push to latest
+  container-push-latest:
+    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
+    with:
+      name: compliance-operator
+      registry_org: complianceascode
+      tag: latest
+      dockerfile_path: build/Dockerfile
+      vendor: 'Compliance Operator Authors'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v**
+
+jobs:
+  container-main:
+    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
+    with:
+      name: compliance-operator
+      registry_org: complianceascode
+      tag: ${GITHUB_REF_NAME}
+      dockerfile_path: Dockerfile
+      vendor: 'Compliance Operator Authors'


### PR DESCRIPTION
This adds two jobs:

* One that with every push to the `master` branch, will build and
  publish the compliance-operator container to the `latest` tag.

* Another one that with every release tag (e.g. `v0.1.51`), will build
  and publish to that specific tag.

Both of these jobs publish the container images to the GitHub container
registry (`ghcr.io`), do container signing via sigstore and generate
provenance information.