### PR TITLE
Use ISO 8601 time format for logs

### DIFF
--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/go-logr/logr"
 	log "github.com/sirupsen/logrus"
+	"go.uber.org/zap/zapcore"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"os"
 	"reflect"
@@ -144,12 +146,22 @@ func printVersion() {
 	setupLog.Info(fmt.Sprintf("Compliance Operator Version: %v", version.Version))
 }
 
+func operatorTimeEncoder() zapcore.TimeEncoder {
+	return zapcore.ISO8601TimeEncoder
+}
+
+func operatorLogger() logr.Logger {
+	return zap.New(zap.UseFlagOptions(&zap.Options{
+		TimeEncoder: operatorTimeEncoder(),
+	}))
+}
+
 func RunOperator(cmd *cobra.Command, args []string) {
 	flags := cmd.Flags()
 	flags.AddGoFlagSet(flag.CommandLine)
 	flags.Parse(args)
 
-	logf.SetLogger(zap.New())
+	logf.SetLogger(operatorLogger())
 
 	printVersion()
 

--- a/cmd/manager/operator_test.go
+++ b/cmd/manager/operator_test.go
@@ -4,9 +4,21 @@ import (
 	"github.com/ComplianceAsCode/compliance-operator/pkg/controller/metrics"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"reflect"
+	"runtime"
+	"strings"
 )
 
 var _ = Describe("Operator Startup Function tests", func() {
+	Context("Operator log format", func() {
+		It("logs in the ISO8601TimeEncoder human-readable format", func() {
+			encoder := operatorTimeEncoder()
+			fullFunctionName := runtime.FuncForPC(reflect.ValueOf(encoder).Pointer()).Name()
+			splitFunctionName := strings.Split(fullFunctionName, ".")
+			Expect(len(splitFunctionName)).To(BeEquivalentTo(4))
+			Expect(splitFunctionName[len(splitFunctionName)-1]).To(BeEquivalentTo("ISO8601TimeEncoder"))
+		})
+	})
 	Context("Service Monitor Creation", func() {
 		When("Installing to non-controlled namespace", func() {
 			It("ServiceMonitor is generated with the proper TLSConfig ServerName", func() {


### PR DESCRIPTION
Rather than the defaulted epoch time, change the zap logger settings to provide a human readable timestamp, e.g.,

   {"level":"info","ts":"2022-09-27T20:22:40.161Z","logger":...