### PR TITLE
bug 2092913: scan: Delete scan pods when deleting the scan itself and debug: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   resources would error out. This manifested as the `api-checks-pod` ending up in
   a `CrashLoopBackOff`. More information can be found in the related
   [bug](https://bugzilla.redhat.com/show_bug.cgi?id=2117268)
+- When the scan settings set the `debug` attribute to `true`, Compliance Operator
+  wasn't deleting the scan pods properly when the scan was deleted. This
+  [bug](https://bugzilla.redhat.com/show_bug.cgi?id=2092913) was fixed and
+  the scanner pods are deleted when the scan is removed regardless of the
+  value of the `debug` attribute.
 
 
 ### Internal Changes

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -482,10 +482,10 @@ func (r *ReconcileComplianceScan) phaseDoneHandler(h scanTypeHandler, instance *
 	var err error
 	logger.Info("Phase: Done")
 
-	// the scan pods and the aggregator are done at this point and can be cleaned up regardless
-	// of the doDelete flag, unless we are running in debug mode and thus requested them to stay
+	// the scan pods and the aggregator are done at this point and can be cleaned up
+	// unless we are running in debug mode and thus requested them to stay
 	// around for later inspection
-	if instance.Spec.Debug == false || instance.NeedsRescan() {
+	if doDelete == true || instance.Spec.Debug == false || instance.NeedsRescan() {
 		// Don't try to clean up scan-type specific resources
 		// if it was an unknown scan type
 		if h != nil {


### PR DESCRIPTION
When scansetting was set with debug:true and the scan was deleted, the
scan pods stayed around even if the scan was deleted.

rhbz: #2092913
