### PR TITLE
Makefile: Set IMG during image-to-cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -583,6 +583,7 @@ image-to-cluster: image openscap-image namespace openshift-user  ## Builds and p
 	@echo "Removing the route from the image registry"
 	@oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":false}}' --type=merge
 	$(eval OPERATOR_IMAGE = image-registry.openshift-image-registry.svc:5000/openshift/$(APP_NAME):$(TAG))
+	$(eval IMG = image-registry.openshift-image-registry.svc:5000/openshift/$(APP_NAME):$(TAG))
 	$(eval OPENSCAP_IMAGE = image-registry.openshift-image-registry.svc:5000/openshift/$(OPENSCAP_NAME):$(OPENSCAP_TAG))
 
 .PHONY: e2e-content-images


### PR DESCRIPTION
The `make e2e-cluster` target runs the e2e suite against the images that are pushed to the local cluster with `image-to-cluster`. During `image-to-cluster` we also need to set IMG to the operator. This allows kustomize to set the image reference properly when the `e2e-set-image` prereq is called.