### PR TITLE
OCPBUGS-4615: Correct rule description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   default value. `ScanSettingBindings` without a `settingRef` will now use the
   `default` `ScanSetting`.
 
+- Fixes an [issue](https://issues.redhat.com/browse/OCPBUGS-4615) where
+  `ComplianceCheckResult` objects do not have correct descriptions, we
+  corrected the descriptions, and also added a new `rationale` field to
+  `ComplianceCheckResult` objects.
+
 ### Internal Changes
 
 - Added the ability to hide compliance check result for helper rule, we will

--- a/config/crd/bases/compliance.openshift.io_compliancecheckresults.yaml
+++ b/config/crd/bases/compliance.openshift.io_compliancecheckresults.yaml
@@ -55,6 +55,9 @@ spec:
             type: string
           metadata:
             type: object
+          rationale:
+            description: The rationale of the Rule
+            type: string
           severity:
             description: The severity of a check status
             type: string

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -85,6 +85,8 @@ type ComplianceCheckResult struct {
 	Severity ComplianceCheckResultSeverity `json:"severity"`
 	// A human-readable check description, what and why it does
 	Description string `json:"description,omitempty"`
+	// The rationale of the Rule
+	Rationale string `json:"rationale,omitempty"`
 	// How to evaluate if the rule status manually. If no automatic test is present, the rule status will be MANUAL
 	// and the administrator should follow these instructions.
 	Instructions string `json:"instructions,omitempty"`


### PR DESCRIPTION
Fixes an [issue](https://issues.redhat.com/browse/OCPBUGS-4615) where `ComplianceCheckResult` objects do not have correct descriptions, we corrected the descriptions, and also added a new `rationale` field to `ComplianceCheckResult` objects.