### PR TITLE
Modify API Resource Collector to Convert YAML to JSON Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   a special Dockerfile for the bundle image so that the bundle image can
   point to the correct images.
 
+- Modify API resource collector to detect if fetched resource is yaml string and
+  convert it to json when found, this is necessary because some of the API resources
+  are not available in json format, and we need to convert it to json format so that
+  it can be read by OpenSCAP.
+
 ### Deprecations
 
 -

--- a/tests/data/configmap_json.json
+++ b/tests/data/configmap_json.json
@@ -1,0 +1,14 @@
+{
+    "apiVersion": "v1",
+    "data": {
+        "config.yaml": "{\"apiServerArguments\":{\"audit-log-format\":[\"json\"],\"audit-log-maxbackup\":[\"10\"],\"audit-log-maxsize\":[\"100\"],\"audit-log-path\":[\"/var/log/openshift-apiserver/audit.log\"],\"audit-policy-file\":[\"/var/run/configmaps/audit/policy.yaml\"],\"shutdown-delay-duration\":[\"15s\"],\"shutdown-send-retry-after\":[\"true\"]},\"apiVersion\":\"openshiftcontrolplane.config.openshift.io/v1\",\"imagePolicyConfig\":{\"internalRegistryHostname\":\"image-registry.openshift-image-registry.svc:5000\"},\"kind\":\"OpenShiftAPIServerConfig\",\"projectConfig\":{\"projectRequestMessage\":\"\"},\"routingConfig\":{\"subdomain\":\"apps.ci-ln-xllhdgb-76ef8.origin-ci-int-aws.dev.rhcloud.com\"},\"servingInfo\":{\"bindNetwork\":\"tcp\",\"cipherSuites\":[\"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\",\"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\",\"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\",\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\",\"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256\",\"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\"],\"minTLSVersion\":\"VersionTLS12\"},\"storageConfig\":{\"urls\":[\"https://10.0.137.27:2379\",\"https://10.0.158.132:2379\",\"https://10.0.204.8:2379\"]}}"
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+        "creationTimestamp": "2023-02-28T05:44:46Z",
+        "name": "config",
+        "namespace": "openshift-apiserver",
+        "resourceVersion": "20949",
+        "uid": "50c1c8ce-5ae3-465d-b60c-47ef2208f665"
+    }
+}

--- a/tests/data/configmap_yaml.json
+++ b/tests/data/configmap_yaml.json
@@ -1,0 +1,53 @@
+{
+    "kind":"ConfigMap",
+    "apiVersion":"v1",
+    "metadata":{
+       "name":"openshift-apiserver",
+       "namespace":"clusters-wenshen-hypershift",
+       "uid":"5ec57109-8d0d-46a0-8c6e-b711afa03dec",
+       "resourceVersion":"158040",
+       "creationTimestamp":"2023-02-27T21:49:46Z",
+       "ownerReferences":[
+          {
+             "apiVersion":"hypershift.openshift.io/v1beta1",
+             "kind":"HostedControlPlane",
+             "name":"wenshen-hypershift",
+             "uid":"50a4550a-e450-4546-a7b4-254011fc5dfe",
+             "controller":true,
+             "blockOwnerDeletion":true
+          }
+       ],
+       "managedFields":[
+          {
+             "manager":"hypershift-controlplane-manager",
+             "operation":"Update",
+             "apiVersion":"v1",
+             "time":"2023-02-27T21:49:46Z",
+             "fieldsType":"FieldsV1",
+             "fieldsV1":{
+                "f:data":{
+                   ".":{
+                      
+                   },
+                   "f:config.yaml":{
+                      
+                   }
+                },
+                "f:metadata":{
+                   "f:ownerReferences":{
+                      ".":{
+                         
+                      },
+                      "k:{\"uid\":\"50a4550a-e450-4546-a7b4-254011fc5dfe\"}":{
+                         
+                      }
+                   }
+                }
+             }
+          }
+       ]
+    },
+    "data":{
+       "config.yaml":"admission: {}\naggregatorConfig:\n  allowedNames: null\n  clientCA: \"\"\n  extraHeaderPrefixes: null\n  groupHeaders: null\n  usernameHeaders: null\napiServerArguments:\n  audit-log-format:\n  - json\n  audit-log-maxsize:\n  - \"100\"\n  audit-log-path:\n  - /var/log/openshift-apiserver/audit.log\n  audit-policy-file:\n  - /etc/kubernetes/audit-config/policy.yaml\n  shutdown-delay-duration:\n  - 3s\napiVersion: openshiftcontrolplane.config.openshift.io/v1\nauditConfig:\n  auditFilePath: \"\"\n  enabled: false\n  logFormat: \"\"\n  maximumFileRetentionDays: 0\n  maximumFileSizeMegabytes: 0\n  maximumRetainedFiles: 0\n  policyConfiguration: null\n  policyFile: \"\"\n  webHookKubeConfig: \"\"\n  webHookMode: \"\"\ncloudProviderFile: \"\"\ncorsAllowedOrigins: null\nimagePolicyConfig:\n  additionalTrustedCA: \"\"\n  allowedRegistriesForImport: null\n  externalRegistryHostnames: null\n  internalRegistryHostname: image-registry.openshift-image-registry.svc:5000\n  maxImagesBulkImportedPerRepository: 0\njenkinsPipelineConfig:\n  autoProvisionEnabled: null\n  parameters: null\n  serviceName: \"\"\n  templateName: \"\"\n  templateNamespace: \"\"\nkind: OpenShiftAPIServerConfig\nkubeClientConfig:\n  connectionOverrides:\n    acceptContentTypes: \"\"\n    burst: 0\n    contentType: \"\"\n    qps: 0\n  kubeConfig: /etc/kubernetes/secrets/svc-kubeconfig/kubeconfig\nprojectConfig:\n  defaultNodeSelector: \"\"\n  projectRequestMessage: \"\"\n  projectRequestTemplate: \"\"\nroutingConfig:\n  subdomain: apps.wenshen-hypershift.devcluster.openshift.com\nserviceAccountOAuthGrantMethod: \"\"\nservingInfo:\n  bindAddress: \"\"\n  bindNetwork: \"\"\n  certFile: /etc/kubernetes/certs/serving/tls.crt\n  cipherSuites:\n  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\n  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\n  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\n  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\n  - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256\n  - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\n  clientCA: /etc/kubernetes/certs/client-ca/ca.crt\n  keyFile: /etc/kubernetes/certs/serving/tls.key\n  maxRequestsInFlight: 0\n  minTLSVersion: VersionTLS12\n  requestTimeoutSeconds: 0\nstorageConfig:\n  ca: /etc/kubernetes/certs/etcd-client-ca/ca.crt\n  certFile: /etc/kubernetes/certs/etcd-client/etcd-client.crt\n  keyFile: /etc/kubernetes/certs/etcd-client/etcd-client.key\n  storagePrefix: \"\"\n  urls:\n  - https://etcd-client:2379\n"
+    }
+ }


### PR DESCRIPTION
Modify API resource collector to detect and convert fetched resources to json format when they are returned in yaml format. This is required because some API resources are not available in json format and need to be converted to json format for reading by OpenSCAP.

example rules:
```
applications/openshift/api-server/ocp_api_server_audit_log_maxsize
applications/openshift/api-server/ocp_api_server_audit_log_maxbackup
```