### PR TITLE
Fix upstream repository URL

### DIFF
--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -166,7 +166,7 @@ metadata:
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
       Container Platform", "OpenShift Platform Plus"]'
-    repository: https://github.com/openshift/compliance-operator
+    repository: https://github.com/ComplianceAsCode/compliance-operator
     support: Red Hat Inc.
   labels:
     operatorframework.io/arch.amd64: supported
@@ -1546,8 +1546,8 @@ spec:
   - openscap
   - audit
   links:
-  - name: Compliance Operator upstream repo
-    url: https://github.com/openshift/compliance-operator
+  - name: Compliance Operator upstream repoistory
+    url: https://github.com/ComplianceAsCode/compliance-operator
   - name: Compliance Operator documentation
     url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html
   maintainers:


### PR DESCRIPTION
We moved the code from openshift/compliance-operator to
ComplianceAsCode/compliance-operator, but we did't update the manifest
references. This means the bundle image would still point to the origin
repository, which isn't what we want.

We attempted to fix this in PR #230, but we only modified the bundle
manifest, which is generated from the manifest base. This commit updates
the manifest base so that it uses the correct URL, too.
