### PR TITLE
Fix up release notes for 0.1.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,36 +7,21 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-### Enhancements
-
--
-
 ### Fixes
 
-- The openshift-compliance namespace was labeled with pod-security.kubernetes.io/
-  labels. Previously on clusters where Pod Security Admission is used and the
-  restricted profiles is in use, the Compliance Operator privileged pods would
-  have either been denied or, in case the cluster is configured to only warn
-  about non-compliant pods, would trigger events with warnings.
-  See this [bug](https://bugzilla.redhat.com/show_bug.cgi?id=2088202) for more
-  information.
-
-### Internal Changes
-
-- Several workloads have had their permissions tightened, including explicitly
-  running as a non-root user or dropping all capabilities as appropriate
-
-### Deprecations
-
--
-
-### Removals
-
--
+- The `openshift-compliance` namespace was labeled with `pod-security.kubernetes.io/`
+  labels. Previously, clusters using Pod Security Admission and restricted
+  profiles, the Compliance Operator privileged pods would have either been
+  denied or, in case the cluster is configured to only warn about non-compliant
+  pods, would trigger events with warnings. See this
+  [bug](https://bugzilla.redhat.com/show_bug.cgi?id=2088202) for more
+  information. No action is required from users to consume this fix.
 
 ### Security
 
--
+- Several workloads have had their permissions tightened, including explicitly
+  running as a non-root user or dropping all capabilities as appropriate. This
+  is an internal change and doesn't require any action from users.
 
 
 ## [0.1.52] - 2022-05-19


### PR DESCRIPTION
This commit removes unpopulated sections of the change log, uses
literals where appropriate, and clarifies what users need to do, if
anything, to consume the updates in the new version of the compliance
operator.