### PR TITLE
operator: Override WATCH_NAMESPACE="" to WATCH_NAMESPACE=openshift-compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Deprecations
 
--
+- Specifying "Install into all namespaces in the cluster" or otherwise setting
+  the `WATCH_NAMESPACES` environment variable to `""` has no effect anymore. This was
+  done to improve operator's memory usage as reported in
+  [an upstream issue](https://github.com/ComplianceAsCode/compliance-operator/issues/40)
+  All Compliance Operator's CRs must be installed in operator's own namespace
+  (typically `openshift-compliance`) in order for the operator to pick them up
+  anyway.
 
 ### Removals
 

--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -149,7 +149,7 @@ func RunOperator(cmd *cobra.Command, args []string) {
 
 	printVersion()
 
-	namespace, err := k8sutil.GetWatchNamespace()
+	namespace, err := common.GetWatchNamespace()
 	if err != nil {
 		log.Error(err, "Failed to get watch namespace")
 		os.Exit(1)

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -66,4 +67,24 @@ func GetComplianceOperatorNamespace() string {
 // currently running with.
 func GetComplianceOperatorName() string {
 	return complianceOperatorName
+}
+
+// GetWatchNamespace returns the Namespace the operator should be watching for changes. Eventually the watch namespace
+// will not be used when OLM begins to support only the AllNamespaces install type. To support AllNamespaces initially,
+// GetWatchNamespace will return the operator namespace if WATCH_NAMESPACE is empty.
+func GetWatchNamespace() (string, error) {
+	// WatchNamespaceEnvVar is the constant for env variable WATCH_NAMESPACE
+	// which specifies the Namespace to watch.
+	// An empty value means the operator is running with cluster scope.
+	var watchNamespaceEnvVar = "WATCH_NAMESPACE"
+
+	ns, found := os.LookupEnv(watchNamespaceEnvVar)
+	if !found {
+		return "", fmt.Errorf("%s must be set", watchNamespaceEnvVar)
+	}
+
+	if ns == "" {
+		ns = GetComplianceOperatorNamespace()
+	}
+	return ns, nil
 }


### PR DESCRIPTION
It was reported that using WATCH_NAMESPACE=openshift-compliance (or
installing into its own namespace) reduced memory usage of the operator:
    https://github.com/ComplianceAsCode/compliance-operator/issues/40#issuecomment-1155180160

Let's implement Matt's suggestion from that issue and override the value
of WATCH_NAMESPACE.

Fixes: #40
