### PR TITLE
Remove deprecated test context method

### DIFF
--- a/tests/e2e/framework/resource.go
+++ b/tests/e2e/framework/resource.go
@@ -83,15 +83,6 @@ func (s *Scanner) Bytes() []byte {
 	return s.token
 }
 
-// TODO: remove before 1.0.0
-// Deprecated: GetNamespace() exists for historical compatibility.
-// Use GetOperatorNamespace() or GetWatchNamespace() instead
-func (ctx *Context) GetNamespace() (string, error) {
-	var err error
-	ctx.namespace, err = ctx.getNamespace(ctx.namespace)
-	return ctx.namespace, err
-}
-
 // GetOperatorNamespace will return an Operator Namespace,
 // if the flag --operator-namespace  not be used (TestOpeatorNamespaceEnv not set)
 // then it will create a new namespace with randon name and return that namespace


### PR DESCRIPTION
The GetNamespace method was deprecated and we have a suitable
replacement called GetOperatorNamespace. All test code is already
updated to use the new method.

This commit removes the deprecated function so we don't have cruft
laying around.
