### PR TITLE
Use an absolute reference for the release remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added a template for proposing and discussing
   [enhancements](https://github.com/ComplianceAsCode/compliance-operator/tree/master/enhancements).
+- Use the upstream remote URL for the repository during the release process.
+  This makes the release process consistent for all contributors, regardless of
+  how they configure their remotes. See the corresponding
+  [issue](https://github.com/ComplianceAsCode/compliance-operator/issues/8) for
+  more information.
 
 ### Deprecations
 

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,10 @@ SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./
 
 MUST_GATHER_IMAGE_PATH?=$(IMAGE_REPO)/must-gather
 MUST_GATHER_IMAGE_TAG?=$(TAG)
+# Set this to the remote used for the upstream repo (for release). Use an
+# absolute reference by default since we don't know if origin is the
+# contributor's fork or if it's the upstream repository.
+GIT_REMOTE?=git@github.com:ComplianceAsCode/compliance-operator.git
 
 # Kubernetes variables
 # ====================
@@ -624,11 +628,11 @@ prepare-release: package-version-to-tag images git-release
 push-release: package-version-to-tag ## Do an official release (Requires permissions)
 	git commit -m "Release v$(TAG)"
 	git tag "v$(TAG)"
-	git push origin "v$(TAG)"
-	git push origin "release-v$(TAG)"
+	git push $(GIT_REMOTE) "v$(TAG)"
+	git push $(GIT_REMOTE) "release-v$(TAG)"
 	git checkout ocp-0.1
 	git merge "release-v$(TAG)"
-	git push origin ocp-0.1
+	git push $(GIT_REMOTE) ocp-0.1
 
 .PHONY: release-images
 release-images: package-version-to-tag push push-index undo-deploy-tag-image


### PR DESCRIPTION
We don't always know what repository the origin remote is pointing to,
but the release process expects it to be the upstream repository.

Let's make sure that's what we're pushing release information to.

Fixes #8