### PR TITLE
Bug 2060726: Use namespace when creating ServiceMonitor

### DIFF
--- a/cmd/manager/operator_test.go
+++ b/cmd/manager/operator_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/compliance-operator/pkg/controller/metrics"
+)
+
+var _ = Describe("Operator Startup Function tests", func() {
+	Context("Service Monitor Creation", func() {
+		When("Installing to non-controlled namespace", func() {
+			It("ServiceMonitor is generated with the proper TLSConfig ServerName", func() {
+				metricService := operatorMetricService("foobar")
+				sm := generateOperatorServiceMonitor(metricService, "foobar")
+				controllerMetricServiceFound := false
+				for _, ep := range sm.Spec.Endpoints {
+					if ep.Port == metrics.ControllerMetricsServiceName && ep.TLSConfig != nil {
+						Expect(ep.TLSConfig.ServerName).To(BeEquivalentTo("metrics.foobar.svc"))
+						controllerMetricServiceFound = true
+					}
+				}
+				Expect(controllerMetricServiceFound).To(BeTrue())
+			})
+		})
+	})
+})


### PR DESCRIPTION
Take the given operator namespace into account when setting the
ServiceMonitor ServerName field. Previously it was always assumed to be
openshift-compliance.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=2060726