### PR TITLE
Add a script to conditionally set upstream remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Internal Changes
 
--
+- Added a utility script to make it easier for maintainers to propose releases,
+  regardless of the git remote configuration. See the previously closed
+  [issue](https://github.com/ComplianceAsCode/compliance-operator/issues/8) for
+  more details.
 
 ### Deprecations
 

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,13 @@ endif
 
 # Git options.
 GIT_OPTS?=
-# Set this to the remote used for the upstream repo (for release)
-GIT_REMOTE?=origin
+# Set this to the remote used for the upstream repo (for release). Different
+# maintainers might use different names for the upstream repository. Since our
+# release process expects maintainers to propose release patches directly to
+# the upstream repository, let's make sure we're proposing it to the right one.
+# We rely on a bash script for this since it's simplier than interating over a
+# list with conditionals in GNU make.
+GIT_REMOTE?=$(shell ./utils/git-remote.sh)
 
 # Image variables
 # ===============
@@ -89,10 +94,6 @@ SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./
 
 MUST_GATHER_IMAGE_PATH?=$(IMAGE_REPO)/must-gather
 MUST_GATHER_IMAGE_TAG?=$(TAG)
-# Set this to the remote used for the upstream repo (for release). Use an
-# absolute reference by default since we don't know if origin is the
-# contributor's fork or if it's the upstream repository.
-GIT_REMOTE?=git@github.com:ComplianceAsCode/compliance-operator.git
 
 # Kubernetes variables
 # ====================

--- a/utils/git-remote.sh
+++ b/utils/git-remote.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# git-remote.sh prints the remote associated with the upstream
+# ComplianceAsCode/compliance-operator repository. If it can't determine the
+# appropriate remote based on a known URL, it defaults to using "origin", which
+# is backwards compatible with the release process.
+
+REMOTE_URL=origin
+for REMOTE in `git remote`; do
+        URL=`git config --get remote.$REMOTE.url`
+        if [[ "$URL" = "https://github.com/ComplianceAsCode/compliance-operator" ]]; then
+                REMOTE_URL=$REMOTE
+                break
+        fi
+done
+echo $REMOTE_URL


### PR DESCRIPTION
Our upstream release process expects maintainers to propose release patches, branches, and tags to the upstream repository (ComplianceAsCode/compliance-operator). Some people prefer to setup their upstream remote as origin, while others use upstream.

This change introduces a script to determine which git remote to use for the GIT_REMOTE variable based on the url associated with the upstream repository. This makes the release process consistent, regardless of who is doing the release. This commit also removes an extra GIT_REMOTE defintion in the Makefile, making it clear where we're setting that variable and what the intended value should be.