### PR TITLE
cleanup: Don't return from a utility function, return an error instead

### DIFF
--- a/cmd/manager/resultcollector.go
+++ b/cmd/manager/resultcollector.go
@@ -239,7 +239,7 @@ func readResultsFile(filename string, timeout int64) (*resultFileContents, error
 	cleanFileName := filepath.Clean(filename)
 	handle, err := waitForResultsFile(cleanFileName, timeout)
 	if err != nil {
-		os.Exit(1)
+		return nil, fmt.Errorf("error waiting for results file: %w", err)
 	}
 	// #nosec
 	defer handle.Close()


### PR DESCRIPTION
Directly calling os.Exit means that we don't even log which file failed
to open which makes triaging issues harder.
