### PR TITLE
Makefile: Fix kustomize install for go1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,19 +321,19 @@ controller-gen: ## Build controller-gen locally.
 KUSTOMIZE = $(shell pwd)/$(TOOLS_DIR)/kustomize
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
+define go-install-tool
 @[ -f $(1) ] || { \
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
-echo "Downloading $(2)" ;\
+echo "Installing $(2)" ;\
 mkdir -p $(TOOLS_DIR) ;\
-GOBIN=$(PROJECT_DIR)/$(TOOLS_DIR) go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/$(TOOLS_DIR) GOFLAGS=-mod=mod go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
Bumps the kustomize tool version to v4 to accommodate go1.18, and use `go install`.