### PR TITLE
Add support for filtering tests using a regular expression 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ TEST_DEPLOY=$(TEST_SETUP_DIR)/deploy_rbac.yaml
 
 # Pass extra flags to the e2e test run.
 # e.g. to run a specific test in the e2e test suite, do:
-# 	make e2e E2E_GO_TEST_FLAGS="-v -run TestE2E/TestScanWithNodeSelectorFiltersCorrectly"
+# 	make e2e E2E_GO_TEST_FLAGS="-v -testRegex TestScanWithNodeSelectorFiltersCorrectly"
 E2E_GO_TEST_FLAGS?=-v -test.timeout 120m
 
 # By default we run all tests; available options: all, parallel, serial
@@ -560,7 +560,7 @@ test-benchmark: ## Run the benchmark tests -- Note that this can only be ran for
 
 .PHONY: e2e
 e2e: e2e-set-image prep-e2e
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
+	CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
 
 .PHONY: prep-e2e
 prep-e2e: kustomize

--- a/tests/e2e/framework/context.go
+++ b/tests/e2e/framework/context.go
@@ -28,6 +28,7 @@ type Context struct {
 	kubeclient         kubernetes.Interface
 	restMapper         *restmapper.DeferredDiscoveryRESTMapper
 	skipCleanupOnError bool
+	testRegex          string
 }
 
 // todo(camilamacedo86): Remove the following line just added for we are able to deprecated TestCtx
@@ -73,6 +74,7 @@ func (f *Framework) newContext(t *testing.T) *Context {
 		restMapper:         f.restMapper,
 		skipCleanupOnError: f.skipCleanupOnError,
 		testType:           f.testType,
+		testRegex:          f.testRegex,
 	}
 }
 
@@ -116,4 +118,8 @@ func (ctx *Context) GetTestType() string {
 
 func (ctx *Context) AddCleanupFn(fn cleanupFn) {
 	ctx.cleanupFns = append(ctx.cleanupFns, fn)
+}
+
+func (ctx *Context) GetTestRegex() string {
+	return ctx.testRegex
 }

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -74,6 +74,7 @@ type Framework struct {
 	localOperatorArgs  string
 	kubeconfigPath     string
 	testType           string
+	testRegex          string
 	schemeMutex        sync.Mutex
 	LocalOperator      bool
 	skipCleanupOnError bool
@@ -86,6 +87,7 @@ type frameworkOpts struct {
 	namespacedManPath  string
 	localOperatorArgs  string
 	testType           string
+	testRegex          string
 	isLocalOperator    bool
 	skipCleanupOnError bool
 }
@@ -105,6 +107,7 @@ const (
 	LocalOperatorArgs      = "localOperatorArgs"
 	SkipCleanupOnErrorFlag = "skipCleanupOnError"
 	TestTypeFlag           = "testType"
+	TestRegexFlag          = "testRegex"
 
 	TestOperatorNamespaceEnv = "TEST_OPERATOR_NAMESPACE"
 	TestWatchNamespaceEnv    = "TEST_WATCH_NAMESPACE"
@@ -123,6 +126,8 @@ func (opts *frameworkOpts) addToFlagSet(flagset *flag.FlagSet) {
 			"will be skipped if an error is faced.")
 	flagset.StringVar(&opts.testType, TestTypeFlag, TestTypeAll,
 		"Defines the type of tests to run. (Options: all, serial, parallel)")
+	flagset.StringVar(&opts.testRegex, TestRegexFlag, "",
+		"A regular expression used to filter the tests that are run.")
 }
 
 func newFramework(opts *frameworkOpts) (*Framework, error) {
@@ -174,6 +179,7 @@ func newFramework(opts *frameworkOpts) (*Framework, error) {
 		restMapper:         restMapper,
 		skipCleanupOnError: opts.skipCleanupOnError,
 		testType:           opts.testType,
+		testRegex:          opts.testRegex,
 	}
 	return framework, nil
 }

--- a/tests/e2e/framework/main_entry.go
+++ b/tests/e2e/framework/main_entry.go
@@ -19,8 +19,10 @@ func MainEntry(m *testing.M) {
 	if kcFlag == nil {
 		flag.StringVar(&fopts.kubeconfigPath, KubeConfigFlag, "", "path to kubeconfig")
 	}
+	testFlag := flag.Lookup(TestRegexFlag)
 
 	flag.Parse()
+	fopts.testRegex = testFlag.Value.String()
 
 	if kcFlag != nil {
 		fopts.kubeconfigPath = kcFlag.Value.String()


### PR DESCRIPTION
Golang supports filtering tests using a -run flag, which can be a
regular expression. The e2e tests don't honor this flag since we're
building the tests in a particular way so we can run parallel tests
(e.g., non-destructive) tests before running the serial tests, which
test remediations and other actions that affect the state of the
cluster, potentially affecting other tests.

To make things more egonomic for contributors, it would be nice to run a
single test so you don't have to wait for the entire suite to execute.

This commit adds a framework flag that introduces a new command line
argument called `-testRegex` and filters e2e tests using the flag as if
it were a regular expression.

Fixes https://github.com/ComplianceAsCode/compliance-operator/issues/226
