### PR TITLE
Refactor e2e test cleanup

### DIFF
--- a/tests/e2e/framework/client.go
+++ b/tests/e2e/framework/client.go
@@ -85,6 +85,14 @@ func (f *frameworkClient) Create(gCtx goctx.Context, obj dynclient.Object, clean
 	return nil
 }
 
+func (f *frameworkClient) CreateWithoutCleanup(gCtx goctx.Context, obj dynclient.Object) error {
+	err := f.Client.Create(gCtx, obj)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (f *frameworkClient) Get(gCtx goctx.Context, key dynclient.ObjectKey, obj dynclient.Object) error {
 	return f.Client.Get(gCtx, key, obj)
 }

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -1,0 +1,97 @@
+package framework
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+// readFile accepts a file path and returns the file contents.
+func (f *Framework) readFile(p *string) ([]byte, error) {
+	y, err := os.ReadFile(*p)
+	if err != nil {
+		log.Printf("unable to read contents of %s: %s", *p, err)
+		return nil, err
+	}
+	return y, nil
+}
+
+// readYAML accepts a byte string that is YAML-like and attempts to read
+// it into a slice of byte strings where each element in the slice is a
+// separate YAML document delimited by "---". This is useful for working
+// with files that contain multiple YAML documents.
+func (f *Framework) readYAML(y []byte) ([][]byte, error) {
+	o := make([][]byte, 0)
+
+	s := NewYAMLScanner(bytes.NewBuffer(y))
+	for s.Scan() {
+		// Grab the current YAML document
+		d := s.Bytes()
+
+		// Convert to JSON and attempt to decode it
+		obj := &unstructured.Unstructured{}
+		j, err := yaml.YAMLToJSON(d)
+		if err != nil {
+			return nil, fmt.Errorf("could not convert yaml document to json: %w", err)
+		}
+		if err := obj.UnmarshalJSON(j); err != nil {
+			return nil, fmt.Errorf("failed to decode object spec: %w", err)
+		}
+		o = append(o, j)
+	}
+	return o, nil
+}
+
+func (f *Framework) cleanUpFromYAMLFile(p *string) error {
+	c, err := f.readFile(p)
+	if err != nil {
+		return err
+	}
+	documents, err := f.readYAML(c)
+	if err != nil {
+		return err
+	}
+
+	for _, d := range documents {
+		obj := &unstructured.Unstructured{}
+		if err := obj.UnmarshalJSON(d); err != nil {
+			return fmt.Errorf("failed to unmarshal object spec: %w", err)
+		}
+		obj.SetNamespace(f.OperatorNamespace)
+		log.Printf("deleting %s %s", obj.GetKind(), obj.GetName())
+		if err := f.Client.Delete(context.TODO(), obj); err != nil {
+			return fmt.Errorf("failed to delete %s: %w", obj, err)
+		}
+	}
+	return nil
+}
+
+func (f *Framework) waitForScanCleanup() error {
+	timeouterr := wait.Poll(time.Second*5, time.Minute*2, func() (bool, error) {
+		var scans compv1alpha1.ComplianceScanList
+		f.Client.List(context.TODO(), &scans, &client.ListOptions{})
+		if len(scans.Items) == 0 {
+			return true, nil
+		}
+		log.Printf("%d scans not cleaned up\n", len(scans.Items))
+		for _, i := range scans.Items {
+			log.Printf("scan %s still exists in namespace %s", i.Name, i.Namespace)
+		}
+		return false, nil
+	})
+
+	if timeouterr != nil {
+		return fmt.Errorf("timed out waiting for scans to cleanup: %w", timeouterr)
+
+	}
+	return nil
+}

--- a/tests/e2e/framework/context.go
+++ b/tests/e2e/framework/context.go
@@ -1,19 +1,13 @@
 package framework
 
 import (
-	goctx "context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 )
 
 type Context struct {
@@ -50,14 +44,13 @@ type CleanupOptions struct {
 type cleanupFn func() error
 
 func (f *Framework) newContext(t *testing.T) *Context {
-
 	// Context is used among others for namespace names where '/' is forbidden and must be 63 characters or less
-	id := "osdk-e2e-" + uuid.New()
+	id := f.OperatorNamespace
 
-	var operatorNamespace string
-	_, ok := os.LookupEnv(TestOperatorNamespaceEnv)
+	operatorNamespace := f.OperatorNamespace
+	val, ok := os.LookupEnv(TestOperatorNamespaceEnv)
 	if ok {
-		operatorNamespace = f.OperatorNamespace
+		operatorNamespace = val
 	}
 
 	watchNamespace := operatorNamespace
@@ -113,11 +106,6 @@ func (ctx *Context) Cleanup() {
 	if ctx.t == nil && failed {
 		log.Fatal("A cleanup function failed")
 	}
-
-	var scans compv1alpha1.ComplianceScanList
-	listOpts := client.ListOptions{}
-	ctx.client.List(goctx.TODO(), &scans, &listOpts)
-	log.Warning(fmt.Sprintf("%d scans not cleaned up", len(scans.Items)))
 
 }
 

--- a/tests/e2e/framework/main_entry.go
+++ b/tests/e2e/framework/main_entry.go
@@ -1,10 +1,14 @@
 package framework
 
 import (
+	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func MainEntry(m *testing.M) {
@@ -33,9 +37,71 @@ func MainEntry(m *testing.M) {
 
 	Global = f
 
+	// Do suite setup
+	if err := f.setUp(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Run the tests
 	exitCode, err := f.runM(m)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Do suite teardown only if we have a successful test run or if we don't care
+	// about removing the test resources if the test failed.
+	if exitCode == 0 || (exitCode > 0 && !f.skipCleanupOnError) {
+		if err = f.tearDown(); err != nil {
+			log.Fatal(err)
+		}
+	}
 	os.Exit(exitCode)
+}
+
+func (f *Framework) setUp() error {
+	return nil
+}
+
+// tearDown performs any tasks necessary to cleanup resources leftover from testing
+// and assumes a specific order. All namespaced resources must be cleaned up before
+// deleting the cluster-wide resources, like roles, service accounts, or the deployment.
+// If we don't properly cleanup resources before deleting CRDs, it leaves resources in a
+// terminating state, making them harder to cleanup.
+func (f *Framework) tearDown() error {
+	// Make sure all scans are cleaned up before we delete the CRDs. Scans should be cleaned up
+	// because they're owned by ScanSettingBindings or ScanSuites, which should be cleaned up
+	// by each individual test either directly or through deferred cleanup. If the test fail
+	// because there are scans that haven't been cleaned up, we could have a bug in the
+	// tests.
+	err := f.waitForScanCleanup()
+	if err != nil {
+		return err
+	}
+
+	// Clean up these resources explicitly in this method because it's guaranteed to run
+	// after all the tests execute. It's also safer to clean up resources that require
+	// a specific cleanup order explicitly than to rely on Go's defer function. Defer
+	// is implemented as a stack, and doesn't guarantee safety across go routines
+	// (which may be the case with parallel tests), making it possible for some
+	// resources to get cleaned up before others. We don't want that to happen with
+	// cluster resources like CRDs, because it will orphan custom resource instances
+	//that haven't been cleaned up, yet.
+	log.Printf("cleaning up namespaced resources in %s\n", f.OperatorNamespace)
+	err = f.cleanUpFromYAMLFile(f.NamespacedManPath)
+	if err != nil {
+		return err
+	}
+
+	log.Println("cleaning up cluster resources")
+	err = f.cleanUpFromYAMLFile(&f.globalManPath)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("cleaning up namespace %s\n", f.OperatorNamespace)
+	err = f.KubeClient.CoreV1().Namespaces().Delete(context.TODO(), f.OperatorNamespace, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to cleanup namespace %s: %w", f.OperatorNamespace, err)
+	}
+	return nil
 }


### PR DESCRIPTION
The e2e tests use a nested test structure, where TestE2E is the
grandparent test, TestE2E/Serial_tests and TestE2E/Parallel_tests are
the parent tests, and each test case is technically a grandchild of
TestE2E.

We use this structure so that TestE2E can actually setup shared
resources for the test (like deploying and configuring the operator).

All the setup functionality used the same .Create() method available
through the test framework client, which automatically defers cleanup of
those resources by executing the deferred calls in a FILO order (stack).

However, as we've seen in various test runs, it's possible for CRDs to
get cleaned up before all resources have been deleted. This orphans the
resources, making them harder to cleanup, leaving the operator resources
and it's namespace in a terminating state.

While this probably isn't a huge deal for CI, which throws away the
environment after tesing, it's problematic when you're developing e2e
tests locally and re-using the same cluster.

This commit adds a specific layer in the test runner that is guaranteed
to run after all tests execute, and cleans up resources in a specific
order so that we don't orphan resources created during the test runs. It
also adds a separate Create function to the framework client that
creates resources without deferring cleanup.
