### PR TITLE
OCPBUGS-4615: Fix rendering variables in instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixes an [issue](https://issues.redhat.com/browse/OCPBUGS-4615) where
   `ComplianceCheckResult` objects do not have correct descriptions, we
   corrected the descriptions, and also added a new `rationale` field to
-  `ComplianceCheckResult` objects.
+  `ComplianceCheckResult` objects. And we fixed variable rendering in 
+  in the `instructions` field.
 
 ### Internal Changes
 

--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -614,7 +614,7 @@ func ParseRulesAndDo(contentDom *xmlquery.Node, stdParser *referenceParser, pb *
 				foundPlatformMap[platform] = true
 			}
 
-			instructions := utils.GetInstructionsForRule(ruleObj, questionsTable)
+			instructions := utils.GetInstructionsForRule(ruleObj, questionsTable, valuesList)
 			defs := utils.GetRuleOvalTest(ruleObj, defTable)
 
 			// note: stdParser is a global variable initialized in init()

--- a/pkg/utils/parse_arf_result_test.go
+++ b/pkg/utils/parse_arf_result_test.go
@@ -800,7 +800,7 @@ Server 3.fedora.pool.ntp.org`
 			})
 		})
 
-		Describe("Testing desciption and rationale rendering", func() {
+		Describe("Testing desciption rationale and instruction rendering", func() {
 			Context("Valid XCCDF", func() {
 				resultsFilename = "../../tests/data/xccdf-result-remdiation-templating.xml"
 				dsFilename = "../../tests/data/ds-input-for-remediation-value.xml"
@@ -828,6 +828,22 @@ Server 3.fedora.pool.ntp.org`
 					description, err := complianceCheckResultDescription(rule, valuesList)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(description).To(ContainSubstring("-----0-----"))
+
+				})
+
+				It("Should render correct rationale", func() {
+					rule := dsDom.SelectElement("//xccdf-1.2:Rule[@id='xccdf_org.ssgproject.content_rule_sshd_set_keepalive']")
+					rationale, err := complianceCheckResultRationale(rule, valuesList)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(rationale).To(ContainSubstring("-----0-----"))
+
+				})
+
+				It("Should render correct instruction", func() {
+					rule := dsDom.SelectElement("//xccdf-1.2:Rule[@id='xccdf_org.ssgproject.content_rule_sshd_set_keepalive']")
+					questionsTable := NewOcilQuestionTable(dsDom)
+					instruction := GetInstructionsForRule(rule, questionsTable, valuesList)
+					Expect(instruction).To(ContainSubstring("-----0-----"))
 
 				})
 			})


### PR DESCRIPTION
This is in addition to https://github.com/ComplianceAsCode/compliance-operator/pull/191.

This adds variable rendering in instructions.