### PR TITLE
Always use dedicated KubeletConfig for remediations

### DIFF
--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -286,12 +286,6 @@ func (r *ReconcileComplianceRemediation) patchRemediation(remObj *unstructured.U
 }
 
 func (r *ReconcileComplianceRemediation) deleteRemediation(remObj *unstructured.Unstructured, foundObj *unstructured.Unstructured, logger logr.Logger) error {
-
-	if utils.IsKubeletConfig(remObj) {
-		logger.Info("Can't unapply since it is KubeletConfig Remediation")
-		return nil
-	}
-
 	logger.Info("Remediation will be deleted")
 
 	if !compv1alpha1.RemediationWasCreatedByOperator(foundObj) {


### PR DESCRIPTION
The implemented logic to use an existing KubeletConfig is unnecessary. The KubeletConfig [design](https://github.com/openshift/machine-config-operator/blob/master/docs/KubeletConfigDesign.md) allows for having multiple objects defined per MachineConfigPool. The only limit on number of objects is due to the implementation in MachineConfigOperator.

This change will have Compliance Operator always use a dedicated KubeletConfig object per detected MachineConfigPool for selected remediations. By doing so, it also allows for removal of remediations.