### PR TITLE
Fix TestSingleTailoredPlatformScanSucceeds by using supported rule

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -950,7 +950,7 @@ func TestE2E(t *testing.T) {
   <xccdf-1.2:Profile id="xccdf_compliance.openshift.io_profile_test-tailoredplatformprofile">
     <xccdf-1.2:title override="true">Test Tailored Platform profile</xccdf-1.2:title>
     <xccdf-1.2:description override="true">This is a test for platform profile tailoring</xccdf-1.2:description>
-    <xccdf-1.2:select idref="xccdf_org.ssgproject.content_rule_scheduler_no_bind_address" selected="true"></xccdf-1.2:select>
+    <xccdf-1.2:select idref="xccdf_org.ssgproject.content_rule_cluster_version_operator_exists" selected="true"></xccdf-1.2:select>
   </xccdf-1.2:Profile>
 </xccdf-1.2:Tailoring>`,
 					},
@@ -970,7 +970,7 @@ func TestE2E(t *testing.T) {
 						ScanType:     compv1alpha1.ScanTypePlatform,
 						ContentImage: contentImagePath,
 						Profile:      "xccdf_compliance.openshift.io_profile_test-tailoredplatformprofile",
-						Rule:         "xccdf_org.ssgproject.content_rule_scheduler_no_bind_address",
+						Rule:         "xccdf_org.ssgproject.content_rule_cluster_version_operator_exists",
 						Content:      ocpContentFile,
 						TailoringConfigMap: &compv1alpha1.TailoringConfigMapRef{
 							Name: tailoringCM.Name,


### PR DESCRIPTION
The TestSingleTailoredPlatformScanSucceeds creates a simple tailored
profile with a single rule, binds it to a scan setting, then asserts the
scan was compliant.

This recently started failing because it was using the
scheduler_no_bind_address rule, which is not applicable to newer
versions of OpenShift:

  https://github.com/ComplianceAsCode/content/commit/778fae292ca76a16b3a191b0a1f75d9241e16dd0

This resulted in the scan result coming back as not applicable instead
of compliant.

This commit uses a different rule for the tailored profile that's still
supported on newer versions of OpenShift so our CI works again.

Fixes #276
