### PR TITLE
Use ghcr.io content image as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ E2E_USE_DEFAULT_IMAGES?=false
 E2E_SKIP_CONTAINER_BUILD?=false
 
 # Used for substitutions
-DEFAULT_CONTENT_IMAGE=$(DEFAULT_REPO)/$(APP_NAME)-content:$(DEFAULT_TAG)
+DEFAULT_CONTENT_IMAGE=ghcr.io/complianceascode/k8scontent:latest
 CONTENT_IMAGE?=$(DEFAULT_CONTENT_IMAGE)
 # Specifies the image path to use for the content in the tests
 E2E_CONTENT_IMAGE_PATH?=ghcr.io/complianceascode/k8scontent:latest

--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -277,6 +277,7 @@ spec:
           - componentstatuses
           - nodes
           - nodes/status
+          - nodes/proxy
           - persistentvolumeclaims/status
           - persistentvolumes
           - persistentvolumes/status
@@ -1240,7 +1241,7 @@ spec:
                 - name: RELATED_IMAGE_OPERATOR
                   value: quay.io/compliance-operator/compliance-operator:latest
                 - name: RELATED_IMAGE_PROFILE
-                  value: quay.io/compliance-operator/compliance-operator-content:latest
+                  value: ghcr.io/complianceascode/k8scontent:latest
                 image: quay.io/compliance-operator/compliance-operator:latest
                 imagePullPolicy: Always
                 name: compliance-operator
@@ -1575,6 +1576,6 @@ spec:
     name: openscap
   - image: quay.io/compliance-operator/compliance-operator:latest
     name: operator
-  - image: quay.io/compliance-operator/compliance-operator-content:latest
+  - image: ghcr.io/complianceascode/k8scontent:latest
     name: profile
   version: 0.1.53

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - name: RELATED_IMAGE_OPERATOR
               value: "quay.io/compliance-operator/compliance-operator:latest"
             - name: RELATED_IMAGE_PROFILE
-              value: "quay.io/compliance-operator/compliance-operator-content:latest"
+              value: "ghcr.io/complianceascode/k8scontent:latest"
           volumeMounts:
             - name: serving-cert
               mountPath: /var/run/secrets/serving-cert


### PR DESCRIPTION
Previously we switched the content images to default to
`ghcr.io/complianceascode/k8scontent:latest`, and this was reverted on
accident in the operator-sdk upgrade patch.