### PR TITLE
Fix test log about --skip-cleanup-error

### DIFF
--- a/tests/e2e/framework/context.go
+++ b/tests/e2e/framework/context.go
@@ -94,7 +94,7 @@ func (ctx *Context) Cleanup() {
 		// The cleanup function will be skipped
 		if ctx.t.Failed() && ctx.skipCleanupOnError {
 			// Also, could we log the error here?
-			log.Info("Skipping cleanup function since --skip-cleanup-error is true")
+			log.Info("Skipping cleanup function since -skipCleanupOnError is true")
 			return
 		}
 	}


### PR DESCRIPTION
That argument doesn't actually exist. Instead we have
`-skipCleanupOnError`. If you read the log and then try to use
`--skip-cleanup-error` you'll get a different error about an unsupported
argument.

This commit updates the log to output the correct argument.
