### PR TITLE
Add Timeout for scanner pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Enhancements
 
--
+- Added support for timeout for Scanner Pod. The timeout is
+  specified in the `ComplianceScanSettings` object as a duration string,
+  e.g. `1h30m`. If the scan is not completed within the timeout, the
+  corresponding scan will either fail or retry.
+  See [To use timeout option for scan](https://github.com/ComplianceAsCode/compliance-operator/blob/master/doc/usage.md#to-use-timeout-option-for-scan) in `doc/usage.md` for details usage.
+
 
 ### Fixes
 

--- a/config/crd/bases/compliance.openshift.io_compliancescans.yaml
+++ b/config/crd/bases/compliance.openshift.io_compliancescans.yaml
@@ -64,6 +64,11 @@ spec:
                   object Defines a proxy for the scan to get external resources from.
                   This is useful for disconnected installations with access to a proxy.
                 type: string
+              maxRetryOnTimeout:
+                default: 3
+                description: MaxRetryOnTimeout is the maximum number of times the
+                  scan will be retried if it times out.
+                type: integer
               noExternalResources:
                 description: Defines that no external resources in the Data Stream
                   should be used. External resources could be, for instance, CVE feeds.
@@ -274,6 +279,11 @@ spec:
                 required:
                 - name
                 type: object
+              timeout:
+                default: 30m
+                description: Timeout is the maximum amount of time the scan can run.
+                  If the scan hasn't finished by then, it will be aborted.
+                type: string
             type: object
           status:
             description: The status will give valuable information on what's going
@@ -333,6 +343,9 @@ spec:
                 description: Is the phase where the scan is at. Normally, one must
                   wait for the scan to reach the phase DONE.
                 type: string
+              remainingRetries:
+                description: Is the number of retries left for the scan on timeout
+                type: integer
               result:
                 description: Once the scan reaches the phase DONE, this will contain
                   the result of the scan. Where COMPLIANT means that the scan succeeded;

--- a/config/crd/bases/compliance.openshift.io_compliancesuites.yaml
+++ b/config/crd/bases/compliance.openshift.io_compliancesuites.yaml
@@ -80,6 +80,11 @@ spec:
                         from. This is useful for disconnected installations with access
                         to a proxy.
                       type: string
+                    maxRetryOnTimeout:
+                      default: 3
+                      description: MaxRetryOnTimeout is the maximum number of times
+                        the scan will be retried if it times out.
+                      type: integer
                     name:
                       description: Contains a human readable name for the scan. This
                         is to identify the objects that it creates.
@@ -305,6 +310,11 @@ spec:
                       required:
                       - name
                       type: object
+                    timeout:
+                      default: 30m
+                      description: Timeout is the maximum amount of time the scan
+                        can run. If the scan hasn't finished by then, it will be aborted.
+                      type: string
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
@@ -432,6 +442,9 @@ spec:
                       description: Is the phase where the scan is at. Normally, one
                         must wait for the scan to reach the phase DONE.
                       type: string
+                    remainingRetries:
+                      description: Is the number of retries left for the scan on timeout
+                      type: integer
                     result:
                       description: Once the scan reaches the phase DONE, this will
                         contain the result of the scan. Where COMPLIANT means that

--- a/config/crd/bases/compliance.openshift.io_scansettings.yaml
+++ b/config/crd/bases/compliance.openshift.io_scansettings.yaml
@@ -49,6 +49,11 @@ spec:
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
+          maxRetryOnTimeout:
+            default: 3
+            description: MaxRetryOnTimeout is the maximum number of times the scan
+              will be retried if it times out.
+            type: integer
           metadata:
             type: object
           noExternalResources:
@@ -243,6 +248,11 @@ spec:
               be strict and error out. `false` means that we don't need to be strict
               and we can proceed.
             type: boolean
+          timeout:
+            default: 30m
+            description: Timeout is the maximum amount of time the scan can run. If
+              the scan hasn't finished by then, it will be aborted.
+            type: string
         type: object
     served: true
     storage: true

--- a/pkg/apis/compliance/v1alpha1/conditions.go
+++ b/pkg/apis/compliance/v1alpha1/conditions.go
@@ -221,3 +221,13 @@ func (conditions *Conditions) SetConditionReady(what string) {
 		Message: fmt.Sprintf("Compliance %s run is done running the scans", what),
 	})
 }
+
+func (conditions *Conditions) SetConditionTimeout(what string) {
+	conditions.SetCondition(Condition{
+		Type:    "Ready",
+		Status:  corev1.ConditionFalse,
+		Reason:  "Timeout",
+		Message: fmt.Sprintf("%s timeout", what),
+	})
+	conditions.RemoveCondition("Processing")
+}

--- a/pkg/controller/common/errors.go
+++ b/pkg/controller/common/errors.go
@@ -19,6 +19,15 @@ type NonRetriableCtrlError struct {
 	customHandler ErrorHandler
 }
 
+// Timeout Error
+type TimeoutError struct {
+	err error
+}
+
+func (t TimeoutError) Error() string {
+	return t.err.Error()
+}
+
 func (cerr NonRetriableCtrlError) Error() string {
 	return cerr.err.Error()
 }
@@ -49,6 +58,13 @@ func NewNonRetriableCtrlError(errorFmt string, args ...interface{}) *NonRetriabl
 	return &NonRetriableCtrlError{
 		canRetry: false,
 		err:      fmt.Errorf(errorFmt, args...),
+	}
+}
+
+// NewTimeoutError creates an error with the RetriableCtrlError interface
+func NewTimeoutError(errorFmt string, args ...interface{}) *TimeoutError {
+	return &TimeoutError{
+		err: fmt.Errorf(errorFmt, args...),
 	}
 }
 

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -139,7 +139,6 @@ func (r *ReconcileComplianceScan) deleteAggregator(instance *compv1alpha1.Compli
 
 func isAggregatorRunning(r *ReconcileComplianceScan, scanInstance *compv1alpha1.ComplianceScan, logger logr.Logger) (bool, error) {
 	logger.Info("Checking aggregator pod for scan", "ComplianceScan.Name", scanInstance.Name)
-
 	podName := getAggregatorPodName(scanInstance.Name)
-	return isPodRunning(r, podName, common.GetComplianceOperatorNamespace(), logger)
+	return isPodRunning(r, podName, common.GetComplianceOperatorNamespace(), podTimeoutDisable, logger)
 }


### PR DESCRIPTION
The scan now has a timeout option that can be specified in the `ComplianceScanSettings `object as a duration string (e.g. 1h30m). If the scan does not finish within the specified timeout, it will either be reattempted (up to a maximum of `MaxRetryOnTimeout` times) or considered a failure, depending on the value of `MaxRetryOnTimeout`. The timeout can be disabled by setting it to 0s, and the default value is 30m. The default value for `MaxRetryOnTimeout` is 3, so the timeout scan will be retried up to three times if it fails.

To set a `Timeout` and `MaxRetryOnTimeout` in ScanSetting:

```
apiVersion: compliance.openshift.io/v1alpha1
kind: ScanSetting
metadata:
  name: default
  namespace: openshift-compliance
rawResultStorage:
  rotation: 3
  size: 1Gi
roles:
- worker
- master
scanTolerations:
- effect: NoSchedule
  key: node-role.kubernetes.io/master
  operator: Exists
schedule: '0 1 * * *'
timeout: '10m0s'
maxRetryOnTimeout: 3
```

So the idea is to check the creation timestamp of the Scanner pod age, if it is longer than timerout, we will terminate the scan or retry.

A timeout scan will send an event warning on retries, and the scan will have an error result. 