### PR TITLE
rbac: Allow reading scansettings and scansettingbindings

### DIFF
--- a/config/rbac/api_resource_collector_cluster_role.yaml
+++ b/config/rbac/api_resource_collector_cluster_role.yaml
@@ -793,6 +793,8 @@ rules:
       - compliance.openshift.io
     resources:
       - compliancesuites
+      - scansettings
+      - scansettingbindings
     verbs:
       - get
       - list


### PR DESCRIPTION
See the patch, it's just a trivial addition of two RBAC rules needed for the STIG
