### PR TITLE
OCPBUGS-2156: suite: Fall back to using betav1 cronjob if v1 cronjob is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   the test content datastream xml files under images/testcontent, and update the broken-content script
   to include that image tag.
 
+- The Compliance Operator now falls back to using the v1beta1 CronJob API
+  on clusters where the v1 CronJob API is not available which fixes a
+  [regression](https://issues.redhat.com/browse/OCPBUGS-2156) which was introduced
+  in the previous release (v0.1.56)
+
 ### Internal Changes
 
 - Added a utility script to make it easier for maintainers to propose releases,

--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -203,19 +203,7 @@ func (r *ReconcileComplianceSuite) Reconcile(ctx context.Context, request reconc
 }
 
 func (r *ReconcileComplianceSuite) suiteDeleteHandler(suite *compv1alpha1.ComplianceSuite, logger logr.Logger) error {
-	rerunner := r.getRerunner(suite)
-	priorityClassName, err := r.getPriorityClassName(suite)
-	if err != nil {
-		logger.Error(err, "Cannot get priority class name, scan will not be run with set priority class")
-	}
-	if priorityClassName != "" {
-		if priorityClassExist, why := utils.ValidatePriorityClassExist(priorityClassName, r.Client); !priorityClassExist {
-			log.Info(why, "Suit.Name", suite.Name)
-			r.Recorder.Eventf(suite, corev1.EventTypeWarning, "PriorityClass", why+" Suit:"+suite.Name)
-		}
-		rerunner.Spec.JobTemplate.Spec.Template.Spec.PriorityClassName = priorityClassName
-	}
-	if err = r.handleRerunnerDelete(rerunner, suite.Name, logger); err != nil {
+	if err := r.handleRerunnerDelete(suite, logger); err != nil {
 		return err
 	}
 

--- a/pkg/controller/compliancesuite/suitererunner.go
+++ b/pkg/controller/compliancesuite/suitererunner.go
@@ -9,11 +9,7 @@ import (
 	cron "github.com/robfig/cron/v3"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
@@ -23,7 +19,6 @@ import (
 const rerunnerServiceAccount = "rerunner"
 
 func (r *ReconcileComplianceSuite) reconcileScanRerunnerCronJob(suite *compv1alpha1.ComplianceSuite, logger logr.Logger) error {
-	rerunner := r.getRerunner(suite)
 	priorityClassName, err := r.getPriorityClassName(suite)
 	if err != nil {
 		logger.Error(err, "Cannot get priority class name, scan will not be run with set priority class")
@@ -33,12 +28,10 @@ func (r *ReconcileComplianceSuite) reconcileScanRerunnerCronJob(suite *compv1alp
 		log.Info(why, "Suite", suite.Name)
 		r.Recorder.Eventf(suite, corev1.EventTypeWarning, "PriorityClass", why+" Suite:"+suite.Name)
 	}
-	rerunner.Spec.JobTemplate.Spec.Template.Spec.PriorityClassName = priorityClassName
-
 	if suite.Spec.Schedule == "" {
-		return r.handleRerunnerDelete(rerunner, suite.Name, logger)
+		return r.handleRerunnerDelete(suite, logger)
 	}
-	return r.handleCreate(suite, rerunner, logger)
+	return r.handleCreate(suite, logger)
 }
 
 // validates that the provided schedule is correctly set. Else it returns false (not valid) and an
@@ -55,24 +48,8 @@ func (r *ReconcileComplianceSuite) validateSchedule(suite *compv1alpha1.Complian
 	return true, ""
 }
 
-func (r *ReconcileComplianceSuite) handleCreate(suite *compv1alpha1.ComplianceSuite, rerunner *batchv1.CronJob, logger logr.Logger) error {
-	key := types.NamespacedName{Name: rerunner.GetName(), Namespace: rerunner.GetNamespace()}
-	found := &batchv1.CronJob{}
-	err := r.Client.Get(context.TODO(), key, found)
-	if err != nil && errors.IsNotFound(err) {
-		// No re-runner found, create it
-		logger.Info("Creating rerunner", "CronJob.Name", rerunner.GetName())
-		return r.Client.Create(context.TODO(), rerunner)
-	} else if err != nil {
-		return err
-	}
-	if found.Spec.Schedule != suite.Spec.Schedule {
-		cronJobCopy := found.DeepCopy()
-		cronJobCopy.Spec.Schedule = suite.Spec.Schedule
-		logger.Info("Updating rerunner", "CronJob.Name", rerunner.GetName())
-		return r.Client.Update(context.TODO(), cronJobCopy)
-	}
-	return nil
+func (r *ReconcileComplianceSuite) handleCreate(suite *compv1alpha1.ComplianceSuite, logger logr.Logger) error {
+	return r.cronJobCompatCreate(suite, reRunnerNamespacedName(suite.Name), logger)
 }
 
 // getPriorityClassName for rerunner from suite scan
@@ -95,20 +72,16 @@ func (r *ReconcileComplianceSuite) getPriorityClassName(suite *compv1alpha1.Comp
 	return scans.Items[0].Spec.PriorityClass, nil
 }
 
-func (r *ReconcileComplianceSuite) handleRerunnerDelete(rerunner *batchv1.CronJob, suiteName string, logger logr.Logger) error {
-	key := types.NamespacedName{Name: rerunner.GetName(), Namespace: rerunner.GetNamespace()}
-	found := &batchv1.CronJob{}
-	err := r.Client.Get(context.TODO(), key, found)
-	if err != nil && errors.IsNotFound(err) {
-		// No re-runner found, we're good
-		return nil
-	} else if err != nil {
+func (r *ReconcileComplianceSuite) handleRerunnerDelete(suite *compv1alpha1.ComplianceSuite, logger logr.Logger) error {
+	key := reRunnerNamespacedName(suite.Name)
+	found, err := cronJobCompatGet(r, key)
+	if err != nil {
 		return err
 	}
 
 	inNs := client.InNamespace(common.GetComplianceOperatorNamespace())
 	withLabel := client.MatchingLabels{
-		compv1alpha1.SuiteLabel:       suiteName,
+		compv1alpha1.SuiteLabel:       suite.Name,
 		compv1alpha1.SuiteScriptLabel: "",
 	}
 	err = r.Client.DeleteAllOf(context.Background(), &corev1.Pod{}, inNs, withLabel)
@@ -121,78 +94,6 @@ func (r *ReconcileComplianceSuite) handleRerunnerDelete(rerunner *batchv1.CronJo
 		return err
 	}
 
-	logger.Info("Deleting rerunner", "CronJob.Name", rerunner.GetName())
-	return r.Client.Delete(context.TODO(), rerunner)
-}
-
-// GetRerunnerName gets the name of the rerunner workload based on the suite name
-func GetRerunnerName(suiteName string) string {
-	// Operator SDK doesn't allow CronJob with names longer than 52
-	// characters. Trim everything but the first 42 characters so we have
-	// enough room for the "-rerunner" string.
-	if len(suiteName) >= 42 {
-		suiteName = suiteName[0:42]
-	}
-	return suiteName + "-rerunner"
-}
-
-func (r *ReconcileComplianceSuite) getRerunner(suite *compv1alpha1.ComplianceSuite) *batchv1.CronJob {
-	falseP := false
-	trueP := true
-	return &batchv1.CronJob{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      GetRerunnerName(suite.Name),
-			Namespace: common.GetComplianceOperatorNamespace(),
-		},
-		Spec: batchv1.CronJobSpec{
-			Schedule: suite.Spec.Schedule,
-			JobTemplate: batchv1.JobTemplateSpec{
-				Spec: batchv1.JobSpec{
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								compv1alpha1.SuiteLabel:       suite.Name,
-								compv1alpha1.SuiteScriptLabel: "",
-								"workload":                    "suitererunner",
-							},
-							Annotations: map[string]string{
-								"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
-							},
-						},
-						Spec: corev1.PodSpec{
-							NodeSelector:       r.schedulingInfo.Selector,
-							Tolerations:        r.schedulingInfo.Tolerations,
-							ServiceAccountName: rerunnerServiceAccount,
-							RestartPolicy:      corev1.RestartPolicyOnFailure,
-							Containers: []corev1.Container{
-								{
-									Name:  "rerunner",
-									Image: utils.GetComponentImage(utils.OPERATOR),
-									SecurityContext: &corev1.SecurityContext{
-										AllowPrivilegeEscalation: &falseP,
-										ReadOnlyRootFilesystem:   &trueP,
-									},
-									Command: []string{
-										"compliance-operator", "suitererunner",
-										"--name", suite.GetName(),
-										"--namespace", suite.GetNamespace(),
-									},
-									Resources: corev1.ResourceRequirements{
-										Requests: corev1.ResourceList{
-											corev1.ResourceMemory: resource.MustParse("20Mi"),
-											corev1.ResourceCPU:    resource.MustParse("10m"),
-										},
-										Limits: corev1.ResourceList{
-											corev1.ResourceMemory: resource.MustParse("100Mi"),
-											corev1.ResourceCPU:    resource.MustParse("50m"),
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	logger.Info("Deleting rerunner", "CronJob.Name", key.Name)
+	return cronJobCompatDelete(r, found)
 }

--- a/pkg/controller/compliancesuite/suitererunner_cron_compat.go
+++ b/pkg/controller/compliancesuite/suitererunner_cron_compat.go
@@ -1,0 +1,260 @@
+package compliancesuite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/ComplianceAsCode/compliance-operator/pkg/controller/common"
+	"github.com/ComplianceAsCode/compliance-operator/pkg/utils"
+)
+
+// GetRerunnerName gets the name of the rerunner workload based on the suite name
+func GetRerunnerName(suiteName string) string {
+	// Operator SDK doesn't allow CronJob with names longer than 52
+	// characters. Trim everything but the first 42 characters so we have
+	// enough room for the "-rerunner" string.
+	if len(suiteName) >= 42 {
+		suiteName = suiteName[0:42]
+	}
+	return suiteName + "-rerunner"
+}
+
+func (r *ReconcileComplianceSuite) cronJobCompatCreate(
+	suite *compv1alpha1.ComplianceSuite,
+	key types.NamespacedName,
+	logger logr.Logger,
+) error {
+	var getObj client.Object
+
+	priorityClassName, err := r.getPriorityClassName(suite)
+	if err != nil {
+		logger.Error(err, "Cannot get priority class name, scan will not be run with set priority class")
+	}
+
+	createBeta := func() *batchv1beta1.CronJob {
+		getObj = &batchv1beta1.CronJob{}
+		return r.getBetaV1Rerunner(suite, priorityClassName)
+	}
+
+	createV1 := func() *batchv1.CronJob {
+		getObj = &batchv1.CronJob{}
+		return r.getV1Rerunner(suite, priorityClassName)
+	}
+
+	updateBeta := func() error {
+		getObjTyped, ok := getObj.(*batchv1beta1.CronJob)
+		if !ok {
+			return fmt.Errorf("failed to cast object to beta CronJob")
+		}
+		if getObjTyped.Spec.Schedule == suite.Spec.Schedule {
+			return nil
+		}
+		cronJobCopy := getObjTyped.DeepCopy()
+		cronJobCopy.Spec.Schedule = suite.Spec.Schedule
+		logger.Info("Updating beta rerunner", "CronJob.Name", cronJobCopy.GetName())
+		return r.Client.Update(context.TODO(), cronJobCopy)
+	}
+
+	updateV1 := func() error {
+		getObjTyped, ok := getObj.(*batchv1.CronJob)
+		if !ok {
+			return fmt.Errorf("failed to cast object to v1 CronJob")
+		}
+		if getObjTyped.Spec.Schedule == suite.Spec.Schedule {
+			return nil
+		}
+		cronJobCopy := getObjTyped.DeepCopy()
+		cronJobCopy.Spec.Schedule = suite.Spec.Schedule
+		logger.Info("Updating v1 rerunner", "CronJob.Name", cronJobCopy.GetName())
+		return r.Client.Update(context.TODO(), cronJobCopy)
+	}
+
+	createAction := func(o client.Object) error {
+		err := r.Client.Get(context.TODO(), key, getObj)
+		if err != nil && errors.IsNotFound(err) {
+			// No re-runner found, create it
+			logger.Info("Creating rerunner", "CronJob.Name", o.GetName())
+			return r.Client.Create(context.TODO(), o)
+		} else if err != nil {
+			return err
+		}
+
+		switch o.(type) {
+		case *batchv1beta1.CronJob:
+			return updateBeta()
+		case *batchv1.CronJob:
+			return updateV1()
+		}
+
+		return nil
+	}
+
+	return doCompat(createAction, createBeta, createV1)
+}
+
+func cronJobCompatGet(r *ReconcileComplianceSuite, key types.NamespacedName) (client.Object, error) {
+	var retObj client.Object
+
+	getEmptyBeta := func() *batchv1beta1.CronJob {
+		return &batchv1beta1.CronJob{}
+	}
+
+	getEmptyV1 := func() *batchv1.CronJob {
+		return &batchv1.CronJob{}
+	}
+
+	getAction := func(o client.Object) error {
+		err := r.Client.Get(context.TODO(), key, o)
+		if err != nil && errors.IsNotFound(err) {
+			// No re-runner found, we're good
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		retObj = o
+		return nil
+	}
+
+	err := doCompat(getAction, getEmptyBeta, getEmptyV1)
+	return retObj, err
+}
+
+func cronJobCompatDelete(r *ReconcileComplianceSuite, cron client.Object) error {
+	if cron == nil {
+		// for cases where cronJobCompatGet returns nil,nil
+		return nil
+	}
+
+	return r.Client.Delete(context.TODO(), cron)
+}
+
+type compatAction func(o client.Object) error
+type getBetaCron func() *batchv1beta1.CronJob
+type getV1Cron func() *batchv1.CronJob
+
+func doCompat(what compatAction, betaCron getBetaCron, v1cron getV1Cron) error {
+	err := what(v1cron())
+	if meta.IsNoMatchError(err) {
+		return what(betaCron())
+	}
+	return err
+}
+
+func reRunnerNamespacedName(suiteName string) types.NamespacedName {
+	return types.NamespacedName{
+		Name:      GetRerunnerName(suiteName),
+		Namespace: common.GetComplianceOperatorNamespace(),
+	}
+}
+
+func reRunnerObjectMeta(suiteName string) *metav1.ObjectMeta {
+	nsName := reRunnerNamespacedName(suiteName)
+
+	return &metav1.ObjectMeta{
+		Name:      nsName.Name,
+		Namespace: nsName.Namespace,
+	}
+}
+
+func (r *ReconcileComplianceSuite) getV1Rerunner(
+	suite *compv1alpha1.ComplianceSuite,
+	priorityClassName string,
+) *batchv1.CronJob {
+	return &batchv1.CronJob{
+		ObjectMeta: *reRunnerObjectMeta(suite.Name),
+		Spec: batchv1.CronJobSpec{
+			Schedule: suite.Spec.Schedule,
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: *r.getRerunnerPodTemplate(suite, priorityClassName),
+				},
+			},
+		},
+	}
+}
+
+func (r *ReconcileComplianceSuite) getBetaV1Rerunner(
+	suite *compv1alpha1.ComplianceSuite,
+	priorityClassName string,
+) *batchv1beta1.CronJob {
+	return &batchv1beta1.CronJob{
+		ObjectMeta: *reRunnerObjectMeta(suite.Name),
+		Spec: batchv1beta1.CronJobSpec{
+			Schedule: suite.Spec.Schedule,
+			JobTemplate: batchv1beta1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: *r.getRerunnerPodTemplate(suite, priorityClassName),
+				},
+			},
+		},
+	}
+}
+
+func (r *ReconcileComplianceSuite) getRerunnerPodTemplate(
+	suite *compv1alpha1.ComplianceSuite,
+	priorityClassName string,
+) *corev1.PodTemplateSpec {
+	falseP := false
+	trueP := true
+
+	// We need to support both v1 and beta1 CronJobs, so we need to use the
+	// same pod template for both. We can't use the same CronJob object
+	// because the API is different.
+	return &corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				compv1alpha1.SuiteLabel:       suite.Name,
+				compv1alpha1.SuiteScriptLabel: "",
+				"workload":                    "suitererunner",
+			},
+			Annotations: map[string]string{
+				"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeSelector:       r.schedulingInfo.Selector,
+			Tolerations:        r.schedulingInfo.Tolerations,
+			ServiceAccountName: rerunnerServiceAccount,
+			RestartPolicy:      corev1.RestartPolicyOnFailure,
+			PriorityClassName:  priorityClassName,
+			Containers: []corev1.Container{
+				{
+					Name:  "rerunner",
+					Image: utils.GetComponentImage(utils.OPERATOR),
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: &falseP,
+						ReadOnlyRootFilesystem:   &trueP,
+					},
+					Command: []string{
+						"compliance-operator", "suitererunner",
+						"--name", suite.GetName(),
+						"--namespace", suite.GetNamespace(),
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("20Mi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
We removed the usage of v1beta1 cronjob API in
5c860d72a438ce5769cead38a7faa3fef089be3d but now that came back to bite
us since on older OpenShift versions (4.6 and 4.7) the beta API is the
only one available.

Let's try to use the v1 API and fall back to the beta API if needed.

Resolves: OCPBUGS-2156
