### PR TITLE
Ignore tests/_setup directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ tags
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 # GoLand files
 .idea
+# Generated files for E2E test setup
+tests/_setup


### PR DESCRIPTION
The operator-sdk update refactored how we setup end-to-end testing. Part
of that was to include a separate directory for custom resource
defintions and custom resources generated by the tooling.

Since the files in tests/_setup are generated, we don't need to track
them in the project. Let's add them to .gitignore.