### PR TITLE
Simplify skipCleanupOnError test flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,11 +121,11 @@ E2E_GO_TEST_FLAGS?=-v -test.timeout 120m
 # By default we run all tests; available options: all, parallel, serial
 E2E_TEST_TYPE?=all
 
-# By default, the tests skip cleanup on failures. Set this variable to false if you prefer
-# the tests to cleanup regardless of test status, e.g.:
-# E2E_SKIP_CLEANUP_ON_ERROR=false make e2e
-E2E_SKIP_CLEANUP_ON_ERROR?=true
-E2E_ARGS=-root=$(PROJECT_DIR) -globalMan=$(TEST_CRD) -namespacedMan=$(TEST_DEPLOY) -skipCleanupOnError=$(E2E_SKIP_CLEANUP_ON_ERROR) -testType=$(E2E_TEST_TYPE)
+# By default, the test runner won't cleanup resources from failed test runs. Set this
+# variable to true if you prefer the tests to cleanup regardless of test status, e.g.:
+# E2E_CLEANUP_ON_ERROR=true make e2e
+E2E_CLEANUP_ON_ERROR?=false
+E2E_ARGS=-root=$(PROJECT_DIR) -globalMan=$(TEST_CRD) -namespacedMan=$(TEST_DEPLOY) -cleanupOnError=$(E2E_CLEANUP_ON_ERROR) -testType=$(E2E_TEST_TYPE)
 TEST_OPTIONS?=
 # Skip pushing the container to your cluster
 E2E_SKIP_CONTAINER_PUSH?=false

--- a/tests/e2e/framework/context.go
+++ b/tests/e2e/framework/context.go
@@ -1,6 +1,7 @@
 package framework
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -21,12 +22,12 @@ type Context struct {
 	watchNamespace    string
 	t                 *testing.T
 
-	namespacedManPath  string
-	testType           string
-	client             *frameworkClient
-	kubeclient         kubernetes.Interface
-	restMapper         *restmapper.DeferredDiscoveryRESTMapper
-	skipCleanupOnError bool
+	namespacedManPath string
+	testType          string
+	client            *frameworkClient
+	kubeclient        kubernetes.Interface
+	restMapper        *restmapper.DeferredDiscoveryRESTMapper
+	cleanupOnError    bool
 }
 
 // todo(camilamacedo86): Remove the following line just added for we are able to deprecated TestCtx
@@ -60,17 +61,17 @@ func (f *Framework) newContext(t *testing.T) *Context {
 	}
 
 	return &Context{
-		id:                 id,
-		t:                  t,
-		namespace:          operatorNamespace,
-		operatorNamespace:  operatorNamespace,
-		watchNamespace:     watchNamespace,
-		namespacedManPath:  *f.NamespacedManPath,
-		client:             f.Client,
-		kubeclient:         f.KubeClient,
-		restMapper:         f.restMapper,
-		skipCleanupOnError: f.skipCleanupOnError,
-		testType:           f.testType,
+		id:                id,
+		t:                 t,
+		namespace:         operatorNamespace,
+		operatorNamespace: operatorNamespace,
+		watchNamespace:    watchNamespace,
+		namespacedManPath: *f.NamespacedManPath,
+		client:            f.Client,
+		kubeclient:        f.KubeClient,
+		restMapper:        f.restMapper,
+		cleanupOnError:    f.cleanupOnError,
+		testType:          f.testType,
 	}
 }
 
@@ -85,9 +86,10 @@ func (ctx *Context) GetID() string {
 func (ctx *Context) Cleanup() {
 	if ctx.t != nil {
 		// The cleanup function will be skipped
-		if ctx.t.Failed() && ctx.skipCleanupOnError {
+		if ctx.t.Failed() && ctx.cleanupOnError {
 			// Also, could we log the error here?
-			log.Info("Skipping cleanup function since -skipCleanupOnError is true")
+			s := fmt.Sprintf("Skipping cleanup function since -cleanupOnError is false and %s failed", ctx.t.Name())
+			log.Info(s)
 			return
 		}
 	}

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -69,25 +69,25 @@ type Framework struct {
 
 	restMapper *restmapper.DeferredDiscoveryRESTMapper
 
-	projectRoot        string
-	globalManPath      string
-	localOperatorArgs  string
-	kubeconfigPath     string
-	testType           string
-	schemeMutex        sync.Mutex
-	LocalOperator      bool
-	skipCleanupOnError bool
+	projectRoot       string
+	globalManPath     string
+	localOperatorArgs string
+	kubeconfigPath    string
+	testType          string
+	schemeMutex       sync.Mutex
+	LocalOperator     bool
+	cleanupOnError    bool
 }
 
 type frameworkOpts struct {
-	projectRoot        string
-	kubeconfigPath     string
-	globalManPath      string
-	namespacedManPath  string
-	localOperatorArgs  string
-	testType           string
-	isLocalOperator    bool
-	skipCleanupOnError bool
+	projectRoot       string
+	kubeconfigPath    string
+	globalManPath     string
+	namespacedManPath string
+	localOperatorArgs string
+	testType          string
+	isLocalOperator   bool
+	cleanupOnError    bool
 }
 
 const (
@@ -97,14 +97,14 @@ const (
 )
 
 const (
-	ProjRootFlag           = "root"
-	KubeConfigFlag         = "kubeconfig"
-	NamespacedManPathFlag  = "namespacedMan"
-	GlobalManPathFlag      = "globalMan"
-	LocalOperatorFlag      = "localOperator"
-	LocalOperatorArgs      = "localOperatorArgs"
-	SkipCleanupOnErrorFlag = "skipCleanupOnError"
-	TestTypeFlag           = "testType"
+	ProjRootFlag          = "root"
+	KubeConfigFlag        = "kubeconfig"
+	NamespacedManPathFlag = "namespacedMan"
+	GlobalManPathFlag     = "globalMan"
+	LocalOperatorFlag     = "localOperator"
+	LocalOperatorArgs     = "localOperatorArgs"
+	CleanupOnErrorFlag    = "cleanupOnError"
+	TestTypeFlag          = "testType"
 
 	TestOperatorNamespaceEnv = "TEST_OPERATOR_NAMESPACE"
 	TestWatchNamespaceEnv    = "TEST_WATCH_NAMESPACE"
@@ -118,9 +118,11 @@ func (opts *frameworkOpts) addToFlagSet(flagset *flag.FlagSet) {
 	flagset.StringVar(&opts.globalManPath, GlobalManPathFlag, "", "path to operator manifest")
 	flagset.StringVar(&opts.localOperatorArgs, LocalOperatorArgs, "",
 		"flags that the operator needs (while using --up-local). example: \"--flag1 value1 --flag2=value2\"")
-	flagset.BoolVar(&opts.skipCleanupOnError, SkipCleanupOnErrorFlag, false,
-		"If set as true, the cleanup function responsible to remove all artifacts "+
-			"will be skipped if an error is faced.")
+	flagset.BoolVar(&opts.cleanupOnError, CleanupOnErrorFlag, false,
+		"If set to true, the test runner will attempt to cleanup all test resources "+
+			"if the test failed. By default, test resources are not cleaned up "+
+			"after failed tests to help debug test issues. This option has no effect on successful test runs, "+
+			"in which case test resources are automatically cleaned up.")
 	flagset.StringVar(&opts.testType, TestTypeFlag, TestTypeAll,
 		"Defines the type of tests to run. (Options: all, serial, parallel)")
 }
@@ -169,13 +171,13 @@ func newFramework(opts *frameworkOpts) (*Framework, error) {
 		OperatorNamespace: operatorNamespace,
 		LocalOperator:     opts.isLocalOperator,
 
-		projectRoot:        opts.projectRoot,
-		globalManPath:      opts.globalManPath,
-		localOperatorArgs:  opts.localOperatorArgs,
-		kubeconfigPath:     opts.kubeconfigPath,
-		restMapper:         restMapper,
-		skipCleanupOnError: opts.skipCleanupOnError,
-		testType:           opts.testType,
+		projectRoot:       opts.projectRoot,
+		globalManPath:     opts.globalManPath,
+		localOperatorArgs: opts.localOperatorArgs,
+		kubeconfigPath:    opts.kubeconfigPath,
+		restMapper:        restMapper,
+		cleanupOnError:    opts.cleanupOnError,
+		testType:          opts.testType,
 	}
 	return framework, nil
 }

--- a/tests/e2e/framework/main_entry.go
+++ b/tests/e2e/framework/main_entry.go
@@ -50,7 +50,7 @@ func MainEntry(m *testing.M) {
 
 	// Do suite teardown only if we have a successful test run or if we don't care
 	// about removing the test resources if the test failed.
-	if exitCode == 0 || (exitCode > 0 && !f.skipCleanupOnError) {
+	if exitCode == 0 || (exitCode > 0 && !f.cleanupOnError) {
 		if err = f.tearDown(); err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
The flag skipCleanupOnError defaulted to false, meaning it would cleanup
test resources in the event of a failure. In the Makefile target for e2e
tests, we override -skipCleanupOnError with true, so we keep resources
when a test fails.

Depending on if you're running the tests using `make e2e` or directly
using `go test` you'd get different behavior.

This commit renames the variable to be more affimative by removing
`skip` from the name (skipCleanupOnError actually means
cleanupOnError=false). It also converges the default in the test runner
to be the same as the default in the Makefile, allowing for consistent
behavior regardless of how you invoke the tests. It also adds more help
text to clarify the behavior.
