### PR TITLE
catalog: Bump the version in preamble

### DIFF
--- a/catalog/preamble.json
+++ b/catalog/preamble.json
@@ -13,8 +13,8 @@
     "package": "compliance-operator",
     "entries": [
         {
-            "name": "compliance-operator.v0.1.56",
-            "skipRange": ">=0.1.17 <0.1.56"
+            "name": "compliance-operator.v0.1.57",
+            "skipRange": ">=0.1.17 <0.1.57"
         }
     ]
 }


### PR DESCRIPTION
Looks like we forgot to do this when releasing 0.1.57. This patch fixes
the skipVersion.
