### PR TITLE
OCPBUGS-3420: Ensure ScanSettingBindings use the default ScanSetting by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
--
+- Fixes an [issue](https://issues.redhat.com/browse/OCPBUGS-3420) where
+  `ScanSettingBindings` created without a `settingRef` did not use a proper
+  default value. `ScanSettingBindings` without a `settingRef` will now use the
+  `default` `ScanSetting`.
 
 ### Internal Changes
 

--- a/bundle/manifests/compliance.openshift.io_scansettingbindings.yaml
+++ b/bundle/manifests/compliance.openshift.io_scansettingbindings.yaml
@@ -46,6 +46,10 @@ spec:
               type: object
             type: array
           settingsRef:
+            default:
+              apiGroup: compliance.openshift.io/v1alpha1
+              kind: ScanSetting
+              name: default
             properties:
               apiGroup:
                 type: string

--- a/config/crd/bases/compliance.openshift.io_scansettingbindings.yaml
+++ b/config/crd/bases/compliance.openshift.io_scansettingbindings.yaml
@@ -47,6 +47,10 @@ spec:
               type: object
             type: array
           settingsRef:
+            default:
+              apiGroup: compliance.openshift.io/v1alpha1
+              kind: ScanSetting
+              name: default
             properties:
               apiGroup:
                 type: string

--- a/pkg/apis/compliance/v1alpha1/scansettingbinding_types.go
+++ b/pkg/apis/compliance/v1alpha1/scansettingbinding_types.go
@@ -22,6 +22,7 @@ type ScanSettingBinding struct {
 
 	Spec        ScanSettingBindingSpec `json:"spec,omitempty"`
 	Profiles    []NamedObjectReference `json:"profiles,omitempty"`
+        // +kubebuilder:default={"name":"default","kind": "ScanSetting", "apiGroup": "compliance.openshift.io/v1alpha1"}
 	SettingsRef *NamedObjectReference  `json:"settingsRef,omitempty"`
 	// +optional
 	Status ScanSettingBindingStatus `json:"status,omitempty"`


### PR DESCRIPTION
By default, ScanSettingBindings don't need to reference a ScanSetting
using the SettingsRef. If you create a binding without a reference to a
scan setting, the scan will run anyway but doesn't take on any of the
default behaviors of the `default` ScanSetting.

This commit fixes this behavior by updating the default for the
ScanSettingBinding settingRef to the `default` ScanSetting.

Related Jira: https://issues.redhat.com/browse/OCPBUGS-3420
