### PR TITLE
Revert "openscap: Update libksba manually to make CVE scanners happy"

### DIFF
--- a/images/openscap/Dockerfile
+++ b/images/openscap/Dockerfile
@@ -8,10 +8,8 @@ LABEL \
     io.openshift.tags="compliance openscap scan" \
     io.openshift.wants="scap-content"
 
-# Remove the microdnf upgrade libksba line when RH releases UBI image with fix for CVE-2022-3515
 RUN true \
     && microdnf install -y openscap-scanner \
-    && microdnf upgrade libksba \
     && microdnf clean all \
     && true
 


### PR DESCRIPTION
This reverts commit 147d8c3873950068d880abd93ce8ba3d399bd874 which
should no longer be needed becuse the UBI image was refreshed.
