### PR TITLE
Add preamble.json to release targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Internal Changes
 
--
+- Ensure `preamble.json` is included in the release process so the catalog is
+  up-to-date with the latest version of the operator.
 
 ### Deprecations
 

--- a/Makefile
+++ b/Makefile
@@ -625,6 +625,7 @@ git-release: fetch-git-tags package-version-to-tag changelog ## Update project f
 	sed -i "s/\(.*VERSION?=\).*/\1$(TAG)/" version.Makefile
 	git add version* bundle CHANGELOG.md config/manifests/bases
 	git add "config/helm/Chart.yaml"
+	git add "catalog/preamble.json"
 	git restore config/manager/kustomization.yaml
 
 .PHONY: fetch-git-tags


### PR DESCRIPTION
We need to keep track of the version number in preamble.json for the
operator index image.

Let's make sure we add it to the makefile targets for releasing the
operator so that it's included in the release commit.
