### PR TITLE
BUG 2102511: Fix hardcoded logic by filtering to expected file name.

### DIFF
--- a/pkg/utils/nodeutils.go
+++ b/pkg/utils/nodeutils.go
@@ -126,78 +126,89 @@ func IsMcfgPoolUsingKC(pool *mcfgv1.MachineConfigPool) (bool, string, error) {
 
 func AreKubeletConfigsRendered(pool *mcfgv1.MachineConfigPool, client runtimeclient.Client) (bool, error, string) {
 	// find out if pool is using a custom kubelet config
-	diffString := ""
 	isUsingKC, currentKCMCName, err := IsMcfgPoolUsingKC(pool)
 	if err != nil {
-		return false, fmt.Errorf("failed to check if pool %s is using a custom kubelet config: %w", pool.Name, err), diffString
+		return false, fmt.Errorf("failed to check if pool %s is using a custom kubelet config: %w", pool.Name, err), ""
 	}
 	if !isUsingKC || currentKCMCName == "" {
-		return true, nil, diffString
+		return true, nil, ""
 	}
 	// if the pool is using a custom kubelet config, check if the kubelet config is rendered
 	kcmcfg := &mcfgv1.MachineConfig{}
 	err = client.Get(context.TODO(), types.NamespacedName{Name: currentKCMCName}, kcmcfg)
 	if err != nil {
-		return false, fmt.Errorf("failed to get machine config %s: %w", currentKCMCName, err), diffString
+		return false, fmt.Errorf("failed to get machine config %s: %w", currentKCMCName, err), ""
 	}
 
 	kc, err := GetKCFromMC(kcmcfg, client)
 	if err != nil {
-		return false, fmt.Errorf("failed to get kubelet config from machine config %s: %w", currentKCMCName, err), diffString
+		return false, fmt.Errorf("failed to get kubelet config from machine config %s: %w", currentKCMCName, err), ""
+	}
+
+	return IsKCSubsetOfMC(kc, kcmcfg)
+}
+
+// IsKCSubsetOfMC determines if the KubeletConfig is a subset of the MachineConfig
+func IsKCSubsetOfMC(kc *mcfgv1.KubeletConfig, mc *mcfgv1.MachineConfig) (bool, error, string) {
+	if kc == nil {
+		return false, fmt.Errorf("kubelet config is nil"), ""
+	}
+	if mc == nil {
+		return false, fmt.Errorf("machine config is nil"), ""
 	}
 
 	var obj interface{}
-	err = json.Unmarshal(kcmcfg.Spec.Config.Raw, &obj)
-	if err != nil {
-		return false, fmt.Errorf("failed to unmarshal machine config %s: %w", currentKCMCName, err), diffString
+	if err := json.Unmarshal(mc.Spec.Config.Raw, &obj); err != nil {
+		return false, fmt.Errorf("failed to unmarshal machine config %s: %w", mc.Name, err), ""
 	}
 
 	// Filter to kubelet.conf file as other files (e.g. /etc/node-sizing-enabled.env) can exist.
 	encodedKC, err := jsonpath.Get(`$.storage.files[?(@.path == "/etc/kubernetes/kubelet.conf")].contents.source`, obj)
 	if err != nil {
-		return false, fmt.Errorf("failed to get encoded kubelet config from machine config %s: %w", currentKCMCName, err), diffString
+		return false, fmt.Errorf("failed to get encoded kubelet config from machine config %s: %w", mc.Name, err), ""
 	}
 	encodedKCSlice := encodedKC.([]interface{})
 	if len(encodedKCSlice) == 0 {
-		return false, fmt.Errorf("encoded kubeletconfig %s is missing", currentKCMCName), diffString
+		return false, fmt.Errorf("encoded kubeletconfig %s is missing", mc.Name), ""
 	}
 	encodedKCStr := encodedKCSlice[0].(string)
 	if encodedKCStr == "" {
-		return false, fmt.Errorf("encoded kubeletconfig %s is empty", currentKCMCName), diffString
+		return false, fmt.Errorf("encoded kubeletconfig %s is empty", mc.Name), ""
 	}
+
+	// Decode kubelet.conf file content
 	var encodedKCStrTrimmed string
 	var decodedKC []byte
 	if strings.HasPrefix(encodedKCStr, mcBase64PayloadPrefix) {
 		encodedKCStrTrimmed = strings.TrimPrefix(encodedKCStr, mcBase64PayloadPrefix)
 		decodedKC, err = base64.StdEncoding.DecodeString(encodedKCStrTrimmed)
 		if err != nil {
-			return false, fmt.Errorf("failed to decode base64 encoded kubeletconfig %s: %w", currentKCMCName, err), diffString
+			return false, fmt.Errorf("failed to decode base64 encoded kubeletconfig %s: %w", mc.Name, err), ""
 		}
 	} else if strings.HasPrefix(encodedKCStr, mcPayloadPrefix) {
 		encodedKCStrTrimmed = strings.TrimPrefix(encodedKCStr, mcPayloadPrefix)
 		decodedStr, err := url.PathUnescape(encodedKCStrTrimmed)
 		decodedKC = []byte(decodedStr)
 		if err != nil {
-			return false, fmt.Errorf("failed to decode urlencoded kubeletconfig %s: %w", currentKCMCName, err), diffString
+			return false, fmt.Errorf("failed to decode urlencoded kubeletconfig %s: %w", mc.Name, err), ""
 		}
 	} else {
-		return false, fmt.Errorf("encoded kubeletconfig %s does not contain encoding prefix", currentKCMCName), diffString
+		return false, fmt.Errorf("encoded kubeletconfig %s does not contain encoding prefix", mc.Name), ""
 	}
 
+	// Check if KubeletConfig is a subset of the MachineConfig
 	isSubset, diff, err := JSONIsSubset(kc.Spec.KubeletConfig.Raw, decodedKC)
 	if err != nil {
-		return false, fmt.Errorf("failed to check if kubeletconfig %s is subset of rendered MC %s: %w", kc.Name, currentKCMCName, err), ""
+		return false, fmt.Errorf("failed to check if kubeletconfig %s is subset of rendered MC %s: %w", kc.Name, mc.Name, err), ""
 	}
 	if isSubset {
-		return true, nil, diffString
-	} else {
-		diffData := make([][]string, 0)
-		for _, r := range diff.Rows {
-			diffData = append(diffData, []string{fmt.Sprintf("Path: %s", r.Key), fmt.Sprintf("Expected: %s", r.Expected), fmt.Sprintf("Got: %s", r.Got)})
-		}
-		diffString = fmt.Sprintf("kubeletconfig %s is not subset of rendered MC %s, diff: %v", kc.Name, currentKCMCName, diffData)
-		return false, nil, diffString
+		return true, nil, ""
 	}
+	diffData := make([][]string, 0)
+	for _, r := range diff.Rows {
+		diffData = append(diffData, []string{fmt.Sprintf("Path: %s", r.Key), fmt.Sprintf("Expected: %s", r.Expected), fmt.Sprintf("Got: %s", r.Got)})
+	}
+	return false, nil, fmt.Sprintf("kubeletconfig %s is not subset of rendered MC %s, diff: %v", kc.Name, mc.Name, diffData)
 }
 
 func GetKCFromMC(mc *mcfgv1.MachineConfig, client runtimeclient.Client) (*mcfgv1.KubeletConfig, error) {

--- a/pkg/utils/nodeutils.go
+++ b/pkg/utils/nodeutils.go
@@ -163,7 +163,7 @@ func IsKCSubsetOfMC(kc *mcfgv1.KubeletConfig, mc *mcfgv1.MachineConfig) (bool, e
 	}
 
 	// Filter to kubelet.conf file as other files (e.g. /etc/node-sizing-enabled.env) can exist.
-	encodedKC, err := jsonpath.Get(`$.storage.files[?(@.path == "/etc/kubernetes/kubelet.conf")].contents.source`, obj)
+	encodedKC, err := jsonpath.Get(`$.storage.files[?(@.path=="/etc/kubernetes/kubelet.conf")].contents.source`, obj)
 	if err != nil {
 		return false, fmt.Errorf("failed to get encoded kubelet config from machine config %s: %w", mc.Name, err), ""
 	}

--- a/pkg/utils/nodeutils.go
+++ b/pkg/utils/nodeutils.go
@@ -152,7 +152,8 @@ func AreKubeletConfigsRendered(pool *mcfgv1.MachineConfigPool, client runtimecli
 		return false, fmt.Errorf("failed to unmarshal machine config %s: %w", currentKCMCName, err), diffString
 	}
 
-	encodedKC, err := jsonpath.Get("storage.files[0].contents.source", obj)
+	// Filter to kubelet.conf file as other files (e.g. /etc/node-sizing-enabled.env) can exist.
+	encodedKC, err := jsonpath.Get(`storage.files[?(@.path=="/etc/kubernetes/kubelet.conf")].contents.source`, obj)
 	if err != nil {
 		return false, fmt.Errorf("failed to get encoded kubelet config from machine config %s: %w", currentKCMCName, err), diffString
 	}

--- a/pkg/utils/nodeutils_test.go
+++ b/pkg/utils/nodeutils_test.go
@@ -7,6 +7,7 @@ import (
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/openshift/compliance-operator/pkg/utils"
 )
@@ -206,6 +207,248 @@ var _ = Describe("Nodeutils", func() {
 			})
 
 		})
+	})
+
+	When("Testing IsKCSubsetOfMC", func() {
+		defaultKCPayload := `
+		{
+			"streamingConnectionIdleTimeout": "0s",
+			"something": "0s"
+		}
+		`
+		testKubeletConfig := func(kcPayload string) *mcfgv1.KubeletConfig {
+			return &mcfgv1.KubeletConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "KubeletConfig",
+					APIVersion: "machineconfiguration.openshift.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kubelet-config-compliance-operator",
+				},
+				Spec: mcfgv1.KubeletConfigSpec{
+					KubeletConfig: &runtime.RawExtension{
+						Raw: []byte(kcPayload),
+					},
+				},
+			}
+		}
+
+		testMachineConfig := func(renderdKC string) *mcfgv1.MachineConfig {
+			return &mcfgv1.MachineConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "MachineConfig",
+					APIVersion: "machineconfiguration.openshift.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "99-master-generated-kubelet",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "machineconfiguration.openshift.io/v1",
+							Kind:       "KubeletConfig",
+							Name:       "kubelet-config-compliance-operator",
+							UID:        "12345",
+						},
+					},
+				},
+				Spec: mcfgv1.MachineConfigSpec{
+					Config: runtime.RawExtension{
+						Raw: []byte(renderdKC),
+					},
+				},
+			}
+		}
+
+		Context("KubeletConfig is a subset of MachineConfig", func() {
+			renderdKC := `
+			{
+				"ignition": {
+					"version": "3.2.0"
+				},
+				"storage": {
+					"files": [
+						{
+							"contents": {
+								"source": "data:text/plain,%7B%0A%20%20%22kind%22%3A%20%22KubeletConfiguration%22%2C%0A%20%20%22apiVersion%22%3A%20%22kubelet.config.k8s.io%2Fv1beta1%22%2C%0A%20%20%22staticPodPath%22%3A%20%22%2Fetc%2Fkubernetes%2Fmanifests%22%2C%0A%20%20%22syncFrequency%22%3A%20%220s%22%2C%0A%20%20%22fileCheckFrequency%22%3A%20%220s%22%2C%0A%20%20%22httpCheckFrequency%22%3A%20%220s%22%2C%0A%20%20%22tlsCipherSuites%22%3A%20%5B%0A%20%20%20%20%22TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256%22%2C%0A%20%20%20%20%22TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256%22%2C%0A%20%20%20%20%22TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384%22%2C%0A%20%20%20%20%22TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384%22%2C%0A%20%20%20%20%22TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256%22%2C%0A%20%20%20%20%22TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256%22%0A%20%20%5D%2C%0A%20%20%22tlsMinVersion%22%3A%20%22VersionTLS12%22%2C%0A%20%20%22rotateCertificates%22%3A%20true%2C%0A%20%20%22serverTLSBootstrap%22%3A%20true%2C%0A%20%20%22authentication%22%3A%20%7B%0A%20%20%20%20%22x509%22%3A%20%7B%0A%20%20%20%20%20%20%22clientCAFile%22%3A%20%22%2Fetc%2Fkubernetes%2Fkubelet-ca.crt%22%0A%20%20%20%20%7D%2C%0A%20%20%20%20%22webhook%22%3A%20%7B%0A%20%20%20%20%20%20%22cacheTTL%22%3A%20%220s%22%0A%20%20%20%20%7D%2C%0A%20%20%20%20%22anonymous%22%3A%20%7B%0A%20%20%20%20%20%20%22enabled%22%3A%20false%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22authorization%22%3A%20%7B%0A%20%20%20%20%22webhook%22%3A%20%7B%0A%20%20%20%20%20%20%22cacheAuthorizedTTL%22%3A%20%220s%22%2C%0A%20%20%20%20%20%20%22cacheUnauthorizedTTL%22%3A%20%220s%22%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22clusterDomain%22%3A%20%22cluster.local%22%2C%0A%20%20%22clusterDNS%22%3A%20%5B%0A%20%20%20%20%22172.30.0.10%22%0A%20%20%5D%2C%0A%20%20%22streamingConnectionIdleTimeout%22%3A%20%220s%22%2C%0A%20%20%22nodeStatusUpdateFrequency%22%3A%20%220s%22%2C%0A%20%20%22nodeStatusReportFrequency%22%3A%20%220s%22%2C%0A%20%20%22imageMinimumGCAge%22%3A%20%220s%22%2C%0A%20%20%22volumeStatsAggPeriod%22%3A%20%220s%22%2C%0A%20%20%22systemCgroups%22%3A%20%22%2Fsystem.slice%22%2C%0A%20%20%22cgroupRoot%22%3A%20%22%2F%22%2C%0A%20%20%22cgroupDriver%22%3A%20%22systemd%22%2C%0A%20%20%22cpuManagerReconcilePeriod%22%3A%20%220s%22%2C%0A%20%20%22runtimeRequestTimeout%22%3A%20%220s%22%2C%0A%20%20%22maxPods%22%3A%20250%2C%0A%20%20%22something%22%3A%20%220s%22%2C%0A%20%20%22kubeAPIBurst%22%3A%20100%2C%0A%20%20%22serializeImagePulls%22%3A%20false%2C%0A%20%20%22evictionPressureTransitionPeriod%22%3A%20%220s%22%2C%0A%20%20%22featureGates%22%3A%20%7B%0A%20%20%20%20%22APIPriorityAndFairness%22%3A%20true%2C%0A%20%20%20%20%22CSIMigrationAWS%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationAzureDisk%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationAzureFile%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationGCE%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationOpenStack%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationvSphere%22%3A%20false%2C%0A%20%20%20%20%22DownwardAPIHugePages%22%3A%20true%2C%0A%20%20%20%20%22LegacyNodeRoleBehavior%22%3A%20false%2C%0A%20%20%20%20%22NodeDisruptionExclusion%22%3A%20true%2C%0A%20%20%20%20%22PodSecurity%22%3A%20true%2C%0A%20%20%20%20%22RotateKubeletServerCertificate%22%3A%20true%2C%0A%20%20%20%20%22ServiceNodeExclusion%22%3A%20true%2C%0A%20%20%20%20%22SupportPodPidsLimit%22%3A%20true%0A%20%20%7D%2C%0A%20%20%22memorySwap%22%3A%20%7B%7D%2C%0A%20%20%22containerLogMaxSize%22%3A%20%2250Mi%22%2C%0A%20%20%22systemReserved%22%3A%20%7B%0A%20%20%20%20%22ephemeral-storage%22%3A%20%221Gi%22%0A%20%20%7D%2C%0A%20%20%22logging%22%3A%20%7B%0A%20%20%20%20%22flushFrequency%22%3A%200%2C%0A%20%20%20%20%22verbosity%22%3A%200%2C%0A%20%20%20%20%22options%22%3A%20%7B%0A%20%20%20%20%20%20%22json%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22infoBufferSize%22%3A%20%220%22%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22shutdownGracePeriod%22%3A%20%220s%22%2C%0A%20%20%22shutdownGracePeriodCriticalPods%22%3A%20%220s%22%0A%7D%0A"
+							},
+							"mode": 420,
+							"overwrite": true,
+							"path": "/etc/kubernetes/kubelet.conf"
+						}
+					]
+				}
+			}`
+			kc := testKubeletConfig(defaultKCPayload)
+			mc := testMachineConfig(renderdKC)
+
+			It("It should evaluate as true", func() {
+				isSubset, err, diffString := utils.IsKCSubsetOfMC(kc, mc)
+				Expect(err).To(BeNil())
+				Expect(isSubset).To(BeTrue())
+				Expect(diffString).To(BeEmpty())
+			})
+		})
+
+		Context("KubeletConfig is a subset of MachineConfig with multiple files", func() {
+			renderdKC := `
+			{
+				"ignition": {
+					"version": "3.2.0"
+				},
+				"storage": {
+					"files": [
+						{
+							"contents": {
+								"source": "data:text/plain,NODE_SIZING_ENABLED%3Dtrue%0ASYSTEM_RESERVED_MEMORY%3D1Gi%0ASYSTEM_RESERVED_CPU%3D500m%0A"
+							},
+							"mode": 420,
+							"overwrite": true,
+							"path": "/etc/node-sizing-enabled.env"
+						},
+						{
+							"contents": {
+								"source": "data:text/plain,%7B%0A%20%20%22kind%22%3A%20%22KubeletConfiguration%22%2C%0A%20%20%22apiVersion%22%3A%20%22kubelet.config.k8s.io%2Fv1beta1%22%2C%0A%20%20%22staticPodPath%22%3A%20%22%2Fetc%2Fkubernetes%2Fmanifests%22%2C%0A%20%20%22syncFrequency%22%3A%20%220s%22%2C%0A%20%20%22fileCheckFrequency%22%3A%20%220s%22%2C%0A%20%20%22httpCheckFrequency%22%3A%20%220s%22%2C%0A%20%20%22tlsCipherSuites%22%3A%20%5B%0A%20%20%20%20%22TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256%22%2C%0A%20%20%20%20%22TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256%22%2C%0A%20%20%20%20%22TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384%22%2C%0A%20%20%20%20%22TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384%22%2C%0A%20%20%20%20%22TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256%22%2C%0A%20%20%20%20%22TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256%22%0A%20%20%5D%2C%0A%20%20%22tlsMinVersion%22%3A%20%22VersionTLS12%22%2C%0A%20%20%22rotateCertificates%22%3A%20true%2C%0A%20%20%22serverTLSBootstrap%22%3A%20true%2C%0A%20%20%22authentication%22%3A%20%7B%0A%20%20%20%20%22x509%22%3A%20%7B%0A%20%20%20%20%20%20%22clientCAFile%22%3A%20%22%2Fetc%2Fkubernetes%2Fkubelet-ca.crt%22%0A%20%20%20%20%7D%2C%0A%20%20%20%20%22webhook%22%3A%20%7B%0A%20%20%20%20%20%20%22cacheTTL%22%3A%20%220s%22%0A%20%20%20%20%7D%2C%0A%20%20%20%20%22anonymous%22%3A%20%7B%0A%20%20%20%20%20%20%22enabled%22%3A%20false%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22authorization%22%3A%20%7B%0A%20%20%20%20%22webhook%22%3A%20%7B%0A%20%20%20%20%20%20%22cacheAuthorizedTTL%22%3A%20%220s%22%2C%0A%20%20%20%20%20%20%22cacheUnauthorizedTTL%22%3A%20%220s%22%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22clusterDomain%22%3A%20%22cluster.local%22%2C%0A%20%20%22clusterDNS%22%3A%20%5B%0A%20%20%20%20%22172.30.0.10%22%0A%20%20%5D%2C%0A%20%20%22streamingConnectionIdleTimeout%22%3A%20%220s%22%2C%0A%20%20%22nodeStatusUpdateFrequency%22%3A%20%220s%22%2C%0A%20%20%22nodeStatusReportFrequency%22%3A%20%220s%22%2C%0A%20%20%22imageMinimumGCAge%22%3A%20%220s%22%2C%0A%20%20%22volumeStatsAggPeriod%22%3A%20%220s%22%2C%0A%20%20%22systemCgroups%22%3A%20%22%2Fsystem.slice%22%2C%0A%20%20%22cgroupRoot%22%3A%20%22%2F%22%2C%0A%20%20%22cgroupDriver%22%3A%20%22systemd%22%2C%0A%20%20%22cpuManagerReconcilePeriod%22%3A%20%220s%22%2C%0A%20%20%22runtimeRequestTimeout%22%3A%20%220s%22%2C%0A%20%20%22maxPods%22%3A%20250%2C%0A%20%20%22something%22%3A%20%220s%22%2C%0A%20%20%22kubeAPIBurst%22%3A%20100%2C%0A%20%20%22serializeImagePulls%22%3A%20false%2C%0A%20%20%22evictionPressureTransitionPeriod%22%3A%20%220s%22%2C%0A%20%20%22featureGates%22%3A%20%7B%0A%20%20%20%20%22APIPriorityAndFairness%22%3A%20true%2C%0A%20%20%20%20%22CSIMigrationAWS%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationAzureDisk%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationAzureFile%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationGCE%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationOpenStack%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationvSphere%22%3A%20false%2C%0A%20%20%20%20%22DownwardAPIHugePages%22%3A%20true%2C%0A%20%20%20%20%22LegacyNodeRoleBehavior%22%3A%20false%2C%0A%20%20%20%20%22NodeDisruptionExclusion%22%3A%20true%2C%0A%20%20%20%20%22PodSecurity%22%3A%20true%2C%0A%20%20%20%20%22RotateKubeletServerCertificate%22%3A%20true%2C%0A%20%20%20%20%22ServiceNodeExclusion%22%3A%20true%2C%0A%20%20%20%20%22SupportPodPidsLimit%22%3A%20true%0A%20%20%7D%2C%0A%20%20%22memorySwap%22%3A%20%7B%7D%2C%0A%20%20%22containerLogMaxSize%22%3A%20%2250Mi%22%2C%0A%20%20%22systemReserved%22%3A%20%7B%0A%20%20%20%20%22ephemeral-storage%22%3A%20%221Gi%22%0A%20%20%7D%2C%0A%20%20%22logging%22%3A%20%7B%0A%20%20%20%20%22flushFrequency%22%3A%200%2C%0A%20%20%20%20%22verbosity%22%3A%200%2C%0A%20%20%20%20%22options%22%3A%20%7B%0A%20%20%20%20%20%20%22json%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22infoBufferSize%22%3A%20%220%22%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22shutdownGracePeriod%22%3A%20%220s%22%2C%0A%20%20%22shutdownGracePeriodCriticalPods%22%3A%20%220s%22%0A%7D%0A"
+							},
+							"mode": 420,
+							"overwrite": true,
+							"path": "/etc/kubernetes/kubelet.conf"
+						}
+					]
+				}
+			}`
+			kc := testKubeletConfig(defaultKCPayload)
+			mc := testMachineConfig(renderdKC)
+
+			It("It should evaluate as true", func() {
+				isSubset, err, diffString := utils.IsKCSubsetOfMC(kc, mc)
+				Expect(err).To(BeNil())
+				Expect(isSubset).To(BeTrue())
+				Expect(diffString).To(BeEmpty())
+			})
+		})
+
+		Context("KubeletConfig is not a subset of MachineConfig", func() {
+			renderdKC := `
+			{
+				"ignition": {
+					"version": "3.2.0"
+				},
+				"storage": {
+					"files": [
+						{
+							"contents": {
+								"source": "data:text/plain,%7B%0A%20%20%22kind%22%3A%20%22KubeletConfiguration%22%2C%0A%20%20%22apiVersion%22%3A%20%22kubelet.config.k8s.io%2Fv1beta1%22%2C%0A%20%20%22staticPodPath%22%3A%20%22%2Fetc%2Fkubernetes%2Fmanifests%22%2C%0A%20%20%22syncFrequency%22%3A%20%220s%22%2C%0A%20%20%22fileCheckFrequency%22%3A%20%220s%22%2C%0A%20%20%22httpCheckFrequency%22%3A%20%220s%22%2C%0A%20%20%22tlsCipherSuites%22%3A%20%5B%0A%20%20%20%20%22TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256%22%2C%0A%20%20%20%20%22TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256%22%2C%0A%20%20%20%20%22TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384%22%2C%0A%20%20%20%20%22TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384%22%2C%0A%20%20%20%20%22TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256%22%2C%0A%20%20%20%20%22TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256%22%0A%20%20%5D%2C%0A%20%20%22tlsMinVersion%22%3A%20%22VersionTLS12%22%2C%0A%20%20%22rotateCertificates%22%3A%20true%2C%0A%20%20%22serverTLSBootstrap%22%3A%20true%2C%0A%20%20%22authentication%22%3A%20%7B%0A%20%20%20%20%22x509%22%3A%20%7B%0A%20%20%20%20%20%20%22clientCAFile%22%3A%20%22%2Fetc%2Fkubernetes%2Fkubelet-ca.crt%22%0A%20%20%20%20%7D%2C%0A%20%20%20%20%22webhook%22%3A%20%7B%0A%20%20%20%20%20%20%22cacheTTL%22%3A%20%220s%22%0A%20%20%20%20%7D%2C%0A%20%20%20%20%22anonymous%22%3A%20%7B%0A%20%20%20%20%20%20%22enabled%22%3A%20false%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22authorization%22%3A%20%7B%0A%20%20%20%20%22webhook%22%3A%20%7B%0A%20%20%20%20%20%20%22cacheAuthorizedTTL%22%3A%20%220s%22%2C%0A%20%20%20%20%20%20%22cacheUnauthorizedTTL%22%3A%20%220s%22%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22clusterDomain%22%3A%20%22cluster.local%22%2C%0A%20%20%22clusterDNS%22%3A%20%5B%0A%20%20%20%20%22172.30.0.10%22%0A%20%20%5D%2C%0A%20%20%22streamingConnectionIdleTimeout%22%3A%20%220s%22%2C%0A%20%20%22nodeStatusUpdateFrequency%22%3A%20%220s%22%2C%0A%20%20%22nodeStatusReportFrequency%22%3A%20%220s%22%2C%0A%20%20%22imageMinimumGCAge%22%3A%20%220s%22%2C%0A%20%20%22volumeStatsAggPeriod%22%3A%20%220s%22%2C%0A%20%20%22systemCgroups%22%3A%20%22%2Fsystem.slice%22%2C%0A%20%20%22cgroupRoot%22%3A%20%22%2F%22%2C%0A%20%20%22cgroupDriver%22%3A%20%22systemd%22%2C%0A%20%20%22cpuManagerReconcilePeriod%22%3A%20%220s%22%2C%0A%20%20%22runtimeRequestTimeout%22%3A%20%220s%22%2C%0A%20%20%22maxPods%22%3A%20250%2C%0A%20%20%22kubeAPIQPS%22%3A%2050%2C%0A%20%20%22kubeAPIBurst%22%3A%20100%2C%0A%20%20%22serializeImagePulls%22%3A%20false%2C%0A%20%20%22evictionPressureTransitionPeriod%22%3A%20%220s%22%2C%0A%20%20%22featureGates%22%3A%20%7B%0A%20%20%20%20%22APIPriorityAndFairness%22%3A%20true%2C%0A%20%20%20%20%22CSIMigrationAWS%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationAzureDisk%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationAzureFile%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationGCE%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationOpenStack%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationvSphere%22%3A%20false%2C%0A%20%20%20%20%22DownwardAPIHugePages%22%3A%20true%2C%0A%20%20%20%20%22LegacyNodeRoleBehavior%22%3A%20false%2C%0A%20%20%20%20%22NodeDisruptionExclusion%22%3A%20true%2C%0A%20%20%20%20%22PodSecurity%22%3A%20true%2C%0A%20%20%20%20%22RotateKubeletServerCertificate%22%3A%20true%2C%0A%20%20%20%20%22ServiceNodeExclusion%22%3A%20true%2C%0A%20%20%20%20%22SupportPodPidsLimit%22%3A%20true%0A%20%20%7D%2C%0A%20%20%22memorySwap%22%3A%20%7B%7D%2C%0A%20%20%22containerLogMaxSize%22%3A%20%2250Mi%22%2C%0A%20%20%22systemReserved%22%3A%20%7B%0A%20%20%20%20%22ephemeral-storage%22%3A%20%221Gi%22%0A%20%20%7D%2C%0A%20%20%22logging%22%3A%20%7B%0A%20%20%20%20%22flushFrequency%22%3A%200%2C%0A%20%20%20%20%22verbosity%22%3A%200%2C%0A%20%20%20%20%22options%22%3A%20%7B%0A%20%20%20%20%20%20%22json%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22infoBufferSize%22%3A%20%220%22%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22shutdownGracePeriod%22%3A%20%220s%22%2C%0A%20%20%22shutdownGracePeriodCriticalPods%22%3A%20%220s%22%0A%7D%0A"
+							},
+							"mode": 420,
+							"overwrite": true,
+							"path": "/etc/kubernetes/kubelet.conf"
+						}
+					]
+				}
+			}`
+			kc := testKubeletConfig(defaultKCPayload)
+			mc := testMachineConfig(renderdKC)
+			expectedDiffString := "kubeletconfig kubelet-config-compliance-operator is not subset of rendered MC 99-master-generated-kubelet, diff: [[Path: /something Expected: 0s Got: NOT FOUND]]"
+
+			It("It should evaluate as false", func() {
+				isSubset, err, diffString := utils.IsKCSubsetOfMC(kc, mc)
+				Expect(err).To(BeNil())
+				Expect(isSubset).To(BeFalse())
+				Expect(diffString).To(Equal(expectedDiffString))
+			})
+		})
+
+		Context("MachineConfig is missing kubeconfig file", func() {
+			renderdKC := `
+			{
+				"ignition": {
+					"version": "3.2.0"
+				},
+				"storage": {
+					"files": []
+				}
+			}`
+			kc := testKubeletConfig(defaultKCPayload)
+			mc := testMachineConfig(renderdKC)
+			expectedError := "encoded kubeletconfig 99-master-generated-kubelet is missing"
+
+			It("It should evaluate as false", func() {
+				isSubset, err, diffString := utils.IsKCSubsetOfMC(kc, mc)
+				Expect(err).To(MatchError(expectedError))
+				Expect(isSubset).To(BeFalse())
+				Expect(diffString).To(BeEmpty())
+			})
+		})
+
+		Context("MachineConfig kubeconfig is empty", func() {
+			renderdKC := `
+			{
+				"ignition": {
+					"version": "3.2.0"
+				},
+				"storage": {
+					"files": [
+						{
+							"contents": {
+								"source": ""
+							},
+							"mode": 420,
+							"overwrite": true,
+							"path": "/etc/kubernetes/kubelet.conf"
+						}
+					]
+				}
+			}`
+			kc := testKubeletConfig(defaultKCPayload)
+			mc := testMachineConfig(renderdKC)
+			expectedError := "encoded kubeletconfig 99-master-generated-kubelet is empty"
+
+			It("It should evaluate as false", func() {
+				isSubset, err, diffString := utils.IsKCSubsetOfMC(kc, mc)
+				Expect(err).To(MatchError(expectedError))
+				Expect(isSubset).To(BeFalse())
+				Expect(diffString).To(BeEmpty())
+			})
+		})
+
+		Context("KubeletConfig is nil", func() {
+			var kc *mcfgv1.KubeletConfig
+			mc := &mcfgv1.MachineConfig{}
+			expectedError := "kubelet config is nil"
+
+			It("It should evaluate as false", func() {
+				isSubset, err, diffString := utils.IsKCSubsetOfMC(kc, mc)
+				Expect(err).To(MatchError(expectedError))
+				Expect(isSubset).To(BeFalse())
+				Expect(diffString).To(BeEmpty())
+			})
+		})
+
+		Context("MachineConfig is nil", func() {
+			kc := &mcfgv1.KubeletConfig{}
+			var mc *mcfgv1.MachineConfig
+			expectedError := "machine config is nil"
+
+			It("It should evaluate as false", func() {
+				isSubset, err, diffString := utils.IsKCSubsetOfMC(kc, mc)
+				Expect(err).To(MatchError(expectedError))
+				Expect(isSubset).To(BeFalse())
+				Expect(diffString).To(BeEmpty())
+			})
+		})
+
+		Context("KubeletConfig and MachineConfig are empty", func() {
+			kc := &mcfgv1.KubeletConfig{}
+			mc := &mcfgv1.MachineConfig{}
+			expectedError := "failed to unmarshal machine config : unexpected end of JSON input"
+
+			It("It should evaluate as false", func() {
+				isSubset, err, diffString := utils.IsKCSubsetOfMC(kc, mc)
+				Expect(err).To(MatchError(expectedError))
+				Expect(isSubset).To(BeFalse())
+				Expect(diffString).To(BeEmpty())
+			})
+		})
+
 	})
 
 	When("Testing getting labels from roles", func() {


### PR DESCRIPTION
It is possible that KubeletConfigs will render more than just a single file in the generated MachineConfig objects. Currently the Compliance Operator is hardcoded to select the first file expecting it to be the `kubelet.conf` file. This is _not_ always the case.

This change uses a jsonpath filter to select the desired `/etc/kubernetes/kubelet.conf` file's contents. Fixes #60 

For example, when setting `autoSizingReserved: true` in a KubeletConfig, it will generate a MachineConfig like this:

```
spec:
  config:
    ignition:
      version: 3.2.0
    storage:
      files:
      - contents:
          source: data:text/plain,NODE_SIZING_ENABLED%3Dtrue%0ASYSTEM_RESERVED_MEMORY%3D1Gi%0ASYSTEM_RESERVED_CPU%3D500m%0A
        mode: 420
        overwrite: true
        path: /etc/node-sizing-enabled.env
      - contents:
          source: data:text/plain,TRUNCATED
        mode: 420
        overwrite: true
        path: /etc/kubernetes/kubelet.conf
  extensions: null
  fips: false
  kernelArguments: null
  kernelType: ""
  osImageURL: ""
```