### PR TITLE
Fix upstream repository URL... again

### DIFF
--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -1546,7 +1546,7 @@ spec:
   - openscap
   - audit
   links:
-  - name: Compliance Operator upstream repoistory
+  - name: Compliance Operator upstream repository
     url: https://github.com/ComplianceAsCode/compliance-operator
   - name: Compliance Operator documentation
     url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html


### PR DESCRIPTION
I just patched this to fix the repository URL, but it also helps enable
spell checking tools.
