### PR TITLE
Use tab indentation for `make help`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ DEFAULT_OPERATOR_IMAGE=$(DEFAULT_REPO)/$(APP_NAME):$(DEFAULT_TAG)
 
 .PHONY: help
 help: ## Display this help.
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m \t%s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 .PHONY: clean
 clean: clean-modcache clean-cache clean-output clean-test clean-kustomize clean-tools ## Run all of the clean targets.


### PR DESCRIPTION
Some of our targets have long names. Mixing long and short targets
causes the help text for each to be formatted inconsistently.

This commit updates the help text to supply description after a tab,
which should keep the indentation consistent.
