### PR TITLE
images: Don't enable an obsolete copr repo

### DIFF
--- a/images/openscap/Dockerfile
+++ b/images/openscap/Dockerfile
@@ -8,18 +8,6 @@ LABEL \
     io.openshift.tags="compliance openscap scan" \
     io.openshift.wants="scap-content"
 
-RUN echo $'[openscap-1-3-5-copr]\n\
-name=Copr repo for openscap-1-3-5 owned by jhrozek\n\
-baseurl=https://download.copr.fedorainfracloud.org/results/jhrozek/openscap-1-3-5/epel-8-$basearch/\n\
-type=rpm-md\n\
-skip_if_unavailable=True\n\
-gpgcheck=1\n\
-gpgkey=https://download.copr.fedorainfracloud.org/results/jhrozek/openscap-1-3-5/pubkey.gpg\n\
-repo_gpgcheck=0\n\
-enabled=1\n\
-enabled_metadata=1\n '\
->> /etc/yum.repos.d/openscap.repo
-
 RUN true \
     && microdnf install -y openscap-scanner \
     && microdnf clean all \

--- a/images/openscap/Dockerfile.ci
+++ b/images/openscap/Dockerfile.ci
@@ -8,18 +8,6 @@ LABEL \
     io.openshift.tags="compliance openscap scan" \
     io.openshift.wants="scap-content"
 
-RUN echo $'[openscap-1-3-5-copr]\n\
-name=Copr repo for openscap-1-3-5 owned by jhrozek\n\
-baseurl=https://download.copr.fedorainfracloud.org/results/jhrozek/openscap-1-3-5/epel-8-$basearch/\n\
-type=rpm-md\n\
-skip_if_unavailable=True\n\
-gpgcheck=1\n\
-gpgkey=https://download.copr.fedorainfracloud.org/results/jhrozek/openscap-1-3-5/pubkey.gpg\n\
-repo_gpgcheck=0\n\
-enabled=1\n\
-enabled_metadata=1\n '\
->> /etc/yum.repos.d/openscap.repo
-
 RUN true \
     && microdnf install -y openscap-scanner \
     && microdnf clean all \


### PR DESCRIPTION
This repo is no longer needed as the base UBI-8 repos have even newer
openscap image (1.3.6) than what the repo has.
