### PR TITLE
Bug 2117268: api-resource-collector: Don't attempt to parse empty Ignition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,19 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
--  Compliance Operator failed to resume `MachineConfigPool` after remediation
-   is applied, some `KubeletConfig` configuration are rendered into multiple 
-   files in `MachineConfig`, and Compliance Operator failed to counter this situation.
-   The Compliance Operator addresses this issue by only checking `/etc/kubernetes/kubelet.conf`
-   Please see the related [bug](https://bugzilla.redhat.com/show_bug.cgi?id=2102511)
-   for more information. No action is required from users to consume this fix.
+- Compliance Operator failed to resume `MachineConfigPool` after remediation
+  is applied, some `KubeletConfig` configuration are rendered into multiple 
+  files in `MachineConfig`, and Compliance Operator failed to counter this situation.
+  The Compliance Operator addresses this issue by only checking `/etc/kubernetes/kubelet.conf`
+  Please see the related [bug](https://bugzilla.redhat.com/show_bug.cgi?id=2102511)
+  for more information. No action is required from users to consume this fix.
+- When Compliance Operator was gathering API resources to check and encountered
+  a `MachineConfig` file with no `Ignition` specification, fetching of the API
+  resources would error out. This manifested as the `api-checks-pod` ending up in
+  a `CrashLoopBackOff`. More information can be found in the related
+  [bug](https://bugzilla.redhat.com/show_bug.cgi?id=2117268)
+
+
 ### Internal Changes
 
 - Added a template for proposing and discussing

--- a/cmd/manager/scap_test.go
+++ b/cmd/manager/scap_test.go
@@ -324,6 +324,16 @@ var _ = Describe("Testing fetching", func() {
 
 			mcList := mcfgv1.MachineConfigList{Items: []mcfgv1.MachineConfig{
 				{
+					// regression test for RHBZ #2117268
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "99-no-ign-mc",
+						Namespace: common.GetComplianceOperatorNamespace(),
+					},
+					Spec: mcfgv1.MachineConfigSpec{
+						KernelArguments: []string{"audit=1"},
+					},
+				},
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "99-worker-fips",
 						Namespace: common.GetComplianceOperatorNamespace(),


### PR DESCRIPTION
While filtering files out of MachineConfigs, we tried to also parse
ignition specification of MachineConfigs that didn't specify any,
leading to an error.

Let's just pass on MCs that don't have any Ignition spec as-is.

Resolves: rhbz#2117268
