### PR TITLE
Update RBAC to allow remediations that set projects templates

### DIFF
--- a/config/rbac/operator_cluster_role.yaml
+++ b/config/rbac/operator_cluster_role.yaml
@@ -51,6 +51,7 @@ rules:
     resources:
       - apiservers
       - oauths
+      - projects
     resourceNames:
       - cluster
     verbs:

--- a/config/rbac/operator_cluster_role.yaml
+++ b/config/rbac/operator_cluster_role.yaml
@@ -35,6 +35,18 @@ rules:
       - watch
   # These are needed for remediating objects
   - apiGroups:
+      - template.openshift.io
+    resources:
+      - templates
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - create
+      - delete
+  - apiGroups:
       - config.openshift.io
     resources:
       - apiservers


### PR DESCRIPTION
- CO ClusterRole: Add the permissions to operate on templates.template.openshift.io
- CO ClusterRole: Add the permissions to operator on projects.config.openshift.io

I'm working on checks and remediations that set up cluster config and projects template so that
all newly created projects include a NetworkPolicy. These RBAC rules are needed in order to create the corresponding remediations.
