### PR TITLE
openscap: Update libksba manually to make CVE scanners happy

### DIFF
--- a/images/openscap/Dockerfile
+++ b/images/openscap/Dockerfile
@@ -8,8 +8,10 @@ LABEL \
     io.openshift.tags="compliance openscap scan" \
     io.openshift.wants="scap-content"
 
+# Remove the microdnf upgrade libksba line when RH releases UBI image with fix for CVE-2022-3515
 RUN true \
     && microdnf install -y openscap-scanner \
+    && microdnf upgrade libksba \
     && microdnf clean all \
     && true
 


### PR DESCRIPTION
RH has fixed CVE-2022-3515 already in an update, but the UBI update lags
behind. Upgrade the package manually in the meantime.
