### PR TITLE
Makefile: Fix release-images target prereqs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -636,7 +636,7 @@ push-release: package-version-to-tag ## Do an official release (Requires permiss
 	git push $(GIT_REMOTE) ocp-0.1
 
 .PHONY: release-images
-release-images: package-version-to-tag push push-index undo-deploy-tag-image
+release-images: package-version-to-tag push catalog
 	# This will ensure that we also push to the latest tag
 	$(MAKE) push TAG=latest
 

--- a/doc/contributor.md
+++ b/doc/contributor.md
@@ -171,9 +171,14 @@ The following is an example release note for a feature with a security note.
 ## Proposing Releases
 
 The release process is separated into three phases, with dedicated `make`
-targets. All targets require that you supply the `OPERATOR_VERSION` prior to
+targets. All targets require that you set the environment variable `VERSION` prior to
 running `make`, which should be a semantic version formatted string (e.g.,
-`OPERATOR_VERSION=0.1.49`).
+`VERSION=0.1.49`).
+
+Additionally, before preparing an official release, it is important to remember
+to unset the `IMAGE_REPO` and  `TAG` environment variables in your shell, if you
+have been previously developing test images. This ensures that the release applies
+to the correct upstream images.
 
 ### Preparing the Release
 


### PR DESCRIPTION
- The correct target to create and push the index is `catalog`, so use that for `release-images`
- Correct the use of VERSION, and add a note about unsetting IMAGE_REPO and TAG prior to release in to doc/contributor.md

Signed-off-by: Matt Rogers <mrogers@redhat.com>