### PR TITLE
Add Makefile target for generating unit test coverage reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -553,6 +553,11 @@ else
 	@set -o pipefail; $(GO) test $(TEST_OPTIONS) -json $(PKGS) --ginkgo.noColor | gotest2junit -v > $(JUNITFILE)
 endif
 
+.PHONY: test-coverage
+test-coverage: fmt ## Run the unit tests and generate a coverage report
+	@$(GO) test -cover -coverprofile=coverage.out $(PKGS)
+	@$(GO) tool cover -func coverage.out
+
 .PHONY: test-benchmark
 test-benchmark: ## Run the benchmark tests -- Note that this can only be ran for one package. You can set $BENCHMARK_PKG for this. cpu.prof and mem.prof will be generated
 	@$(GO) test -cpuprofile cpu.prof -memprofile mem.prof -bench . $(TEST_OPTIONS) $(BENCHMARK_PKG)

--- a/doc/contributor.md
+++ b/doc/contributor.md
@@ -37,6 +37,15 @@ can run them using:
 $ make test-unit
 ```
 
+### Coverage Tests
+
+There is a seperate target specifically for unit test coverage that outputs a
+coverage report in `coverage.out`. It also provides a coverage summary.
+
+```console
+$ make test-coverage
+```
+
 ### Functional Tests
 
 The end-to-end tests for the compliance-operator require a Kubernetes


### PR DESCRIPTION
While end-to-end coverage is important, it's good to have an idea of
what parts of the code aren't being exercised with unit tests. Good unit
tests can provide efficent coverage without expensive infrastructure or
wait times.

This commit makes it easier for developers to see test coverage by
adding an explicity target for it.
