### PR TITLE
Minor follow-ups to code review of PR 206

### DIFF
--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -178,15 +178,6 @@ func (r *ComplianceRemediation) RemediationPayloadDiffers(other *ComplianceRemed
 	return !reflect.DeepEqual(r.Spec.Current.normalized(), other.Spec.Current.normalized())
 }
 
-func (r *ComplianceRemediation) normalize() {
-	if r.Annotations == nil {
-		r.Annotations = make(map[string]string)
-	}
-	if r.Labels == nil {
-		r.Annotations = make(map[string]string)
-	}
-}
-
 func (r *ComplianceRemediation) GetSuite() string {
 	return r.Labels[SuiteLabel]
 }


### PR DESCRIPTION
Two simple patches

- complianceremediation api: remove unused method
- tests: Improve tests to normalize compliance remediations
