### PR TITLE
Replace ioutils with io and os modules

### DIFF
--- a/cmd/manager/resultcollector.go
+++ b/cmd/manager/resultcollector.go
@@ -25,7 +25,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -283,7 +282,7 @@ func readWarningsFile(filename string) string {
 	if filename == "" {
 		return ""
 	}
-	contents, err := ioutil.ReadFile(filepath.Clean(filename))
+	contents, err := os.ReadFile(filepath.Clean(filename))
 	if os.IsNotExist(err) {
 		// warnings file provided, but no warnings were generated
 		return ""
@@ -433,7 +432,7 @@ func getOscapExitCode(scapresultsconf *scapresultsConfig) string {
 	}
 	defer exitcodeContent.close()
 
-	exitcode, _ := ioutil.ReadAll(exitcodeContent.contents)
+	exitcode, _ := io.ReadAll(exitcodeContent.contents)
 	return strings.Trim(string(exitcode), "\n")
 }
 
@@ -442,7 +441,7 @@ func getMutualHttpsTransport(c *scapresultsConfig) (*http.Transport, error) {
 	if err != nil {
 		return nil, err
 	}
-	ca, err := ioutil.ReadFile(c.CA)
+	ca, err := os.ReadFile(c.CA)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/manager/resultcollector_test.go
+++ b/cmd/manager/resultcollector_test.go
@@ -1,7 +1,6 @@
 package manager
 
 import (
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -13,11 +12,11 @@ var _ = Describe("Resultcollector", func() {
 	Context("Testing result file is waited for", func() {
 		var fileName string
 		writeResult := func(fName string) {
-			err := ioutil.WriteFile(fName, []byte("1"), 0644)
+			err := os.WriteFile(fName, []byte("1"), 0644)
 			Expect(err).To(BeNil())
 		}
 		BeforeEach(func() {
-			f, err := ioutil.TempFile("", "result")
+			f, err := os.CreateTemp("", "result")
 			defer f.Close()
 			Expect(err).To(BeNil())
 			fileName = f.Name()

--- a/cmd/manager/resultserver.go
+++ b/cmd/manager/resultserver.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509"
 	"flag"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
@@ -172,7 +171,7 @@ func server(c *resultServerConfig) {
 
 	rotateResultDirectories(c.BasePath, c.Rotation)
 
-	caCert, err := ioutil.ReadFile(c.CA)
+	caCert, err := os.ReadFile(c.CA)
 	if err != nil {
 		cmdLog.Error(err, "Error reading CA file")
 		os.Exit(1)

--- a/cmd/manager/resultserver_test.go
+++ b/cmd/manager/resultserver_test.go
@@ -16,7 +16,7 @@ limitations under the License.
 package manager
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"time"
@@ -41,7 +41,7 @@ var _ = Describe("Resultserver testing", func() {
 
 		BeforeEach(func() {
 			var err error
-			rootDir, err = ioutil.TempDir("", "rotate-root")
+			rootDir, err = os.MkdirTemp("", "rotate-root")
 			Expect(err).To(BeNil())
 
 			// Ensure lost+found
@@ -49,23 +49,23 @@ var _ = Describe("Resultserver testing", func() {
 			os.Mkdir(lostFoundDir, 0644)
 
 			// Create temporary directories which represent what will be rotated
-			dir1, err = ioutil.TempDir(rootDir, "rotate-1")
+			dir1, err = os.MkdirTemp(rootDir, "rotate-1")
 			Expect(err).To(BeNil())
-			ioutil.TempFile(dir1, "foo")
-			fileToBeRead, err := ioutil.TempFile(dir1, "bar")
+			os.CreateTemp(dir1, "foo")
+			fileToBeRead, err := os.CreateTemp(dir1, "bar")
 			Expect(err).To(BeNil())
-			ioutil.TempFile(dir1, "baz")
+			os.CreateTemp(dir1, "baz")
 
 			// Ensure next directory will have significant time difference
 			time.Sleep(100 * time.Millisecond)
-			dir2, err = ioutil.TempDir(rootDir, "rotate-2")
+			dir2, err = os.MkdirTemp(rootDir, "rotate-2")
 			Expect(err).To(BeNil())
-			ioutil.TempFile(dir2, "foo")
-			ioutil.TempFile(dir2, "bar")
+			os.CreateTemp(dir2, "foo")
+			os.CreateTemp(dir2, "bar")
 
 			// Ensure next directory will have significant time difference
 			time.Sleep(100 * time.Millisecond)
-			dir3, err = ioutil.TempDir(rootDir, "rotate-3")
+			dir3, err = os.MkdirTemp(rootDir, "rotate-3")
 			Expect(err).To(BeNil())
 
 			// chmod the dirs in reverse order to make sure we are really relying on
@@ -81,7 +81,7 @@ var _ = Describe("Resultserver testing", func() {
 			Expect(err).To(BeNil())
 
 			// Read a file to ensure that hierarchy doesn't change
-			_, err = ioutil.ReadAll(fileToBeRead)
+			_, err = io.ReadAll(fileToBeRead)
 			Expect(err).To(BeNil())
 		})
 

--- a/cmd/manager/scap.go
+++ b/cmd/manager/scap.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"html"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -563,7 +562,7 @@ func fetch(ctx context.Context, streamDispatcher streamerDispatcherFn, rfClients
 				return fmt.Errorf("streaming URIs failed: %w", err)
 			}
 			defer stream.Close()
-			body, err := ioutil.ReadAll(stream)
+			body, err := io.ReadAll(stream)
 			if err != nil {
 				return err
 			}
@@ -672,7 +671,7 @@ func (c *scapContentDataStream) SaveWarningsIfAny(warnings []string, outputFile 
 	}
 	DBG("Persisting warnings to output file")
 	warningsStr := strings.Join(warnings, "\n")
-	err := ioutil.WriteFile(outputFile, []byte(warningsStr), 0600)
+	err := os.WriteFile(outputFile, []byte(warningsStr), 0600)
 	return err
 }
 
@@ -692,7 +691,7 @@ func saveResources(rootDir string, data map[string][]byte) error {
 		if err != nil {
 			return err
 		}
-		err = ioutil.WriteFile(savePath, fileContents, 0600)
+		err = os.WriteFile(savePath, fileContents, 0600)
 		if err != nil {
 			return err
 		}

--- a/cmd/manager/scap_test.go
+++ b/cmd/manager/scap_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/ComplianceAsCode/compliance-operator/pkg/controller/common"
@@ -217,7 +216,7 @@ var _ = Describe("Testing filtering", func() {
 			nsFile, err := os.Open("../../tests/data/namespaces.json")
 			Expect(err).To(BeNil())
 			var readErr error
-			rawns, readErr = ioutil.ReadAll(nsFile)
+			rawns, readErr = io.ReadAll(nsFile)
 			Expect(readErr).To(BeNil())
 		})
 		It("filters namespaces appropriately", func() {
@@ -243,7 +242,7 @@ var _ = Describe("Testing filtering", func() {
 				nsFile, err := os.Open("../../tests/data/namespaces.json")
 				Expect(err).To(BeNil())
 				var readErr error
-				rawns, readErr = ioutil.ReadAll(nsFile)
+				rawns, readErr = io.ReadAll(nsFile)
 				Expect(readErr).To(BeNil())
 			})
 

--- a/pkg/controller/common/constants.go
+++ b/pkg/controller/common/constants.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -45,7 +44,7 @@ func init() {
 			}
 		}
 	} else {
-		nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 		if err != nil {
 			return
 		}

--- a/pkg/utils/resultconfigmap.go
+++ b/pkg/utils/resultconfigmap.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +24,7 @@ func encodetoBase64(src io.Reader) string {
 			pw.Close()
 		}
 	}()
-	out, _ := ioutil.ReadAll(pr)
+	out, _ := io.ReadAll(pr)
 	return string(out)
 }
 
@@ -39,7 +38,7 @@ func GetResultConfigMap(owner metav1.Object, configMapName, filename, nodeName s
 		}
 		strcontents = encodetoBase64(contents)
 	} else {
-		contentBytes, _ := ioutil.ReadAll(contents)
+		contentBytes, _ := io.ReadAll(contents)
 		strcontents = string(contentBytes)
 	}
 	if nodeName != "" {

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -5,7 +5,6 @@ import (
 	goctx "context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -238,7 +237,7 @@ func (f *Framework) runM(m *testing.M) (int, error) {
 	}
 
 	// create crd
-	globalYAML, err := ioutil.ReadFile(f.globalManPath)
+	globalYAML, err := os.ReadFile(f.globalManPath)
 	if err != nil {
 		return 0, fmt.Errorf("failed to read global resource manifest: %w", err)
 	}

--- a/tests/e2e/framework/projutil.go
+++ b/tests/e2e/framework/projutil.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -214,7 +213,7 @@ func GetGoPkg() string {
 	if _, err := os.Stat(goModFile); err != nil && !os.IsNotExist(err) {
 		log.Fatalf("Failed to read go.mod: %v", err)
 	} else if err == nil {
-		b, err := ioutil.ReadFile(goModFile)
+		b, err := os.ReadFile(goModFile)
 		if err != nil {
 			log.Fatalf("Read go.mod: %v", err)
 		}

--- a/tests/e2e/framework/resource.go
+++ b/tests/e2e/framework/resource.go
@@ -6,7 +6,6 @@ import (
 	goctx "context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -211,7 +210,7 @@ func (ctx *Context) createFromYAML(yamlFile []byte, skipIfExists bool, cleanupOp
 
 func (ctx *Context) InitializeClusterResources(cleanupOptions *CleanupOptions) error {
 	// create namespaced resources
-	namespacedYAML, err := ioutil.ReadFile(ctx.namespacedManPath)
+	namespacedYAML, err := os.ReadFile(ctx.namespacedManPath)
 	if err != nil {
 		return fmt.Errorf("failed to read namespaced manifest: %w", err)
 	}

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -481,7 +480,7 @@ func replaceNamespaceFromManifest(t *testing.T, namespace string, namespacedManP
 	}
 	manPath := *namespacedManPath
 	// #nosec
-	read, err := ioutil.ReadFile(manPath)
+	read, err := os.ReadFile(manPath)
 	if err != nil {
 		t.Fatalf("Error reading namespaced manifest file: %s", err)
 	}
@@ -489,7 +488,7 @@ func replaceNamespaceFromManifest(t *testing.T, namespace string, namespacedManP
 	newContents := strings.Replace(string(read), "openshift-compliance", namespace, -1)
 
 	// #nosec
-	err = ioutil.WriteFile(manPath, []byte(newContents), 644)
+	err = os.WriteFile(manPath, []byte(newContents), 644)
 	if err != nil {
 		t.Fatalf("Error writing namespaced manifest file: %s", err)
 	}


### PR DESCRIPTION
The ioutils module was deprecated in 1.19 and its functionality
replaced with io and os modules.

  https://pkg.go.dev/io/ioutil

Let's use those instead.
