### PR TITLE
Implement result and remediation forwarding

### DIFF
--- a/pkg/controller/compliancescan/forwarder.go
+++ b/pkg/controller/compliancescan/forwarder.go
@@ -1,0 +1,46 @@
+package compliancescan
+
+import (
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+)
+
+func NewForwarder(s *compv1alpha1.ComplianceScan) Forwarder {
+	// Figure out what type of forwarding implementation we need based on
+	// scan configuration. By default, use the noopForwarder which doesn't
+	// do anything and maintains backwards compatibility.
+	if s.Spec.Debug {
+		logf.Log.Info("Forwarding compliance results and remediations to logs")
+		return logForwarder{}
+	}
+	logf.Log.Info("Result and remediation forwarding is disabled")
+	return noopForwarder{}
+}
+
+type Forwarder interface {
+	SendComplianceCheckResult(c *compv1alpha1.ComplianceCheckResult) error
+	SendComplianceRemediation(r *compv1alpha1.ComplianceRemediation) error
+}
+
+type logForwarder struct{}
+
+func (f logForwarder) SendComplianceCheckResult(c *compv1alpha1.ComplianceCheckResult) error {
+	logf.Log.Info("ComplianceCheckResult", c.ID, c.Status)
+	return nil
+}
+
+func (f logForwarder) SendComplianceRemediation(r *compv1alpha1.ComplianceRemediation) error {
+	logf.Log.Info("ComplianceRemediation", r.Spec, r.Status)
+	return nil
+}
+
+type noopForwarder struct{}
+
+func (f noopForwarder) SendComplianceCheckResult(c *compv1alpha1.ComplianceCheckResult) error {
+	return nil
+}
+
+func (f noopForwarder) SendComplianceRemediation(r *compv1alpha1.ComplianceRemediation) error {
+	return nil
+}

--- a/pkg/controller/compliancescan/forwarder_test.go
+++ b/pkg/controller/compliancescan/forwarder_test.go
@@ -1,0 +1,56 @@
+package compliancescan
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+)
+
+var _ = Describe("Test forwarding factory", func() {
+
+	Context("Without debug enabled in scan", func() {
+		It("should return a noop forwarding implementation", func() {
+			s := &compv1alpha1.ComplianceScan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: compv1alpha1.ComplianceScanSpec{
+					ScanType: compv1alpha1.ScanTypeNode,
+					ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+						RawResultStorage: compv1alpha1.RawResultStorageSettings{
+							PVAccessModes: defaultAccessMode,
+							Size:          compv1alpha1.DefaultRawStorageSize,
+						},
+					},
+				},
+			}
+			f := NewForwarder(s)
+			Expect(f).To(Equal(noopForwarder{}))
+		})
+	})
+
+	Context("With debug enabled in scan", func() {
+		It("should return a log forwarding implementation", func() {
+			s := &compv1alpha1.ComplianceScan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: compv1alpha1.ComplianceScanSpec{
+					ScanType: compv1alpha1.ScanTypeNode,
+					ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+						Debug: true,
+						RawResultStorage: compv1alpha1.RawResultStorageSettings{
+							PVAccessModes: defaultAccessMode,
+							Size:          compv1alpha1.DefaultRawStorageSize,
+						},
+					},
+				},
+			}
+			f := NewForwarder(s)
+			Expect(f).To(Equal(logForwarder{}))
+		})
+	})
+
+})


### PR DESCRIPTION
This commit identifies a basic seam to implement result and remediation
forwarding. While this commit is non-functional, it serves a purpose in
debating where we put the functionality and what the interface looks
like.