### PR TITLE
renovate: Open PRs on weekends only, set labels

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
   "extends": [
     "config:base"
+  ],
+  "labels": ["ok-to-test","px-approved","docs-approved","qe-approved"],
+  "schedule": [
+      "every weekend"
   ]
 }


### PR DESCRIPTION
There has been a lot of dependency churn lately which is congesting CI,
costing money and making it hard to follow all PRs. Let's update
dependencies weekly only.

In addition, let's set the labels that allow CI to be run automatically
and ensure that the `{px,docs,qe}-approved` labels are set on the PRs so
that we don't have to do that ourselves.
