### PR TITLE
OCPBUGS-3009: Prune stale CCRs before aggregating scan results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The operator now parses links from the compliance content and renders it in
   custom resources accordingly.
+- `ComplianceCheckResult` objects are automatically cleaned up on each scan.
+  This prevents the [illusion](https://issues.redhat.com/browse/OCPBUGS-3009)
+  that changes to profiles, like excluding rules, aren't taking effect because
+  stale `ComplianceCheckResult` objects are leftover from previous runs.
 
 - The operator have the ability to hide warnings for certain failed to fetched
   resources, this is useful when the user does not want to see the warnings

--- a/config/rbac/remediation_aggregator_role.yaml
+++ b/config/rbac/remediation_aggregator_role.yaml
@@ -52,8 +52,10 @@ rules:
     verbs:
       - create
       - get
+      - list
       - update
       - patch
+      - delete
   - apiGroups:
       - compliance.openshift.io
     resources:


### PR DESCRIPTION
Previously, the compliance operator would leave CCRs around and then
just overwrite them on subsequent scans. While the most recent scan data
was accurate, because it was overwriting existing check results, it gave
the impression that some changes weren't taking effect.

For example, if you create a tailored profile, run a scan, exclude a
rule, and rerun the scan, it appears the change you just made never took
effect because the result from the rule you ignored still exists.

To avoid this, let's check for any check results at scan time and make
sure we clean them up before we aggregate the new results.
