### PR TITLE
OCPBUGS-4445: Excludes node sizing, and system reserved parameters from KubeletConfig rendering checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   `ScanSettingBindings` created without a `settingRef` did not use a proper
   default value. `ScanSettingBindings` without a `settingRef` will now use the
   `default` `ScanSetting`.
+  
+- System reserved parameters do not get generated into `/etc/kubernetes/kubelet.conf`,
+  and it is causing Compliance Operator to fail to unpause the machine config pool,
+  this PR excludes node sizing, and system reserved parameters from checking if 
+  KubeletConfig is not part of the generated Machine Config since it does not get
+  generated into `/etc/kubernetes/kubelet.conf` file.
+  [OCPBUGS-4445] https://issues.redhat.com/browse/OCPBUGS-4445
 
 - Fixes an [issue](https://issues.redhat.com/browse/OCPBUGS-4615) where
   `ComplianceCheckResult` objects do not have correct descriptions, we

--- a/pkg/utils/nodeutils.go
+++ b/pkg/utils/nodeutils.go
@@ -41,6 +41,8 @@ const (
 	mcBase64PayloadPrefix  = `data:text/plain;charset=utf-8;base64,`
 )
 
+var nodeSizingEnvList = [2]string{"autoSizingReserved", "systemReserved"}
+
 func GetFirstNodeRoleLabel(nodeSelector map[string]string) string {
 	if nodeSelector == nil {
 		return ""
@@ -213,11 +215,18 @@ func IsKCSubsetOfMC(kc *mcfgv1.KubeletConfig, mc *mcfgv1.MachineConfig) (bool, e
 		return false, fmt.Errorf("encoded kubeletconfig %s does not contain encoding prefix", mc.Name), ""
 	}
 
+	// remove node sizing related fields from kubelet config
+	filteredKC, err := removeNodeSizingEnvParams(kc.Spec.KubeletConfig.Raw)
+	if err != nil {
+		return false, fmt.Errorf("failed to remove node sizing related fields from decoded kubelet config: %w", err), ""
+	}
+
 	// Check if KubeletConfig is a subset of the MachineConfig
-	isSubset, diff, err := JSONIsSubset(kc.Spec.KubeletConfig.Raw, decodedKC)
+	isSubset, diff, err := JSONIsSubset(filteredKC, decodedKC)
 	if err != nil {
 		return false, fmt.Errorf("failed to check if kubeletconfig %s is subset of rendered MC %s: %w", kc.Name, mc.Name, err), ""
 	}
+
 	if isSubset {
 		return true, nil, ""
 	}
@@ -244,6 +253,21 @@ func GetKCFromMC(mc *mcfgv1.MachineConfig, client runtimeclient.Client) (*mcfgv1
 		}
 	}
 	return nil, fmt.Errorf("machine config %s doesn't have a KubeletConfig owner reference", mc.GetName())
+}
+
+// removeNodeSizingEnvParams remove KubeletConfig Parameter related to /etc/node-sizing-enabled.env,
+// as it is not rendered in the MachineConfig to file /etc/kubernetes/kubelet.conf
+func removeNodeSizingEnvParams(mc []byte) ([]byte, error) {
+	var data map[string]json.RawMessage
+
+	if err := json.Unmarshal(mc, &data); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal kubelet config: %w", err)
+	}
+
+	for _, key := range nodeSizingEnvList {
+		delete(data, key)
+	}
+	return json.Marshal(data)
 }
 
 // McfgPoolLabelMatches verifies if the given nodeSelector matches the given MachineConfigPool's nodeSelector

--- a/pkg/utils/nodeutils_test.go
+++ b/pkg/utils/nodeutils_test.go
@@ -213,7 +213,12 @@ var _ = Describe("Nodeutils", func() {
 		defaultKCPayload := `
 		{
 			"streamingConnectionIdleTimeout": "0s",
-			"something": "0s"
+			"something": "0s",
+			"systemReserved": {
+				"cpu": "0s",
+				"memory": "0s"
+			},
+			"autoSizingReserved": true
 		}
 		`
 		testKubeletConfig := func(kcPayload string) *mcfgv1.KubeletConfig {


### PR DESCRIPTION
System reserved parameters do not get generated into `/etc/kubernetes/kubelet.conf`, and it is causing Compliance Operator to fail to unpause the machine config pool, this PR excludes node sizing, and system reserved parameters from checking if KubeletConfig is not part of the generated Machine Config since it does not get generated into `/etc/kubernetes/kubelet.conf` file.

[OCPBUGS-4445] https://issues.redhat.com/browse/OCPBUGS-4445

See the slack thread for more details: https://coreos.slack.com/archives/C02CZNQHGN8/p1669843411934799?thread_ts=1669842906.487409&cid=C02CZNQHGN8