### PR TITLE
Add makefile targets to run serials and parallel e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -567,6 +567,14 @@ test-benchmark: ## Run the benchmark tests -- Note that this can only be ran for
 e2e: e2e-set-image prep-e2e ## Run full end-to-end tests that exercise content on an operational cluster.
 	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
 
+.PHONY: e2e-parallel
+e2e-parallel: ## Run non-destructive end-to-end tests concurrently.
+	E2E_GO_TEST_FLAGS=parallel $(MAKE) e2e
+
+.PHONY: e2e-serial
+e2e-serial: ## Run destructive end-to-end tests serially.
+	E2E_GO_TEST_FLAGS=serial $(MAKE) e2e
+
 .PHONY: prep-e2e
 prep-e2e: kustomize
 	rm -rf $(TEST_SETUP_DIR)


### PR DESCRIPTION
The e2e test framework keeps track of tests that are safe to run
concurrently and which must be run serially.

For example, tests that focus on scanning and don't interfere with each
other are safe to run in parallel. Tests that apply remediations to the
cluster impact other tests that assert specific checks or outcomes from
a scan.

We typically lump all these tests into a single run using `make e2e` and
ensure the concurrent tests are run first, followed by the serial tests.

By adding separate makefile targets, we're making it easier for
contributors to run a group of tests, instead of the whole suite,
shortening the feedback loop. We can also use this in CI and create
separate jobs, running parallel tests and serial tests on different
clusters, speeding up CI reporting time. It's also easier to see, at a
glance, if a particular set of tests is failing consistently.

This change also adds a layer of abstraction between contributors and
the internal details of the tests, giving us more flexibility to evolve
the tests and reorganize them as we see fit without as much disruption
to contributors.
