### PR TITLE
Make scanner's and api-resource-collector's limits configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Added the ability to set `PriorityClass` through `ScanSetting`. All the scanner pods
   will be launched using the `PriorityClass` if set. This is an optional attribute, the
   scan pods will be launched without `PriorityClass` if not set.
+- The `ScanSetting` Custom Resource now allows to override the default
+  CPU and memory limits of scanner pods through the `scanLimits` attribute.
+  Please refer to the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+  for syntax reference.
+  In order to set the memory limits of the operator itself, modify the
+  `Subscription` object, if installed through OLM or the operator deployment
+  itself otherwise. Increasing the memory limit for the operator or the scanner
+  might be needed in case the default limits are not sufficient and either the operator
+  or the scanner pods are killed by the OOM killer.
 
 - Added the ability to check default `KubeletConfig` configuration. Compliance Operator
   will fetch `KubeletConfig` for each node and save it to `/kubeletconfig/role/{{role}}`.

--- a/config/crd/bases/compliance.openshift.io_compliancescans.yaml
+++ b/config/crd/bases/compliance.openshift.io_compliancescans.yaml
@@ -190,6 +190,18 @@ spec:
                   for a specific rule. Note that when leaving this empty, the scan
                   will check for all the rules for a specific profile.
                 type: string
+              scanLimits:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: ScanLimits allows to set the resource limits that the
+                  scan pods are allowed to use. By default, compliance operator will
+                  use sensible defaults (500Mi memory, 100m CPU for the scanner container
+                  and 200Mi memory with 100m CPU for the api-resource-collector container).
+                type: object
               scanTolerations:
                 default:
                 - operator: Exists

--- a/config/crd/bases/compliance.openshift.io_compliancesuites.yaml
+++ b/config/crd/bases/compliance.openshift.io_compliancesuites.yaml
@@ -218,6 +218,19 @@ spec:
                         only for a specific rule. Note that when leaving this empty,
                         the scan will check for all the rules for a specific profile.
                       type: string
+                    scanLimits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: ScanLimits allows to set the resource limits that
+                        the scan pods are allowed to use. By default, compliance operator
+                        will use sensible defaults (500Mi memory, 100m CPU for the
+                        scanner container and 200Mi memory with 100m CPU for the api-resource-collector
+                        container).
+                      type: object
                     scanTolerations:
                       default:
                       - operator: Exists

--- a/config/crd/bases/compliance.openshift.io_scansettings.yaml
+++ b/config/crd/bases/compliance.openshift.io_scansettings.yaml
@@ -170,6 +170,18 @@ spec:
             items:
               type: string
             type: array
+          scanLimits:
+            additionalProperties:
+              anyOf:
+              - type: integer
+              - type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            description: ScanLimits allows to set the resource limits that the scan
+              pods are allowed to use. By default, compliance operator will use sensible
+              defaults (500Mi memory, 100m CPU for the scanner container and 200Mi
+              memory with 100m CPU for the api-resource-collector container).
+            type: object
           scanTolerations:
             default:
             - operator: Exists

--- a/config/helm/crds/compliance.openshift.io_compliancescans_crd.yaml
+++ b/config/helm/crds/compliance.openshift.io_compliancescans_crd.yaml
@@ -186,6 +186,17 @@ spec:
                   for a specific rule. Note that when leaving this empty, the scan
                   will check for all the rules for a specific profile.
                 type: string
+              scanLimits:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: ScanLimits allows to set the resource limits that the
+                  scan pods are allowed to use. By default, compliance operator will
+                  use sensible defaults
+                type: object
               scanTolerations:
                 default:
                 - operator: Exists

--- a/config/helm/crds/compliance.openshift.io_compliancesuites_crd.yaml
+++ b/config/helm/crds/compliance.openshift.io_compliancesuites_crd.yaml
@@ -214,6 +214,17 @@ spec:
                         only for a specific rule. Note that when leaving this empty,
                         the scan will check for all the rules for a specific profile.
                       type: string
+                    scanLimits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: ScanLimits allows to set the resource limits that
+                        the scan pods are allowed to use. By default, compliance operator
+                        will use sensible defaults
+                      type: object
                     scanTolerations:
                       default:
                       - operator: Exists

--- a/config/helm/crds/compliance.openshift.io_scansettings_crd.yaml
+++ b/config/helm/crds/compliance.openshift.io_scansettings_crd.yaml
@@ -166,6 +166,17 @@ spec:
             items:
               type: string
             type: array
+          scanLimits:
+            additionalProperties:
+              anyOf:
+              - type: integer
+              - type: string
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            description: ScanLimits allows to set the resource limits that the scan
+              pods are allowed to use. By default, compliance operator will use sensible
+              defaults
+            type: object
           scanTolerations:
             default:
             - operator: Exists

--- a/doc/crds.md
+++ b/doc/crds.md
@@ -608,6 +608,8 @@ In the `spec`:
   [Kubernetes documentation on this](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).
 * **PriorityClass**: Defines the priority class name of the scan(s).
   [Kubernetes documentation on this](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+* **scanLimits**: Allows to override the default memory or CPU limits for the
+  scanner pods. For syntax, refer to the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
 
 Regarding the `status`:
 

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -197,6 +198,12 @@ type ComplianceScanSettings struct {
 	// the Name of a desired PriorityClass should be set here, this is an
 	// optional field, if PriorityClass is invalid or not found, it will be ignored.
 	PriorityClass string `json:"priorityClass,omitempty"`
+
+	// ScanLimits allows to set the resource limits that the scan pods are allowed to use.
+	// By default, compliance operator will use sensible defaults (500Mi memory, 100m CPU
+	// for the scanner container and 200Mi memory with 100m CPU for the api-resource-collector
+	// container).
+	ScanLimits map[corev1.ResourceName]resource.Quantity `json:"scanLimits,omitempty"`
 }
 
 // ComplianceScanSpec defines the desired state of ComplianceScan

--- a/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/compliance/v1alpha1/zz_generated.deepcopy.go
@@ -23,6 +23,7 @@ package v1alpha1
 
 import (
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -293,6 +294,13 @@ func (in *ComplianceScanSettings) DeepCopyInto(out *ComplianceScanSettings) {
 		in, out := &in.StrictNodeScan, &out.StrictNodeScan
 		*out = new(bool)
 		**out = **in
+	}
+	if in.ScanLimits != nil {
+		in, out := &in.ScanLimits, &out.ScanLimits
+		*out = make(map[v1.ResourceName]resource.Quantity, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
 	}
 }
 

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -47,6 +47,24 @@ func (r *ReconcileComplianceScan) launchScanPod(instance *compv1alpha1.Complianc
 	return nil
 }
 
+func scanLimits(scanInstance *compv1alpha1.ComplianceScan, defaultMem, defaultCpu string) *corev1.ResourceList {
+	limits := corev1.ResourceList{
+		corev1.ResourceMemory: resource.MustParse(defaultMem),
+		corev1.ResourceCPU:    resource.MustParse(defaultCpu),
+	}
+
+	if scanInstance.Spec.ScanLimits != nil {
+		for resource := range limits {
+			customLimit, ok := scanInstance.Spec.ScanLimits[resource]
+			if ok {
+				limits[resource] = customLimit
+			}
+		}
+	}
+
+	return &limits
+}
+
 func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.Node, logger logr.Logger) *corev1.Pod {
 	mode := int32(0744)
 
@@ -172,10 +190,9 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 							corev1.ResourceMemory: resource.MustParse("50Mi"),
 							corev1.ResourceCPU:    resource.MustParse("10m"),
 						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("500Mi"),
-							corev1.ResourceCPU:    resource.MustParse("100m"),
-						},
+						// NOTE: when changing the default limits, remember to also change the
+						// doc text in the CRD.
+						Limits: *scanLimits(scanInstance, "500Mi", "100m"),
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -375,10 +392,9 @@ func (r *ReconcileComplianceScan) newPlatformScanPod(scanInstance *compv1alpha1.
 							corev1.ResourceMemory: resource.MustParse("20Mi"),
 							corev1.ResourceCPU:    resource.MustParse("10m"),
 						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("200Mi"),
-							corev1.ResourceCPU:    resource.MustParse("100m"),
-						},
+						// NOTE: when changing the default limits, remember to also change the
+						// doc text in the CRD.
+						Limits: *scanLimits(scanInstance, "202Mi", "100m"),
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
@@ -463,10 +479,9 @@ func (r *ReconcileComplianceScan) newPlatformScanPod(scanInstance *compv1alpha1.
 							corev1.ResourceMemory: resource.MustParse("50Mi"),
 							corev1.ResourceCPU:    resource.MustParse("10m"),
 						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("500Mi"),
-							corev1.ResourceCPU:    resource.MustParse("100m"),
-						},
+						// NOTE: when changing the default limits, remember to also change the
+						// doc text in the CRD.
+						Limits: *scanLimits(scanInstance, "500Mi", "100m"),
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/ComplianceAsCode/compliance-operator/pkg/apis"
 	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	compscanctrl "github.com/ComplianceAsCode/compliance-operator/pkg/controller/compliancescan"
 	compsuitectrl "github.com/ComplianceAsCode/compliance-operator/pkg/controller/compliancesuite"
 	"github.com/ComplianceAsCode/compliance-operator/pkg/utils"
 	"github.com/ComplianceAsCode/compliance-operator/tests/e2e/e2eutil"
@@ -2110,6 +2111,38 @@ func checkPodPriorityClass(t *testing.T, c kubernetes.Interface, podName, namesp
 		if pod.Spec.PriorityClassName != priorityClass {
 			E2ELogf(t, "pod %s has priority class %s, expected %s", podName, pod.Spec.PriorityClassName, priorityClass)
 			return true, nil
+		}
+
+		return true, nil
+	}
+}
+
+// check if pod name has priority class set to the given value.
+func checkPodLimit(t *testing.T, c kubernetes.Interface, podName, namespace, cpuLimit, memLimit string) wait.ConditionFunc {
+	return func() (bool, error) {
+		pod, err := c.CoreV1().Pods(namespace).Get(goctx.TODO(), podName, metav1.GetOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return false, err
+		}
+
+		if apierrors.IsNotFound(err) {
+			E2ELogf(t, "Pod %s not found yet", podName)
+			return false, nil
+		}
+
+		for i := range pod.Spec.Containers {
+			cnt := &pod.Spec.Containers[i]
+			if cnt.Name != compscanctrl.PlatformScanResourceCollectorName && cnt.Name != compscanctrl.OpenSCAPScanContainerName {
+				continue
+			}
+
+			if cnt.Resources.Limits.Cpu().String() != cpuLimit {
+				return false, fmt.Errorf("container %s in pod %s has cpu limit %s, expected %s", cnt.Name, podName, cnt.Resources.Limits.Cpu().String(), cpuLimit)
+			}
+
+			if cnt.Resources.Limits.Memory().String() != memLimit {
+				return false, fmt.Errorf("container %s in pod %s has memory limit %s, expected %s", cnt.Name, podName, cnt.Resources.Limits.Cpu().String(), cpuLimit)
+			}
 		}
 
 		return true, nil


### PR DESCRIPTION
Even with the recent fix to the memory consumption, we might need to
provide a way for our users to bump the limits on scans, especially with
huge cluster nodes and Linux scans that traverse the filesystem.

This patch adds a new scanLimits attribute to the scan settings CR.
If unset, the compiled-in defaults are used, otherwise the settings take
precedence.

The only containers that are affected are the scanner and the
api-resource-collector as we've seen reports with those containers being
OOMKilled.

Jira: OCPBUGSM-39585
