### PR TITLE
OCPBUGS-6710: remediations: Normalize remediations' annotations to avoid needlesly marking remediations as Outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
--
+- On re-running scans, remediations that were previously Applied might
+  have been marked as Outdated after a re-run finished
+  despite no changes in the actual remediation content because of
+  a buggy comparison that did not take into account trivial differences
+  in remediation metadata (tracked with [OCPBUGS-6710](https://issues.redhat.com/browse/OCPBUGS-6710))
 
 ### Internal Changes
 

--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -123,6 +123,17 @@ type ComplianceRemediationPayload struct {
 	Object *unstructured.Unstructured `json:"object,omitempty"`
 }
 
+func (p *ComplianceRemediationPayload) normalized() *ComplianceRemediationPayload {
+	n := p.DeepCopy()
+	if n.Object == nil {
+		return n
+	}
+	if n.Object.GetAnnotations() == nil {
+		n.Object.SetAnnotations(map[string]string{})
+	}
+	return n
+}
+
 // ComplianceRemediationSpec defines the desired state of ComplianceRemediation
 // +k8s:openapi-gen=true
 type ComplianceRemediationSpec struct {
@@ -164,7 +175,16 @@ type ComplianceRemediation struct {
 }
 
 func (r *ComplianceRemediation) RemediationPayloadDiffers(other *ComplianceRemediation) bool {
-	return !reflect.DeepEqual(r.Spec.Current, other.Spec.Current)
+	return !reflect.DeepEqual(r.Spec.Current.normalized(), other.Spec.Current.normalized())
+}
+
+func (r *ComplianceRemediation) normalize() {
+	if r.Annotations == nil {
+		r.Annotations = make(map[string]string)
+	}
+	if r.Labels == nil {
+		r.Annotations = make(map[string]string)
+	}
 }
 
 func (r *ComplianceRemediation) GetSuite() string {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -3567,6 +3567,25 @@ func TestE2E(t *testing.T) {
 					return err
 				}
 
+				err = assertHasCheck(f, suiteName, scanName, checkResult)
+				if err != nil {
+					return err
+				}
+
+				// The remediation must not be Outdated
+				remediation := &compv1alpha1.ComplianceRemediation{}
+				remNsName := types.NamespacedName{
+					Name:      remName,
+					Namespace: namespace,
+				}
+				err = f.Client.Get(goctx.TODO(), remNsName, remediation)
+				if err != nil {
+					return fmt.Errorf("couldn't get remediation %s: %w", remName, err)
+				}
+				if remediation.Status.ApplicationState != compv1alpha1.RemediationApplied {
+					return fmt.Errorf("remediation %s is not applied, but %s", remName, remediation.Status.ApplicationState)
+				}
+
 				E2ELogf(t, "The test succeeded!")
 				return nil
 			},


### PR DESCRIPTION
Because the remediation contents we Get() from the cluster after they've
been applied contain an empty Annotations map, but the remediations we
parse from content do not, the comparison always yielded false and the
remediatins have been set to Outdated as a result.

This patch adds an empty annotations map to remediations before
comparing them, so that we compare their normalized version.

note: I have not ran the e2e test addition yet. I did test the PR manually, though.
