### PR TITLE
OCPBUGS-4338: Apply all remediations associate with each ComplianceCheckResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   corrected the descriptions, and also added a new `rationale` field to
   `ComplianceCheckResult` objects.
 
+- Make Compliance Operator to apply all the related remediations for 
+  one ComplianceCheckResult at once, this helps users who use manual
+  remediation, this feature will look for all the related remediations
+  for a ComplianceCheckResult when one remediation is applied. For ex.
+  we have `cp4-cis-kubelet-evictio...-inodesfree`, `cp4-cis-kubelet-evictio...-inodesfree-1`,
+  remediations, when a user applies either one of them, we will apply
+  all the other remediations associate with the rule.
+  [OCPBUGS-4338]https://issues.redhat.com/browse/OCPBUGS-4338
+
+
 ### Internal Changes
 
 - The Compliance Operator now marks a `ScanSettingBinding` that uses a


### PR DESCRIPTION
Make Compliance Operator apply all the related remediations for one ComplianceCheckResult at once, this helps users who use manual remediation, this feature will look for all the related remediations for a ComplianceCheckResult when one remediation is applied.

For ex. we have 
```
ocp4-cis-kubelet-eviction-thresholds-set-soft-nodefs-inodesfree                                  
ocp4-cis-kubelet-eviction-thresholds-set-soft-nodefs-inodesfree-1                              
ocp4-cis-kubelet-eviction-thresholds-set-soft-nodefs-inodesfree-2         
ocp4-cis-kubelet-eviction-thresholds-set-soft-nodefs-inodesfree-3     
ocp4-cis-kubelet-eviction-thresholds-set-soft-nodefs-inodesfree-4
```
remediations, when a user applies either one of them, we will apply all the other remediations associated with the rule.

[OCPBUGS-4338]https://issues.redhat.com/browse/OCPBUGS-4338

