### PR TITLE
Use golang 1.20, RHEL 9, and OpenShift 4.14 images for CI

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Step one: build compliance-operator
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14 AS builder
 
 WORKDIR /go/src/github.com/openshift/compliance-operator
 
@@ -10,7 +10,7 @@ COPY . .
 RUN make manager
 
 # Step two: containerize compliance-operator
-FROM registry.access.redhat.com/ubi8/ubi-micro:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 
 ENV OPERATOR=/usr/local/bin/compliance-operator \
     USER_UID=1001 \

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,5 +1,5 @@
 # Step one: build compliance-operator
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14 AS builder
 
 WORKDIR /go/src/github.com/openshift/compliance-operator
 
@@ -10,7 +10,7 @@ COPY . .
 RUN make manager
 
 # Step two: containerize compliance-operator
-FROM registry.access.redhat.com/ubi8/ubi-micro:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 
 ENV OPERATOR=/usr/local/bin/compliance-operator \
     USER_UID=1001 \


### PR DESCRIPTION
To use golang version 1.20, we need to use a RHEL9 image with OpenShift 4.14, because that is what's available in the CI registries.
