### PR TITLE
Add cleanup logging after tests run

### DIFF
--- a/tests/e2e/framework/context.go
+++ b/tests/e2e/framework/context.go
@@ -1,6 +1,8 @@
 package framework
 
 import (
+	goctx "context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -9,6 +11,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 )
 
 type Context struct {
@@ -108,6 +113,12 @@ func (ctx *Context) Cleanup() {
 	if ctx.t == nil && failed {
 		log.Fatal("A cleanup function failed")
 	}
+
+	var scans compv1alpha1.ComplianceScanList
+	listOpts := client.ListOptions{}
+	ctx.client.List(goctx.TODO(), &scans, &listOpts)
+	log.Warning(fmt.Sprintf("%d scans not cleaned up", len(scans.Items)))
+
 }
 
 func (ctx *Context) GetTestType() string {


### PR DESCRIPTION
We've noticed that some of the tests aren't cleaning up the way we
expect. Specifically, some of the compliance scans are still laying
around even when we exit the context Cleanup() function, which is
designed to execute a bunch of callbacks to cleanup test resources.

This probably isn't much of a problem in CI since the cluster gets torn
down after the tests run, but it impacts contributor's ability to re-use
the same environment for multiple e2e runs. Ideally, we want to run a
single test in isolation and have it cleanup after itself so we can
continue using the same environment.

This commit adds basic logging in Cleanup() that logs how many scans are
left over before we tear down the environment.
