### PR TITLE
Stash e2e test output when running locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ tags
 .idea
 # Generated files for E2E test setup
 tests/_setup
+tests/e2e-test.log

--- a/Makefile
+++ b/Makefile
@@ -560,7 +560,7 @@ test-benchmark: ## Run the benchmark tests -- Note that this can only be ran for
 
 .PHONY: e2e
 e2e: e2e-set-image prep-e2e
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS)
+	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
 
 .PHONY: prep-e2e
 prep-e2e: kustomize


### PR DESCRIPTION
Saving these logs are helpful. Let's tee stdout to a file we can use
later.
