### PR TITLE
Fix e2e flaky issue

### DIFF
--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1362,6 +1362,11 @@ func waitForGenericRemediationToBeAutoApplied(t *testing.T, f *framework.Framewo
 			return false, nil
 		}
 		E2ELogf(t, "Found remediation: %s\n", remName)
+		if rem.Status.ApplicationState == compv1alpha1.RemediationNotApplied || rem.Status.ApplicationState == compv1alpha1.RemediationPending {
+			E2ELogf(t, "Retrying. remediation not yet applied. Remediation Name: %s, ApplicationState: %s\n", remName, rem.Status.ApplicationState)
+		}
+		// wait for the remediation to get applied
+		time.Sleep(5 * time.Second)
 		return true, nil
 	})
 	assertNoErrorNorTimeout(t, lastErr, timeouterr, "getting remediation before auto-applying it")


### PR DESCRIPTION
This PR adds a 5-second wait after we found the remediation, this helps remediation gets applied before we check MCP updates.