### PR TITLE
Optimize how we check runtime KubeletConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
--
+- Optimize how we check the KubeletConfig rule, we now store the runtime KubeletConfig
+  in a ConfigMap per node when a node scan is launched. Then, we mount the ConfigMap to
+  the scanner pod to scan for it. Hold on to applying remediation until all scans are 
+  done in the suite.
+  This fixes issues when comparing the KubeletConfig for each node.
+  This also fixes "/api/v1/nodes/NODE_NAME/proxy/configz" warning message in the log.
+  [OCPBUGS-11037](https://issues.redhat.com/browse/OCPBUGS-11037)
 
 ### Internal Changes
 
@@ -25,7 +31,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removals
 
--
+- We have reverted commit 9cbf874, which is a fix for OCPBUGS-3864, the fix
+  is not needed anymore since the issue is fixed when we switched back to
+  the old way remediate the KubeletConfig.
 
 ### Security
 

--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1093,11 +1093,19 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - nodes
           - namespaces
           verbs:
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          - nodes/proxy
+          verbs:
+          - list
+          - watch
+          - get
         - apiGroups:
           - machineconfiguration.openshift.io
           resources:
@@ -1347,6 +1355,15 @@ spec:
           - update
           - delete
           - deletecollection
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          - nodes/proxy
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -289,7 +289,7 @@ func RunOperator(cmd *cobra.Command, args []string) {
 	}
 
 	// Setup all Controllers
-	if err := controller.AddToManager(mgr, met, si); err != nil {
+	if err := controller.AddToManager(mgr, met, si, kubeClient); err != nil {
 		setupLog.Error(err, "")
 		os.Exit(1)
 	}

--- a/config/rbac/operator_cluster_role.yaml
+++ b/config/rbac/operator_cluster_role.yaml
@@ -6,11 +6,19 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - nodes  # We need to list the nodes to be able to selectively scan
       - namespaces # We need this to get the range
     verbs:
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes # We need to list the nodes to be able to selectively scan
+      - nodes/proxy # We need to be able to get runtime kubeletconfig from the nodes
+    verbs:
+      - list
+      - watch
+      - get
   - apiGroups:
       - machineconfiguration.openshift.io
     resources:

--- a/config/rbac/operator_role.yaml
+++ b/config/rbac/operator_role.yaml
@@ -33,6 +33,15 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - nodes
+      - nodes/proxy
+    verbs:
+      - get
+      - list
+      - watch 
+  - apiGroups:
+      - ""
+    resources:
       - secrets  # Secrets are used to store TLS assets
     verbs:
       - create   # The operator must create certificate secrets

--- a/main.go
+++ b/main.go
@@ -18,8 +18,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/ComplianceAsCode/compliance-operator/cmd/manager"
 	"os"
+
+	"github.com/ComplianceAsCode/compliance-operator/cmd/manager"
 
 	"github.com/spf13/cobra"
 )

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -29,6 +29,9 @@ const ComplianceScanLabel = "compliance.openshift.io/scan-name"
 // ScriptLabel defines that the object is a script for a scan object
 const ScriptLabel = "complianceoperator.openshift.io/scan-script"
 
+// KubeletConfigLabel defines that the object is a fetched KubeletConfig for a scan object
+const KubeletConfigLabel = "complianceoperator.openshift.io/scan-kubeletconfig"
+
 // ResultLabel defines that the object is a result of a scan
 const ResultLabel = "complianceoperator.openshift.io/scan-result"
 

--- a/pkg/apis/compliance/v1alpha1/scansettingbinding_types.go
+++ b/pkg/apis/compliance/v1alpha1/scansettingbinding_types.go
@@ -20,10 +20,10 @@ type ScanSettingBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec     ScanSettingBindingSpec `json:"spec,omitempty"`
-	Profiles []NamedObjectReference `json:"profiles,omitempty"`
-	// +kubebuilder:default={"name":"default","kind": "ScanSetting", "apiGroup": "compliance.openshift.io/v1alpha1"}
-	SettingsRef *NamedObjectReference `json:"settingsRef,omitempty"`
+	Spec        ScanSettingBindingSpec `json:"spec,omitempty"`
+	Profiles    []NamedObjectReference `json:"profiles,omitempty"`
+        // +kubebuilder:default={"name":"default","kind": "ScanSetting", "apiGroup": "compliance.openshift.io/v1alpha1"}
+	SettingsRef *NamedObjectReference  `json:"settingsRef,omitempty"`
 	// +optional
 	Status ScanSettingBindingStatus `json:"status,omitempty"`
 }

--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,7 +48,7 @@ func (r *ReconcileComplianceRemediation) SetupWithManager(mgr ctrl.Manager) erro
 
 // Add creates a new ComplianceRemediation Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, met *metrics.Metrics, _ utils.CtlplaneSchedulingInfo) error {
+func Add(mgr manager.Manager, met *metrics.Metrics, _ utils.CtlplaneSchedulingInfo, _ *kubernetes.Clientset) error {
 	return add(mgr, newReconciler(mgr, met))
 }
 

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -397,12 +397,12 @@ func (r *ReconcileComplianceScan) getRuntimeKubeletConfig(nodeName string) (stri
 	// get the runtime kubeletconfig
 	kubeletConfigIO, err := r.ClientSet.CoreV1().RESTClient().Get().RequestURI("/api/v1/nodes/" + nodeName + "/proxy/configz").Stream(context.TODO())
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("cannot get the runtime kubelet config for node %s: %v", nodeName, err)
 	}
 	defer kubeletConfigIO.Close()
 	kubeletConfig, err := ioutil.ReadAll(kubeletConfigIO)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("cannot read the runtime kubelet config for node %s: %v", nodeName, err)
 	}
 	// kubeletConfig is a byte array, we need to convert it to string
 	kubeletConfigStr := string(kubeletConfig)

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"strings"
 	"time"
@@ -17,8 +18,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,14 +62,15 @@ func (r *ReconcileComplianceScan) SetupWithManager(mgr ctrl.Manager) error {
 
 // Add creates a new ComplianceScan Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, met *metrics.Metrics, si utils.CtlplaneSchedulingInfo) error {
-	return add(mgr, newReconciler(mgr, met, si))
+func Add(mgr manager.Manager, met *metrics.Metrics, si utils.CtlplaneSchedulingInfo, kubeClient *kubernetes.Clientset) error {
+	return add(mgr, newReconciler(mgr, met, si, kubeClient))
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, met *metrics.Metrics, si utils.CtlplaneSchedulingInfo) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, met *metrics.Metrics, si utils.CtlplaneSchedulingInfo, kubeClient *kubernetes.Clientset) reconcile.Reconciler {
 	return &ReconcileComplianceScan{
 		Client:         mgr.GetClient(),
+		ClientSet:      kubeClient,
 		Scheme:         mgr.GetScheme(),
 		Recorder:       mgr.GetEventRecorderFor("scanctrl"),
 		Metrics:        met,
@@ -89,10 +93,11 @@ var _ reconcile.Reconciler = &ReconcileComplianceScan{}
 type ReconcileComplianceScan struct {
 	// This Client, initialized using mgr.Client() above, is a split Client
 	// that reads objects from the cache and writes to the apiserver
-	Client   client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
-	Metrics  *metrics.Metrics
+	Client    client.Client
+	ClientSet *kubernetes.Clientset
+	Scheme    *runtime.Scheme
+	Recorder  record.EventRecorder
+	Metrics   *metrics.Metrics
 	// helps us schedule platform scans on the nodes labeled for the
 	// compliance operator's control plane
 	schedulingInfo utils.CtlplaneSchedulingInfo
@@ -104,6 +109,7 @@ type ReconcileComplianceScan struct {
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,persistentvolumes,verbs=watch,create,get,list,delete
 //+kubebuilder:rbac:groups="",resources=pods,configmaps,events,verbs=create,get,list,watch,patch,update,delete,deletecollection
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create,get,list,update,watch,delete
+//+kubebuilder:rbac:groups="",resources=nodes,nodes/proxy,verbs=get,list,watch
 //+kubebuilder:rbac:groups=apps,resources=replicasets,deployments,verbs=get,list,watch,create,update,delete
 //+kubebuilder:rbac:groups=compliance.openshift.io,resources=compliancescans,verbs=create,watch,patch,get,list
 //+kubebuilder:rbac:groups=compliance.openshift.io,resources=*,verbs=*
@@ -275,7 +281,6 @@ func (r *ReconcileComplianceScan) validate(instance *compv1alpha1.ComplianceScan
 
 func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.ComplianceScan, logger logr.Logger) (reconcile.Result, error) {
 	logger.Info("Phase: Pending")
-
 	// Remove annotation if needed
 	if instance.NeedsRescan() {
 		instanceCopy := instance.DeepCopy()
@@ -350,6 +355,11 @@ func (r *ReconcileComplianceScan) phaseLaunchingHandler(h scanTypeHandler, logge
 		return reconcile.Result{}, err
 	}
 
+	if err = r.handleRuntimeKubeletConfig(scan, logger); err != nil {
+		logger.Error(err, "Cannot handle runtime kubelet config")
+		return reconcile.Result{}, err
+	}
+
 	if err = h.createScanWorkload(); err != nil {
 		if !common.IsRetriable(err) {
 			// Surface non-retriable errors to the CR
@@ -378,6 +388,101 @@ func (r *ReconcileComplianceScan) phaseLaunchingHandler(h scanTypeHandler, logge
 	}
 	r.Metrics.IncComplianceScanStatus(scan.Name, scan.Status)
 	return reconcile.Result{}, nil
+}
+
+// getRuntimeKubeletConfig gets the runtime kubeletconfig for a node
+// by fetching /api/v1/nodes/$nodeName/proxy/configz endpoint use the kubeClientset
+// and store it in a configmap for each node
+func (r *ReconcileComplianceScan) getRuntimeKubeletConfig(nodeName string) (string, error) {
+	// get the runtime kubeletconfig
+	kubeletConfigIO, err := r.ClientSet.CoreV1().RESTClient().Get().RequestURI("/api/v1/nodes/" + nodeName + "/proxy/configz").Stream(context.TODO())
+	if err != nil {
+		return "", err
+	}
+	defer kubeletConfigIO.Close()
+	kubeletConfig, err := ioutil.ReadAll(kubeletConfigIO)
+	if err != nil {
+		return "", err
+	}
+	// kubeletConfig is a byte array, we need to convert it to string
+	kubeletConfigStr := string(kubeletConfig)
+	return kubeletConfigStr, nil
+}
+
+func (r *ReconcileComplianceScan) createKubeletConfigCM(instance *compv1alpha1.ComplianceScan, node *corev1.Node) error {
+	kubeletConfig, err := r.getRuntimeKubeletConfig(node.Name)
+	if err != nil {
+		return fmt.Errorf("cannot get the runtime kubelet config for node %s: %v", node.Name, err)
+	}
+	trueP := true
+	// create a configmap for the node
+	kubeletConfigCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getKubeletCMNameForScan(instance, node),
+			Namespace: instance.Namespace,
+			CreationTimestamp: metav1.Time{
+				Time: time.Now(),
+			},
+			Labels: map[string]string{
+				compv1alpha1.ComplianceScanLabel: instance.Name,
+				compv1alpha1.KubeletConfigLabel:  "",
+			},
+		},
+		Data: map[string]string{
+			KubeletConfigMapName: kubeletConfig,
+		},
+		Immutable: &trueP,
+	}
+	err = r.Client.Create(context.TODO(), kubeletConfigCM)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *ReconcileComplianceScan) getNodesForScan(instance *compv1alpha1.ComplianceScan) (corev1.NodeList, error) {
+	nodes := corev1.NodeList{}
+	nodeScanSelector := map[string]string{"kubernetes.io/os": "linux"}
+	listOpts := client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Merge(instance.Spec.NodeSelector, nodeScanSelector)),
+	}
+
+	if err := r.Client.List(context.TODO(), &nodes, &listOpts); err != nil {
+		return nodes, err
+	}
+	return nodes, nil
+}
+
+func (r *ReconcileComplianceScan) handleRuntimeKubeletConfig(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
+	// only handle node scans
+	if instance.Spec.ScanType != compv1alpha1.ScanTypeNode {
+		return nil
+	}
+	nodes, err := r.getNodesForScan(instance)
+	if err != nil {
+		logger.Error(err, "Cannot get the nodes for the scan")
+		return err
+	}
+	for _, node := range nodes.Items {
+		// check if the configmap already exists for the node
+		kubeletConfigCM := &corev1.ConfigMap{}
+		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: getKubeletCMNameForScan(instance, &node), Namespace: instance.Namespace}, kubeletConfigCM)
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				logger.Error(err, "Error getting the configmap for the runtime kubeletconfig", "node", node.Name)
+				return err
+			}
+			// create a configmap for the node
+			err = r.createKubeletConfigCM(instance, &node)
+			logger.Info("Created a new configmap for the node", "configmap", kubeletConfigCM.Name, "node", node.Name)
+			if err != nil {
+				logger.Error(err, "Error creating the configmap for the runtime kubeletconfig", "node", node.Name)
+				return err
+			}
+			continue
+		}
+	}
+	return nil
 }
 
 func (r *ReconcileComplianceScan) phaseRunningHandler(h scanTypeHandler, logger logr.Logger) (reconcile.Result, error) {
@@ -575,6 +680,7 @@ func (r *ReconcileComplianceScan) phaseDoneHandler(h scanTypeHandler, instance *
 			logger.Error(err, "Cannot delete aggregator")
 			return reconcile.Result{}, err
 		}
+
 	}
 
 	// We need to remove resources before doing a re-scan
@@ -602,6 +708,11 @@ func (r *ReconcileComplianceScan) phaseDoneHandler(h scanTypeHandler, instance *
 
 		if err = r.deleteScriptConfigMaps(instance, logger); err != nil {
 			logger.Error(err, "Cannot delete script ConfigMaps")
+			return reconcile.Result{}, err
+		}
+
+		if err := r.deleteKubeletConfigConfigMaps(instance, logger); err != nil {
+			logger.Error(err, "Cannot delete KubeletConfig ConfigMaps")
 			return reconcile.Result{}, err
 		}
 
@@ -745,6 +856,19 @@ func (r *ReconcileComplianceScan) deleteScriptConfigMaps(instance *compv1alpha1.
 func (r *ReconcileComplianceScan) deleteResultConfigMaps(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
 	inNs := client.InNamespace(common.GetComplianceOperatorNamespace())
 	withLabel := client.MatchingLabels{compv1alpha1.ComplianceScanLabel: instance.Name}
+	err := r.Client.DeleteAllOf(context.Background(), &corev1.ConfigMap{}, inNs, withLabel)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *ReconcileComplianceScan) deleteKubeletConfigConfigMaps(instance *compv1alpha1.ComplianceScan, logger logr.Logger) error {
+	inNs := client.InNamespace(common.GetComplianceOperatorNamespace())
+	withLabel := client.MatchingLabels{
+		compv1alpha1.ComplianceScanLabel: instance.Name,
+		compv1alpha1.KubeletConfigLabel:  "",
+	}
 	err := r.Client.DeleteAllOf(context.Background(), &corev1.ConfigMap{}, inNs, withLabel)
 	if err != nil {
 		return err

--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -20,6 +20,15 @@ const (
 	// This is how the script would be mounted
 	OpenScapScriptPath = "/scripts/openscap-container-entrypoint"
 
+	// configMap that contains the runtime kubeletconfig
+	KubeletConfigMapName = "openscap-kubeletconfig"
+	// This is how the kubeletconfig would be mounted
+	KubeletConfigMapPath = "/kubeletconfig"
+	// This is how the kubeletconfig would be linked in the host
+	KubeletConfigLinkPath = "/host/etc/kubernetes/compliance-operator/kubeletconfig"
+	// This is the folder where the kubeletconfig would be linked in the host
+	KubeletConfigLinkFolder = "/host/etc/kubernetes/compliance-operator"
+
 	// a configMap with env vars for the script
 	OpenScapEnvConfigMapName = "openscap-env-map"
 	// A configMap same as above but minus hostroot

--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -30,6 +30,7 @@ const (
 	ClientCertPrefix             = "result-client-cert-"
 	RootCAPrefix                 = "root-ca-"
 	CertValidityDays             = 1
+	KubeletConfigCMSuffix        = "-runtime-kubeletconfig"
 )
 
 // New returns an error that formats as the given text.
@@ -139,4 +140,8 @@ func secretExists(c client.Client, name, namespace string) (bool, error) {
 		return false, err
 	}
 	return err == nil, nil
+}
+
+func getKubeletCMNameForScan(scan *compv1alpha1.ComplianceScan, node *corev1.Node) string {
+	return fmt.Sprintf("%s-%s%s", scan.Name, node.Name, KubeletConfigCMSuffix)
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/ComplianceAsCode/compliance-operator/pkg/controller/metrics"
@@ -8,12 +9,13 @@ import (
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager, *metrics.Metrics, utils.CtlplaneSchedulingInfo) error
+var AddToManagerFuncs []func(manager.Manager, *metrics.Metrics, utils.CtlplaneSchedulingInfo, *kubernetes.Clientset) error
 
 // AddToManager adds all Controllers to the Manager
 func AddToManager(m manager.Manager,
 	met *metrics.Metrics,
 	si utils.CtlplaneSchedulingInfo,
+	kubeClient *kubernetes.Clientset,
 ) error {
 	// Add metrics Startup to the manager
 	if err := m.Add(met); err != nil {
@@ -21,7 +23,7 @@ func AddToManager(m manager.Manager,
 	}
 
 	for _, f := range AddToManagerFuncs {
-		if err := f(m, met, si); err != nil {
+		if err := f(m, met, si, kubeClient); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -2,8 +2,9 @@ package profilebundle
 
 import (
 	"context"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/ComplianceAsCode/compliance-operator/pkg/controller/metrics"
 
@@ -27,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -45,7 +47,7 @@ func (r *ReconcileProfileBundle) SetupWithManager(mgr ctrl.Manager) error {
 
 // Add creates a new ProfileBundle Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, met *metrics.Metrics, si utils.CtlplaneSchedulingInfo) error {
+func Add(mgr manager.Manager, met *metrics.Metrics, si utils.CtlplaneSchedulingInfo, _ *kubernetes.Clientset) error {
 	return add(mgr, newReconciler(mgr, met, si))
 }
 

--- a/pkg/controller/scansettingbinding/scansettingbinding_controller.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"strings"
 	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/ComplianceAsCode/compliance-operator/pkg/controller/metrics"
 
@@ -22,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -48,7 +50,7 @@ func (r *ReconcileScanSettingBinding) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func Add(mgr manager.Manager, met *metrics.Metrics, _ utils.CtlplaneSchedulingInfo) error {
+func Add(mgr manager.Manager, met *metrics.Metrics, _ utils.CtlplaneSchedulingInfo, _ *kubernetes.Clientset) error {
 	return add(mgr, newReconciler(mgr, met))
 }
 
@@ -320,7 +322,7 @@ func (r *ReconcileScanSettingBinding) applyConstraint(
 		return common.WrapNonRetriableCtrlError(err)
 	}
 
-	if valErr := r.validateRoles(instance, &v1setting, logger); valErr != nil {
+	if valErr := r.validateRoles(&v1setting); valErr != nil {
 		return common.NewRetriableCtrlErrorWithCustomHandler(
 			func() (reconcile.Result, error) {
 				return reconcile.Result{}, nil
@@ -340,11 +342,7 @@ func (r *ReconcileScanSettingBinding) applyConstraint(
 	return nil
 }
 
-func (r *ReconcileScanSettingBinding) validateRoles(
-	binding *compliancev1alpha1.ScanSettingBinding,
-	setting *compliancev1alpha1.ScanSetting,
-	logger logr.Logger,
-) error {
+func (r *ReconcileScanSettingBinding) validateRoles(setting *compliancev1alpha1.ScanSetting) error {
 	if len(setting.Roles) == 0 {
 		r.Eventf(setting, corev1.EventTypeWarning, "EmptyRoles",
 			"The ScanSetting's roles are empty. Node scans won't be scheduled.")
@@ -361,94 +359,8 @@ func (r *ReconcileScanSettingBinding) validateRoles(
 		if !r.roleVal.MatchString(role) {
 			return fmt.Errorf("role %s is invalid", role)
 		}
-		if !isBuiltInRole(role) {
-			// if the scan setting is not using a built-in role, we need to make sure that the role is set
-			// in a tailored profile
-			if err := r.verifyRoleInScanSettingBinding(binding, role, logger); err != nil {
-				msg := "The scanSetting references a non-default role, but either no tailored profile is set or the role variables are not set"
-				ssb := binding.DeepCopy()
-				ssb.Status.SetConditionInvalid(msg)
-				if updateErr := r.Client.Status().Update(context.TODO(), ssb); updateErr != nil {
-					return fmt.Errorf("couldn't update ScanSettingBinding condition: %w", updateErr)
-				}
-				return fmt.Errorf("role %s is not set in any tailored profile: %w", role, err)
-			}
-		}
 	}
 	return nil
-}
-
-// return an error if the ssb references at least one Platform profile that is not
-// tailored or a tailored profile that does not have the role set
-func (r *ReconcileScanSettingBinding) verifyRoleInScanSettingBinding(
-	binding *compliancev1alpha1.ScanSettingBinding,
-	role string,
-	logger logr.Logger,
-) error {
-	profilesToCheck := []compliancev1alpha1.NamedObjectReference{}
-
-	for i := range binding.Profiles {
-		prfRef := &binding.Profiles[i]
-
-		key := types.NamespacedName{Namespace: binding.Namespace, Name: prfRef.Name}
-		prfObj, err := getUnstructured(r, binding, key, prfRef.Kind, prfRef.APIGroup, logger)
-		if err != nil {
-			return fmt.Errorf("error getting Profile %s: %w", prfRef.Name, err)
-		}
-
-		profileType, err := getTpScanType(r, binding, prfRef.APIGroup, prfObj, logger)
-		if err != nil {
-			logger.Info("error getting scan type, assuming Platform", "profile", prfRef.Name, "error", err)
-			profileType = compliancev1alpha1.ScanTypePlatform
-		}
-
-		if profileType == compliancev1alpha1.ScanTypeNode {
-			continue
-		}
-
-		profilesToCheck = append(profilesToCheck, *prfRef)
-	}
-
-	if len(profilesToCheck) == 0 {
-		// all profiles we had were node profiles, so we don't need to check for the roles
-		return nil
-	}
-
-	// at least one of profilesToCheck must be a TP with the role set
-	for i := range profilesToCheck {
-		prfRef := &profilesToCheck[i]
-
-		if prfRef.Kind != "TailoredProfile" {
-			// we only care about tailored profiles
-			continue
-		}
-
-		key := types.NamespacedName{Namespace: binding.Namespace, Name: prfRef.Name}
-		tp, geterr := getUnstructured(r, binding, key, prfRef.Kind, prfRef.APIGroup, logger)
-		if geterr != nil {
-			return fmt.Errorf("error getting TailoredProfile %s: %w", prfRef.Name, geterr)
-		}
-
-		if err := isCmpv1Alpha1Gvk(tp, "TailoredProfile"); err != nil {
-			return common.WrapNonRetriableCtrlError(err)
-		}
-
-		v1alphaTp := compliancev1alpha1.TailoredProfile{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(tp.Object, &v1alphaTp); err != nil {
-			return common.WrapNonRetriableCtrlError(err)
-		}
-
-		for vi := range v1alphaTp.Spec.SetValues {
-			val := &v1alphaTp.Spec.SetValues[vi]
-			if val.Value == role {
-				return nil
-			}
-		}
-	}
-
-	msg := fmt.Sprintf("role %s is not set in any variable in tailored profiles", role)
-	r.Eventf(binding, corev1.EventTypeWarning, "", msg)
-	return fmt.Errorf(msg)
 }
 
 func (r *ReconcileScanSettingBinding) createScansWithSelector(
@@ -490,10 +402,6 @@ func (r *ReconcileScanSettingBinding) sanitizeRoleForName(roleName string) strin
 	// has already happened.
 	return r.invalidRole.ReplaceAllString(roleName, "")
 
-}
-
-func isBuiltInRole(role string) bool {
-	return role == "master" || role == "worker" || role == "control-plane"
 }
 
 func newCompScanFromBindingProfile(r *ReconcileScanSettingBinding, instance *compliancev1alpha1.ScanSettingBinding, profile *unstructured.Unstructured, logger logr.Logger) (*compliancev1alpha1.ComplianceScanSpecWrapper, string, error) {

--- a/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
@@ -3,8 +3,9 @@ package scansettingbinding
 import (
 	"context"
 	"regexp"
-	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
+
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/zapr"
 	. "github.com/onsi/ginkgo"
@@ -30,11 +31,8 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 		reconciler ReconcileScanSettingBinding
 
 		pBundleRhcos *compv1alpha1.ProfileBundle
-		pBundleOcp   *compv1alpha1.ProfileBundle
 		profRhcosE8  *compv1alpha1.Profile
-		profOcpCis   *compv1alpha1.Profile
 		tpRhcosE8    *compv1alpha1.TailoredProfile
-		tpOcpCis     *compv1alpha1.TailoredProfile
 		scratchTP    *compv1alpha1.TailoredProfile
 
 		setting *compv1alpha1.ScanSetting
@@ -56,14 +54,9 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 		ssb = &compv1alpha1.ScanSettingBinding{}
 		suite = &compv1alpha1.ComplianceSuite{}
 
-		nodeProfileAnnotations := map[string]string{
+		platformProfileAnnotations := map[string]string{
 			compv1alpha1.ProductTypeAnnotation: string(compv1alpha1.ScanTypeNode),
 			compv1alpha1.ProductAnnotation:     "rhcos4",
-		}
-
-		platformProfileAnnotation := map[string]string{
-			compv1alpha1.ProductTypeAnnotation: string(compv1alpha1.ScanTypePlatform),
-			compv1alpha1.ProductAnnotation:     "ocp4",
 		}
 
 		pBundleRhcos = &compv1alpha1.ProfileBundle{
@@ -80,25 +73,11 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 			},
 		}
 
-		pBundleOcp = &compv1alpha1.ProfileBundle{
-			ObjectMeta: v1.ObjectMeta{
-				Name:      "ocp4",
-				Namespace: common.GetComplianceOperatorNamespace(),
-			},
-			Spec: compv1alpha1.ProfileBundleSpec{
-				ContentImage: "ghcr.io/complianceascode/k8scontent:latest",
-				ContentFile:  "ssg-ocp4-ds.xml",
-			},
-			Status: compv1alpha1.ProfileBundleStatus{
-				DataStreamStatus: compv1alpha1.DataStreamValid,
-			},
-		}
-
 		profRhcosE8 = &compv1alpha1.Profile{
 			ObjectMeta: v1.ObjectMeta{
 				Name:        "rhcos4-e8",
 				Namespace:   common.GetComplianceOperatorNamespace(),
-				Annotations: nodeProfileAnnotations,
+				Annotations: platformProfileAnnotations,
 			},
 			ProfilePayload: compv1alpha1.ProfilePayload{
 				Title:       "rhcos4 profile",
@@ -107,24 +86,11 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 			},
 		}
 
-		profOcpCis = &compv1alpha1.Profile{
-			ObjectMeta: v1.ObjectMeta{
-				Name:        "ocp4-cis",
-				Namespace:   common.GetComplianceOperatorNamespace(),
-				Annotations: platformProfileAnnotation,
-			},
-			ProfilePayload: compv1alpha1.ProfilePayload{
-				Title:       "ocp4 profile",
-				Description: "ocp4 profile description",
-				ID:          "xccdf_org.ssgproject.content_profile_ocp4",
-			},
-		}
-
 		tpRhcosE8 = &compv1alpha1.TailoredProfile{
 			ObjectMeta: v1.ObjectMeta{
-				Name:        "emptypass-rhcos4-e8",
-				Namespace:   common.GetComplianceOperatorNamespace(),
-				Annotations: nodeProfileAnnotations,
+				Name:      "emptypass-rhcos4-e8",
+				Namespace: common.GetComplianceOperatorNamespace(),
+				Labels:    platformProfileAnnotations,
 			},
 			Spec: compv1alpha1.TailoredProfileSpec{
 				Extends:     profRhcosE8.Name,
@@ -148,49 +114,11 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 			},
 		}
 
-		tpOcpCis = &compv1alpha1.TailoredProfile{
-			ObjectMeta: v1.ObjectMeta{
-				Name:        "auditprofile-ocp4-cis",
-				Namespace:   common.GetComplianceOperatorNamespace(),
-				Annotations: platformProfileAnnotation,
-			},
-			Spec: compv1alpha1.TailoredProfileSpec{
-				Extends:     profOcpCis.Name,
-				Title:       "testing TP",
-				Description: "some desc",
-				DisableRules: []compv1alpha1.RuleReferenceSpec{
-					{
-						Name:      "ocp4-var-openshift-audit-profile",
-						Rationale: "I don't want this rule",
-					},
-				},
-				SetValues: []compv1alpha1.VariableValueSpec{
-					{
-						Name:  "ocp4-var-role-master",
-						Value: "role-1",
-					},
-					{
-						Name:  "ocp4-var-role-worker",
-						Value: "role-2",
-					},
-				},
-			},
-			Status: compv1alpha1.TailoredProfileStatus{
-				ID: "xccdf_compliance.openshift.io_profile_auditprofile-ocp4-cis",
-				OutputRef: compv1alpha1.OutputRef{
-					Name:      "auditprofile-ocp4-cis-tp",
-					Namespace: common.GetComplianceOperatorNamespace(),
-				},
-				State:        compv1alpha1.TailoredProfileStateReady,
-				ErrorMessage: "",
-			},
-		}
-
 		scratchTP = &compv1alpha1.TailoredProfile{
 			ObjectMeta: v1.ObjectMeta{
 				Name:        "scratch-tp",
 				Namespace:   common.GetComplianceOperatorNamespace(),
-				Annotations: nodeProfileAnnotations,
+				Annotations: platformProfileAnnotations,
 			},
 			Spec: compv1alpha1.TailoredProfileSpec{
 				Title:       "testing TP",
@@ -229,7 +157,6 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 		}
 
 		objs = append(objs, ssb, pBundleRhcos, profRhcosE8, tpRhcosE8, scratchTP, suite, setting)
-		objs = append(objs, pBundleOcp, profOcpCis, tpOcpCis)
 
 		scheme := scheme.Scheme
 		scheme.AddKnownTypes(compv1alpha1.SchemeGroupVersion, objs...)
@@ -249,12 +176,6 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 		}, pBundleRhcos)
 		Expect(err).To(BeNil())
 
-		err = client.Get(context.TODO(), types.NamespacedName{
-			Namespace: pBundleOcp.Namespace,
-			Name:      pBundleOcp.Name,
-		}, pBundleOcp)
-		Expect(err).To(BeNil())
-
 		profRhcosE8.OwnerReferences = append(profRhcosE8.OwnerReferences,
 			v1.OwnerReference{
 				Name:       pBundleRhcos.Name,
@@ -269,20 +190,6 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 		}, profRhcosE8)
 		Expect(err).To(BeNil())
 
-		profOcpCis.OwnerReferences = append(profOcpCis.OwnerReferences,
-			v1.OwnerReference{
-				Name:       pBundleOcp.Name,
-				Kind:       pBundleOcp.Kind,
-				APIVersion: pBundleOcp.APIVersion})
-		err = client.Update(context.TODO(), profOcpCis)
-		Expect(err).To(BeNil())
-
-		err = client.Get(context.TODO(), types.NamespacedName{
-			Namespace: profOcpCis.Namespace,
-			Name:      profOcpCis.Name,
-		}, profOcpCis)
-		Expect(err).To(BeNil())
-
 		tpRhcosE8.OwnerReferences = append(tpRhcosE8.OwnerReferences,
 			v1.OwnerReference{
 				Name:       profRhcosE8.Name,
@@ -295,20 +202,6 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 			Namespace: tpRhcosE8.Namespace,
 			Name:      tpRhcosE8.Name,
 		}, tpRhcosE8)
-		Expect(err).To(BeNil())
-
-		tpOcpCis.OwnerReferences = append(tpOcpCis.OwnerReferences,
-			v1.OwnerReference{
-				Name:       profOcpCis.Name,
-				Kind:       profOcpCis.Kind,
-				APIVersion: profOcpCis.APIVersion})
-		err = client.Update(context.TODO(), tpOcpCis)
-		Expect(err).To(BeNil())
-
-		err = client.Get(context.TODO(), types.NamespacedName{
-			Namespace: tpOcpCis.Namespace,
-			Name:      tpOcpCis.Name,
-		}, tpOcpCis)
 		Expect(err).To(BeNil())
 
 		scratchTP.OwnerReferences = append(scratchTP.OwnerReferences,
@@ -860,48 +753,17 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 	})
 
 	When("Validating roles", func() {
-		JustBeforeEach(func() {
-			ssb = &compv1alpha1.ScanSettingBinding{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "simple-compliance-requirements",
-					Namespace: common.GetComplianceOperatorNamespace(),
-				},
-				Profiles: []compv1alpha1.NamedObjectReference{
-					{
-						Name:     tpOcpCis.Name,
-						Kind:     tpOcpCis.Kind,
-						APIGroup: tpOcpCis.APIVersion,
-					},
-				},
-				SettingsRef: &compv1alpha1.NamedObjectReference{
-					Name:     setting.Name,
-					Kind:     setting.Kind,
-					APIGroup: setting.APIVersion,
-				},
-			}
-
-			ssb.Status.SetConditionPending()
-
-			err := reconciler.Client.Create(context.TODO(), ssb)
-			Expect(err).To(BeNil())
-
-			err = reconciler.Client.Get(context.TODO(), types.NamespacedName{
-				Namespace: ssb.Namespace,
-				Name:      ssb.Name,
-			}, ssb)
-			Expect(err).To(BeNil())
-		})
-
 		DescribeTable("Should pass the validation",
 			func(roles []string) {
 				ss := &compv1alpha1.ScanSetting{
 					Roles: roles,
 				}
-				err := reconciler.validateRoles(ssb, ss, log)
+				err := reconciler.validateRoles(ss)
 				Expect(err).To(BeNil())
 			},
 			Entry("master & worker", []string{"master", "worker"}),
 			Entry("@all", []string{"@all"}),
+			Entry("other samples", []string{"control-plane", "role-1", "role-2", "role-3"}),
 		)
 
 		When("Passing empty roles", func() {
@@ -909,7 +771,7 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 				ss := &compv1alpha1.ScanSetting{
 					Roles: []string{},
 				}
-				err := reconciler.validateRoles(ssb, ss, log)
+				err := reconciler.validateRoles(ss)
 				Expect(err).To(BeNil())
 				// TODO(jaosorior): Validate that a warning was issued
 			})
@@ -920,7 +782,7 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 				ss := &compv1alpha1.ScanSetting{
 					Roles: roles,
 				}
-				err := reconciler.validateRoles(ssb, ss, log)
+				err := reconciler.validateRoles(ss)
 				Expect(err).ToNot(BeNil(), "validation should have returned an error")
 			},
 			Entry("spaces", []string{"master "}),
@@ -928,28 +790,6 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 			Entry("too long", []string{strings.Repeat("foo", 100)}),
 			Entry("empty string", []string{""}),
 			Entry("invalid character", []string{"l33t$"}),
-		)
-
-		DescribeTable("Custom roles defined in TP variables should pass validation",
-			func(roles []string) {
-				ss := &compv1alpha1.ScanSetting{
-					Roles: roles,
-				}
-				err := reconciler.validateRoles(ssb, ss, log)
-				Expect(err).To(BeNil())
-			},
-			Entry("other samples", []string{"role-1", "role-2"}),
-		)
-
-		DescribeTable("Custom roles not defined in TP variables should not pass validation",
-			func(roles []string) {
-				ss := &compv1alpha1.ScanSetting{
-					Roles: roles,
-				}
-				err := reconciler.validateRoles(ssb, ss, log)
-				Expect(err).ToNot(BeNil())
-			},
-			Entry("other samples", []string{"role-3"}),
 		)
 	})
 

--- a/pkg/controller/tailoredprofile/tailoredprofile_controller.go
+++ b/pkg/controller/tailoredprofile/tailoredprofile_controller.go
@@ -3,8 +3,9 @@ package tailoredprofile
 import (
 	"context"
 	"fmt"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"strings"
+
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/ComplianceAsCode/compliance-operator/pkg/controller/metrics"
 	"github.com/ComplianceAsCode/compliance-operator/pkg/utils"
@@ -19,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -40,7 +42,7 @@ func (r *ReconcileTailoredProfile) SetupWithManager(mgr ctrl.Manager) error {
 
 // Add creates a new TailoredProfile Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager, met *metrics.Metrics, _ utils.CtlplaneSchedulingInfo) error {
+func Add(mgr manager.Manager, met *metrics.Metrics, _ utils.CtlplaneSchedulingInfo, _ *kubernetes.Clientset) error {
 	return add(mgr, newReconciler(mgr, met))
 }
 

--- a/vendor/k8s.io/client-go/rest/fake/fake.go
+++ b/vendor/k8s.io/client-go/rest/fake/fake.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is made a separate package and should only be imported by tests, because
+// it imports testapi
+package fake
+
+import (
+	"net/http"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+// CreateHTTPClient creates an http.Client that will invoke the provided roundTripper func
+// when a request is made.
+func CreateHTTPClient(roundTripper func(*http.Request) (*http.Response, error)) *http.Client {
+	return &http.Client{
+		Transport: roundTripperFunc(roundTripper),
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// RESTClient provides a fake RESTClient interface. It is used to mock network
+// interactions via a rest.Request, or to make them via the provided Client to
+// a specific server.
+type RESTClient struct {
+	NegotiatedSerializer runtime.NegotiatedSerializer
+	GroupVersion         schema.GroupVersion
+	VersionedAPIPath     string
+
+	// Err is returned when any request would be made to the server. If Err is set,
+	// Req will not be recorded, Resp will not be returned, and Client will not be
+	// invoked.
+	Err error
+	// Req is set to the last request that was executed (had the methods Do/DoRaw) invoked.
+	Req *http.Request
+	// If Client is specified, the client will be invoked instead of returning Resp if
+	// Err is not set.
+	Client *http.Client
+	// Resp is returned to the caller after Req is recorded, unless Err or Client are set.
+	Resp *http.Response
+}
+
+func (c *RESTClient) Get() *restclient.Request {
+	return c.Verb("GET")
+}
+
+func (c *RESTClient) Put() *restclient.Request {
+	return c.Verb("PUT")
+}
+
+func (c *RESTClient) Patch(pt types.PatchType) *restclient.Request {
+	return c.Verb("PATCH").SetHeader("Content-Type", string(pt))
+}
+
+func (c *RESTClient) Post() *restclient.Request {
+	return c.Verb("POST")
+}
+
+func (c *RESTClient) Delete() *restclient.Request {
+	return c.Verb("DELETE")
+}
+
+func (c *RESTClient) Verb(verb string) *restclient.Request {
+	return c.Request().Verb(verb)
+}
+
+func (c *RESTClient) APIVersion() schema.GroupVersion {
+	return c.GroupVersion
+}
+
+func (c *RESTClient) GetRateLimiter() flowcontrol.RateLimiter {
+	return nil
+}
+
+func (c *RESTClient) Request() *restclient.Request {
+	config := restclient.ClientContentConfig{
+		ContentType:  runtime.ContentTypeJSON,
+		GroupVersion: c.GroupVersion,
+		Negotiator:   runtime.NewClientNegotiator(c.NegotiatedSerializer, c.GroupVersion),
+	}
+	return restclient.NewRequestWithClient(&url.URL{Scheme: "https", Host: "localhost"}, c.VersionedAPIPath, config, CreateHTTPClient(c.do))
+}
+
+// do is invoked when a Request() created by this client is executed.
+func (c *RESTClient) do(req *http.Request) (*http.Response, error) {
+	if c.Err != nil {
+		return nil, c.Err
+	}
+	c.Req = req
+	if c.Client != nil {
+		return c.Client.Do(req)
+	}
+	return c.Resp, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1018,6 +1018,7 @@ k8s.io/client-go/plugin/pkg/client/auth/exec
 k8s.io/client-go/plugin/pkg/client/auth/gcp
 k8s.io/client-go/plugin/pkg/client/auth/oidc
 k8s.io/client-go/rest
+k8s.io/client-go/rest/fake
 k8s.io/client-go/rest/watch
 k8s.io/client-go/restmapper
 k8s.io/client-go/testing


### PR DESCRIPTION
# Runtime KubeletConfig Changes Proposed

This PR aims to optimize how we check the `KubeletConfig` rule. Currently, to check the runtime `KubeletConfig` configuration, we fetch all nodes `KubeletConfig`, compare them, and merge them into a file per MachineConfig pool. This approach relies on the node label, which might not work on other Kubernetes distros such as EKS, we use @all on EKS. Also, if there are more than two machine config pool or their names are not master/worker, they might need a tailored profile.

To address this issue, we propose to store the runtime `KubeletConfig` in a ConfigMap per node when a node scan is launched. Then, we mount the ConfigMap to the scanner pod to scan for it.

## Pros:

* No need to set up role variables using a tailored profile: Currently, our approach requires setting up role variables based on the machine config pool names, which can be cumbersome and error-prone. With the new approach, we can use a generic profile that works for all nodes.

* No need to set up more than one scan for two or more node roles: The previous approach required multiple scans if there were more than two node roles, but with the new approach, we can scan all nodes with the same command.

* Support for generic Kubernetes distributions: The new approach works with any Kubernetes distribution, not just OpenShift because it stores runtime kubeletconfig per node.

* All `KubeletConfig` rules will go back to the node rule: By storing the runtime `KubeletConfig` in a ConfigMap per node, we can scan for all rules that apply to that node and avoid the need for merging and comparing `KubeletConfig` from multiple nodes.

## Cons:

* We might need a way to save the mounted `KubeletConfig` along with the /host mount because we are running openscap in chroot mode: Since we are running openscap in chroot mode, there is only one single entrypoint. 
* We need to create a symlink for mounted `KubeletConfig` inside /host mount point. on the host
 

## What's changed:

* Use ConfigMap to store Runtime `KubeletConfig`
* Added ClienSet to get RESTClient for raw API , (In order to get runtime `KubeletConfig`, we need that, fetching nodes/proxy)
* Mount `KubeletConfig` configmap on the Scanner pod
* Hold on to applying remediation until all scans are done in the suite. 
* An additional pod to create symlink between mounted `KubeletConfig` to `/host/tmp/compliance-operator/kubeletconfig`
