### PR TITLE
Reproducible builds: Ensure we can get reproducible builds for CO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,6 @@ CURPATH=$(PWD)
 TARGET_DIR=$(CURPATH)/build/_output
 GOFLAGS?=-mod=vendor
 GO=GOFLAGS=$(GOFLAGS) GO111MODULE=auto go
-GOBUILD=$(GO) build
 BUILD_GOPATH=$(TARGET_DIR):$(CURPATH)/cmd
 TARGET_OPERATOR=$(TARGET_DIR)/bin/$(APP_NAME)
 MAIN_PKG=main.go
@@ -418,7 +417,10 @@ images-extra: openscap-image e2e-content-images  ## Build the openscap and test 
 
 .PHONY: build
 build: generate fmt vet test-unit ## Build the operator binary.
-	$(GO) build -o $(TARGET_OPERATOR) $(MAIN_PKG)
+	$(GO) build \
+		-trimpath \
+		-ldflags=-buildid= \
+		-o $(TARGET_OPERATOR) $(MAIN_PKG)
 
 .PHONY: manager
 manager: build  ## Alias for make build.


### PR DESCRIPTION
By setting the `-trimpath` flag, we ensure that we don't pollute the
debug paths with absolute paths of the environment where we built the
image; instead, this will will show the path of the go module (which is
also quite understandable for debugging). Making the go binary's buildid
blank also ensures that the binary has data we can predict, and thus
ensures reproducible builds.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
