### PR TITLE
rbac: Allow to Read imagepruners

### DIFF
--- a/config/rbac/api_resource_collector_cluster_role.yaml
+++ b/config/rbac/api_resource_collector_cluster_role.yaml
@@ -769,6 +769,16 @@ rules:
       - list
       - watch
   - apiGroups:
+      - imageregistry.operator.openshift.io
+    resources:
+      - imagepruners
+    resourceNames:
+      - cluster
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - operator.openshift.io
     resources:
       - kubeapiservers


### PR DESCRIPTION
One of STIG compliance rules requires to read this API resource.
