### PR TITLE
Fix -testType option for e2e

### DIFF
--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -173,6 +173,7 @@ func newFramework(opts *frameworkOpts) (*Framework, error) {
 		kubeconfigPath:     opts.kubeconfigPath,
 		restMapper:         restMapper,
 		skipCleanupOnError: opts.skipCleanupOnError,
+		testType:           opts.testType,
 	}
 	return framework, nil
 }


### PR DESCRIPTION
The value passed in to the test binary was being lost on the way. This caused the e2e to skip all tests by default.

Signed-off-by: Matt Rogers <mrogers@redhat.com>