### PR TITLE
OCPBUGS-4621: Add non-nil check before comparing if KubeletConfig is fully rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   corrected the descriptions, and also added a new `rationale` field to
   `ComplianceCheckResult` objects.
 
+- Added check for nil pointer before comparing if KubeletConfig is fully rendered。
+  This is necessary because setting the KubeletConfig object incorrectly can result
+  in an empty KubeletConfig Spec, which can cause a panic error. This check will prevent
+  this issue and ensure the comparison is performed safely.
+  [OCPBUGS-4621](https://issues.redhat.com/browse/OCPBUGS-4621)
+
 ### Internal Changes
 
 - The Compliance Operator now marks a `ScanSettingBinding` that uses a

--- a/pkg/utils/compare_json.go
+++ b/pkg/utils/compare_json.go
@@ -20,6 +20,9 @@ type JSONDiffRow struct {
 
 // JSONIsSubset checks if a is a subset json of b
 func JSONIsSubset(a, b []byte) (bool, *JSONDiff, error) {
+	if a == nil || b == nil {
+		return false, nil, fmt.Errorf("nil json")
+	}
 	return jsonIsSubsetR(a, b, nil, nil)
 }
 

--- a/pkg/utils/nodeutils.go
+++ b/pkg/utils/nodeutils.go
@@ -159,7 +159,7 @@ func AreKubeletConfigsRendered(pool *mcfgv1.MachineConfigPool, client runtimecli
 
 	kc, err := GetKCFromMC(kcmcfg, client)
 	if err != nil {
-		return false, fmt.Errorf("failed to get kubelet config from machine config %s: %w", currentKCMCName, err), ""
+		return false, fmt.Errorf("failed to get kubelet config using machine config name %s: %w", currentKCMCName, err), ""
 	}
 
 	return IsKCSubsetOfMC(kc, kcmcfg)
@@ -172,6 +172,9 @@ func IsKCSubsetOfMC(kc *mcfgv1.KubeletConfig, mc *mcfgv1.MachineConfig) (bool, e
 	}
 	if mc == nil {
 		return false, fmt.Errorf("machine config is nil"), ""
+	}
+	if kc.Spec.KubeletConfig == nil {
+		return false, fmt.Errorf("kubelet config spec is nil, please check if KubeletConfig object has been used correctly"), ""
 	}
 
 	var obj interface{}

--- a/pkg/utils/nodeutils_test.go
+++ b/pkg/utils/nodeutils_test.go
@@ -216,6 +216,18 @@ var _ = Describe("Nodeutils", func() {
 			"something": "0s"
 		}
 		`
+		testKubeletConfigNil := func() *mcfgv1.KubeletConfig {
+			return &mcfgv1.KubeletConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "KubeletConfig",
+					APIVersion: "machineconfiguration.openshift.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kubelet-config-compliance-operator",
+				},
+				Spec: mcfgv1.KubeletConfigSpec{},
+			}
+		}
 		testKubeletConfig := func(kcPayload string) *mcfgv1.KubeletConfig {
 			return &mcfgv1.KubeletConfig{
 				TypeMeta: metav1.TypeMeta{
@@ -357,6 +369,44 @@ var _ = Describe("Nodeutils", func() {
 			})
 		})
 
+		Context("KubeletConfig is nil", func() {
+			renderdKC := `
+			{
+				"ignition": {
+				  "version": "3.2.0"
+				},
+				"storage": {
+				  "files": [
+					{
+					  "contents": {
+						"source": "data:text/plain,NODE_SIZING_ENABLED%3Dtrue%0ASYSTEM_RESERVED_MEMORY%3D1Gi%0ASYSTEM_RESERVED_CPU%3D500m%0A"
+					  },
+					  "mode": 420,
+					  "overwrite": true,
+					  "path": "/etc/node-sizing-enabled.env"
+					},
+					{
+					  "contents": {
+						"source": "data:text/plain,%7B%0A%20%20%22kind%22%3A%20%22KubeletConfiguration%22%2C%0A%20%20%22apiVersion%22%3A%20%22kubelet.config.k8s.io%2Fv1beta1%22%2C%0A%20%20%22staticPodPath%22%3A%20%22%2Fetc%2Fkubernetes%2Fmanifests%22%2C%0A%20%20%22syncFrequency%22%3A%20%220s%22%2C%0A%20%20%22fileCheckFrequency%22%3A%20%220s%22%2C%0A%20%20%22httpCheckFrequency%22%3A%20%220s%22%2C%0A%20%20%22tlsCipherSuites%22%3A%20%5B%0A%20%20%20%20%22TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256%22%2C%0A%20%20%20%20%22TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256%22%2C%0A%20%20%20%20%22TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384%22%2C%0A%20%20%20%20%22TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384%22%2C%0A%20%20%20%20%22TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256%22%2C%0A%20%20%20%20%22TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256%22%0A%20%20%5D%2C%0A%20%20%22tlsMinVersion%22%3A%20%22VersionTLS12%22%2C%0A%20%20%22rotateCertificates%22%3A%20true%2C%0A%20%20%22serverTLSBootstrap%22%3A%20true%2C%0A%20%20%22authentication%22%3A%20%7B%0A%20%20%20%20%22x509%22%3A%20%7B%0A%20%20%20%20%20%20%22clientCAFile%22%3A%20%22%2Fetc%2Fkubernetes%2Fkubelet-ca.crt%22%0A%20%20%20%20%7D%2C%0A%20%20%20%20%22webhook%22%3A%20%7B%0A%20%20%20%20%20%20%22cacheTTL%22%3A%20%220s%22%0A%20%20%20%20%7D%2C%0A%20%20%20%20%22anonymous%22%3A%20%7B%0A%20%20%20%20%20%20%22enabled%22%3A%20false%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22authorization%22%3A%20%7B%0A%20%20%20%20%22webhook%22%3A%20%7B%0A%20%20%20%20%20%20%22cacheAuthorizedTTL%22%3A%20%220s%22%2C%0A%20%20%20%20%20%20%22cacheUnauthorizedTTL%22%3A%20%220s%22%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22clusterDomain%22%3A%20%22cluster.local%22%2C%0A%20%20%22clusterDNS%22%3A%20%5B%0A%20%20%20%20%22172.30.0.10%22%0A%20%20%5D%2C%0A%20%20%22streamingConnectionIdleTimeout%22%3A%20%220s%22%2C%0A%20%20%22nodeStatusUpdateFrequency%22%3A%20%220s%22%2C%0A%20%20%22nodeStatusReportFrequency%22%3A%20%220s%22%2C%0A%20%20%22imageMinimumGCAge%22%3A%20%220s%22%2C%0A%20%20%22volumeStatsAggPeriod%22%3A%20%220s%22%2C%0A%20%20%22systemCgroups%22%3A%20%22%2Fsystem.slice%22%2C%0A%20%20%22cgroupRoot%22%3A%20%22%2F%22%2C%0A%20%20%22cgroupDriver%22%3A%20%22systemd%22%2C%0A%20%20%22cpuManagerReconcilePeriod%22%3A%20%220s%22%2C%0A%20%20%22runtimeRequestTimeout%22%3A%20%220s%22%2C%0A%20%20%22maxPods%22%3A%20250%2C%0A%20%20%22something%22%3A%20%220s%22%2C%0A%20%20%22kubeAPIBurst%22%3A%20100%2C%0A%20%20%22serializeImagePulls%22%3A%20false%2C%0A%20%20%22evictionPressureTransitionPeriod%22%3A%20%220s%22%2C%0A%20%20%22featureGates%22%3A%20%7B%0A%20%20%20%20%22APIPriorityAndFairness%22%3A%20true%2C%0A%20%20%20%20%22CSIMigrationAWS%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationAzureDisk%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationAzureFile%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationGCE%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationOpenStack%22%3A%20false%2C%0A%20%20%20%20%22CSIMigrationvSphere%22%3A%20false%2C%0A%20%20%20%20%22DownwardAPIHugePages%22%3A%20true%2C%0A%20%20%20%20%22LegacyNodeRoleBehavior%22%3A%20false%2C%0A%20%20%20%20%22NodeDisruptionExclusion%22%3A%20true%2C%0A%20%20%20%20%22PodSecurity%22%3A%20true%2C%0A%20%20%20%20%22RotateKubeletServerCertificate%22%3A%20true%2C%0A%20%20%20%20%22ServiceNodeExclusion%22%3A%20true%2C%0A%20%20%20%20%22SupportPodPidsLimit%22%3A%20true%0A%20%20%7D%2C%0A%20%20%22memorySwap%22%3A%20%7B%7D%2C%0A%20%20%22containerLogMaxSize%22%3A%20%2250Mi%22%2C%0A%20%20%22systemReserved%22%3A%20%7B%0A%20%20%20%20%22ephemeral-storage%22%3A%20%221Gi%22%0A%20%20%7D%2C%0A%20%20%22logging%22%3A%20%7B%0A%20%20%20%20%22flushFrequency%22%3A%200%2C%0A%20%20%20%20%22verbosity%22%3A%200%2C%0A%20%20%20%20%22options%22%3A%20%7B%0A%20%20%20%20%20%20%22json%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22infoBufferSize%22%3A%20%220%22%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22shutdownGracePeriod%22%3A%20%220s%22%2C%0A%20%20%22shutdownGracePeriodCriticalPods%22%3A%20%220s%22%0A%7D%0A"
+					  },
+					  "mode": 420,
+					  "overwrite": true,
+					  "path": "/etc/kubernetes/kubelet.conf"
+					}
+				  ]
+				}
+			  }`
+			kc := testKubeletConfigNil()
+			mc := testMachineConfig(renderdKC)
+			It("It should evaluate as false", func() {
+				errorMsg := "kubelet config spec is nil, please check if KubeletConfig object has been used correctly"
+				isSubset, err, diffString := utils.IsKCSubsetOfMC(kc, mc)
+				Expect(err).To(MatchError(errorMsg))
+				Expect(isSubset).To(BeFalse())
+				Expect(diffString).To(BeEmpty())
+			})
+		})
+
 		Context("MachineConfig is missing kubeconfig file", func() {
 			renderdKC := `
 			{
@@ -439,7 +489,7 @@ var _ = Describe("Nodeutils", func() {
 		Context("KubeletConfig and MachineConfig are empty", func() {
 			kc := &mcfgv1.KubeletConfig{}
 			mc := &mcfgv1.MachineConfig{}
-			expectedError := "failed to unmarshal machine config : unexpected end of JSON input"
+			expectedError := "kubelet config spec is nil, please check if KubeletConfig object has been used correctly"
 
 			It("It should evaluate as false", func() {
 				isSubset, err, diffString := utils.IsKCSubsetOfMC(kc, mc)


### PR DESCRIPTION
Added check for nil pointer before comparing if KubeletConfig is fully rendered。
This is necessary because setting the KubeletConfig object incorrectly can result
in an empty KubeletConfig Spec, which can cause a panic error. This check will prevent
this issue and ensure the comparison is performed safely.
  [OCPBUGS-4621](https://issues.redhat.com/browse/OCPBUGS-4621)

Example of an incorrect way of setting autoSizingReserved KubletConfig:
```
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  name: dynamic-node
spec:
  autoSizingReserved: true
  machineConfigPoolSelector:
    matchLabels:
      pools.operator.machineconfiguration.openshift.io/worker: ""
```

Instead, it should be set as follows according to [OpenShift Doc](https://docs.openshift.com/container-platform/4.11/nodes/nodes/nodes-nodes-resources-configuring.html):
```
apiVersion: machineconfiguration.openshift.io/v1
kind: KubeletConfig
metadata:
  name: dynamic-node 
spec:
  kubeletConfig:
    autoSizingReserved: true 
  machineConfigPoolSelector:
    matchLabels:
      pools.operator.machineconfiguration.openshift.io/worker: "" 
```