### PR TITLE
Add skeleton for functional tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ tags
 # Generated files for E2E test setup
 tests/_setup
 tests/e2e-test.log
+tests/functional-parallel-test.log
+tests/functional-serial-test.log

--- a/Makefile
+++ b/Makefile
@@ -574,6 +574,14 @@ prep-e2e: kustomize
 	$(KUSTOMIZE) build config/no-ns | sed -e 's%$(DEFAULT_OPERATOR_IMAGE)%$(OPERATOR_IMAGE)%' -e 's%$(DEFAULT_CONTENT_IMAGE)%$(E2E_CONTENT_IMAGE_PATH)%' -e 's%$(DEFAULT_OPENSCAP_IMAGE)%$(OPENSCAP_IMAGE)%'  > $(TEST_DEPLOY)
 	$(KUSTOMIZE) build config/crd > $(TEST_CRD)
 
+.PHONY: functional-parallel
+functional-parallel: ## Installs the operator on a cluster and runs all non-destructive functional tests concurrently.
+	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/functional/parallel/main_test.go $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/functional-parallel-test.log
+
+.PHONY: functional-serial
+functional-serial: ## Installs the operator on a cluster and runs all serial tests.
+	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/functional/serial/main_test.go $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/functional-serial-test.log
+
 ifdef IMAGE_FROM_CI
 e2e-set-image: kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image $(APP_NAME)=$(IMAGE_FROM_CI)

--- a/tests/common/common.go
+++ b/tests/common/common.go
@@ -1,0 +1,15 @@
+package common
+
+import "github.com/ComplianceAsCode/compliance-operator/tests/e2e/framework"
+
+func SetUp(f *framework.Framework) error {
+	return nil
+}
+
+// TearDown runs after all tests complete and provides an opportunity to cleanup anything
+// created or configured in Setup. This function is invoked per run and not after individual
+// tests. Tests should explicitly add functions to t.Cleanup if they create resources that
+// need to be cleaned up after that specific test completes.
+func TearDown(f *framework.Framework) error {
+	return nil
+}

--- a/tests/e2e/framework/main_entry.go
+++ b/tests/e2e/framework/main_entry.go
@@ -7,7 +7,8 @@ import (
 	"testing"
 )
 
-func MainEntry(m *testing.M) {
+// setUp is an adapter for MainEntry and NewFramework to share similar code.
+func setUp() *Framework {
 	fopts := &frameworkOpts{}
 	fopts.addToFlagSet(flag.CommandLine)
 	// controller-runtime registers the --kubeconfig flag in client config
@@ -30,7 +31,15 @@ func MainEntry(m *testing.M) {
 	if err != nil {
 		log.Fatalf("Failed to create framework: %v", err)
 	}
+	return f
+}
 
+// MainEntry sets up a Framework, which contains clients for the tests to share when
+// interacting with the cluster. The Framework is exposed as a global variable called Global.
+// MainEntry does effectively the same thing as NewFramework without returning the actual
+// Framework reference.
+func MainEntry(m *testing.M) {
+	f := setUp()
 	Global = f
 
 	exitCode, err := f.runM(m)
@@ -38,4 +47,11 @@ func MainEntry(m *testing.M) {
 		log.Fatal(err)
 	}
 	os.Exit(exitCode)
+}
+
+// NewFramework sets up and returns a Framework, which contains clients for the tests to share when
+// interacting with a cluster. This method is meant to supersede MainEntry so we don't have to rely
+// on a global variable for sharing the Framework between tests or test code.
+func NewFramework() *Framework {
+	return setUp()
 }

--- a/tests/functional/parallel/main_test.go
+++ b/tests/functional/parallel/main_test.go
@@ -1,0 +1,30 @@
+package parallel
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ComplianceAsCode/compliance-operator/tests/common"
+	"github.com/ComplianceAsCode/compliance-operator/tests/e2e/framework"
+)
+
+// TestMain sets up, runs, and cleans up all tests that are safe to run concurrently.
+func TestMain(m *testing.M) {
+
+	f := framework.NewFramework()
+
+	// Setup shared resources to use when testing, like installing the Compliance Operator
+	common.SetUp(f)
+
+	c := m.Run()
+
+	// Last chance to clean up anything from the test run. This function is ideal for
+	// cleaning up things created or configured in SetUp(). Tests that create resources
+	// should clean up those resources using t.Cleanup() instead of deferring cleanup or
+	// using common.TearDown() so that resources are isolated to the test that created them.
+	common.TearDown(f)
+
+	os.Exit(c)
+}
+
+func TestProfileModification(t *testing.T) {}

--- a/tests/functional/serial/main_test.go
+++ b/tests/functional/serial/main_test.go
@@ -1,0 +1,31 @@
+package serial
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ComplianceAsCode/compliance-operator/tests/common"
+	"github.com/ComplianceAsCode/compliance-operator/tests/e2e/framework"
+)
+
+// TestMain sets up, runs, and cleans up all serial tests, which must run
+// serially so they don't interfere with each other.
+func TestMain(m *testing.M) {
+
+	f := framework.NewFramework()
+
+	// Setup shared resources to use when testing, like installing the Compliance Operator
+	common.SetUp(f)
+
+	c := m.Run()
+
+	// Last chance to clean up anything from the test run. This function is ideal for
+	// cleaning up things created or configured in SetUp(). Tests that create resources
+	// should clean up those resources using t.Cleanup() instead of deferring cleanup or
+	// using common.TearDown() so that resources are isolated to the test that created them.
+	common.TearDown(f)
+
+	os.Exit(c)
+}
+
+func TestSuiteScan(t *testing.T) {}


### PR DESCRIPTION
The current E2E tests run serial and parallel tests in the same suite
using a single test orchestrator. This orchestrator addes some
complexity around how the tests are invoked because order is important.

This commit introduces a new functional test skeleton that will
supersede the e2e tests by breaking them into two separate test suites.
One for parallel and one for serial tests. This will allow us to lean
on native features of go like t.cleanup and testing.M to do setup and
teardown, and use native test discovery in golang without having to
reimplement it for our test orchestrator.
