### PR TITLE
Fix the dockerfile path in the release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,5 +12,5 @@ jobs:
       name: compliance-operator
       registry_org: complianceascode
       tag: ${GITHUB_REF_NAME}
-      dockerfile_path: Dockerfile
+      dockerfile_path: build/Dockerfile
       vendor: 'Compliance Operator Authors'


### PR DESCRIPTION
This CI is failing because the Dockerfile is not available:

  unable to prepare context: unable to evaluate symlinks in Dockerfile
  path: lstat
  /home/runner/work/compliance-operator/compliance-operator/Dockerfile:
  no such file or directory

This commit attempts to fix the issue by using the correct dockerfile
path.