### PR TITLE
Allow running a subset of tests through a MakeFile variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,15 @@ TEST_DEPLOY=$(TEST_SETUP_DIR)/deploy_rbac.yaml
 # e.g. to run a specific test in the e2e test suite, do:
 # 	make e2e E2E_GO_TEST_FLAGS="-v -run TestE2E/TestScanWithNodeSelectorFiltersCorrectly"
 E2E_GO_TEST_FLAGS?=-v -test.timeout 120m
+
+# By default we run all tests; available options: all, parallel, serial
+E2E_TEST_TYPE?=all
+
 # By default, the tests skip cleanup on failures. Set this variable to false if you prefer
 # the tests to cleanup regardless of test status, e.g.:
 # E2E_SKIP_CLEANUP_ON_ERROR=false make e2e
 E2E_SKIP_CLEANUP_ON_ERROR?=true
-E2E_ARGS=-root=$(PROJECT_DIR) -globalMan=$(TEST_CRD) -namespacedMan=$(TEST_DEPLOY) -skipCleanupOnError=$(E2E_SKIP_CLEANUP_ON_ERROR)
+E2E_ARGS=-root=$(PROJECT_DIR) -globalMan=$(TEST_CRD) -namespacedMan=$(TEST_DEPLOY) -skipCleanupOnError=$(E2E_SKIP_CLEANUP_ON_ERROR) -testType=$(E2E_TEST_TYPE)
 TEST_OPTIONS?=
 # Skip pushing the container to your cluster
 E2E_SKIP_CONTAINER_PUSH?=false

--- a/tests/e2e/framework/context.go
+++ b/tests/e2e/framework/context.go
@@ -23,6 +23,7 @@ type Context struct {
 	t                 *testing.T
 
 	namespacedManPath  string
+	testType           string
 	client             *frameworkClient
 	kubeclient         kubernetes.Interface
 	restMapper         *restmapper.DeferredDiscoveryRESTMapper
@@ -71,6 +72,7 @@ func (f *Framework) newContext(t *testing.T) *Context {
 		kubeclient:         f.KubeClient,
 		restMapper:         f.restMapper,
 		skipCleanupOnError: f.skipCleanupOnError,
+		testType:           f.testType,
 	}
 }
 
@@ -106,6 +108,10 @@ func (ctx *Context) Cleanup() {
 	if ctx.t == nil && failed {
 		log.Fatal("A cleanup function failed")
 	}
+}
+
+func (ctx *Context) GetTestType() string {
+	return ctx.testType
 }
 
 func (ctx *Context) AddCleanupFn(fn cleanupFn) {

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -73,6 +73,7 @@ type Framework struct {
 	globalManPath      string
 	localOperatorArgs  string
 	kubeconfigPath     string
+	testType           string
 	schemeMutex        sync.Mutex
 	LocalOperator      bool
 	skipCleanupOnError bool
@@ -84,9 +85,16 @@ type frameworkOpts struct {
 	globalManPath      string
 	namespacedManPath  string
 	localOperatorArgs  string
+	testType           string
 	isLocalOperator    bool
 	skipCleanupOnError bool
 }
+
+const (
+	TestTypeAll      = "all"
+	TestTypeParallel = "parallel"
+	TestTypeSerial   = "serial"
+)
 
 const (
 	ProjRootFlag           = "root"
@@ -96,6 +104,7 @@ const (
 	LocalOperatorFlag      = "localOperator"
 	LocalOperatorArgs      = "localOperatorArgs"
 	SkipCleanupOnErrorFlag = "skipCleanupOnError"
+	TestTypeFlag           = "testType"
 
 	TestOperatorNamespaceEnv = "TEST_OPERATOR_NAMESPACE"
 	TestWatchNamespaceEnv    = "TEST_WATCH_NAMESPACE"
@@ -112,6 +121,8 @@ func (opts *frameworkOpts) addToFlagSet(flagset *flag.FlagSet) {
 	flagset.BoolVar(&opts.skipCleanupOnError, SkipCleanupOnErrorFlag, false,
 		"If set as true, the cleanup function responsible to remove all artifacts "+
 			"will be skipped if an error is faced.")
+	flagset.StringVar(&opts.testType, TestTypeFlag, TestTypeAll,
+		"Defines the type of tests to run. (Options: all, serial, parallel)")
 }
 
 func newFramework(opts *frameworkOpts) (*Framework, error) {


### PR DESCRIPTION
This introduces the `E2E_TEST_TYPE` variable, which, if set, allows the
e2e test suite to run only a subset of tests. This subsets are defined
in-code and currently only take either `parallel` or `serial`. However,
the default is to run them all (the default is literally called `all`)
so the current behavior is kept.

This will allow us to create another test in the `openshift/release`
repo and divide the test runs to take different clusters, which will
speed up the e2e CI run.

We could have `e2e-serial` and `e2e-parallel` tests.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
