### PR TITLE
Use content image from GHCR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,8 @@ E2E_SKIP_CONTAINER_BUILD?=false
 E2E_GO_TEST_FLAGS?=-test.v -test.timeout 120m
 
 # Specifies the image path to use for the content in the tests
-DEFAULT_CONTENT_IMAGE_PATH=quay.io/compliance-operator/compliance-operator-content:latest
-E2E_CONTENT_IMAGE_PATH?=quay.io/compliance-operator/compliance-operator-content:latest
+DEFAULT_CONTENT_IMAGE_PATH=ghcr.io/complianceascode/k8scontent:latest
+E2E_CONTENT_IMAGE_PATH?=ghcr.io/complianceascode/k8scontent:latest
 # We specifically omit the tag here since we use this for testing
 # different images referenced by different tags.
 E2E_BROKEN_CONTENT_IMAGE_PATH?=quay.io/compliance-operator/test-broken-content


### PR DESCRIPTION
We've been building Kubernetes content in a [GitHub Action](https://github.com/ComplianceAsCode/content/blob/master/.github/workflows/k8s-content.yaml)
for a while now; let's take that into use!

This now uses `ghcr.io/complianceascode/k8scontent:latest` which allows
us to fetch the latest content from ComplianceAsCode/content and is also
signed.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
