### PR TITLE
OCPBUGS-4409: Support converting HTML links to Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixes
 
--
+- The operator now parses links from the compliance content and renders it in
+  custom resources accordingly.
 
 ### Internal Changes
 

--- a/pkg/utils/xml2text.go
+++ b/pkg/utils/xml2text.go
@@ -52,7 +52,8 @@ func xmlToHtml(in string, preRender bool, needsSpace bool) string {
 					builder.WriteString(formatElement(tok.Name, "<"))
 				}
 			} else {
-				builder.WriteString(formatElement(tok.Name, "<"))
+				// This is a special case so that we can look for links in <a> tags.
+				builder.WriteString(formatStartElement(tok))
 			}
 		case xml.EndElement:
 			builder.WriteString(formatElement(tok.Name, "</"))
@@ -87,6 +88,19 @@ func formatElement(elName xml.Name, tag string) string {
 		if elName.Local == "pre" && tag == "</" {
 			t += tag + "p>"
 		}
+	}
+
+	return t
+}
+
+func formatStartElement(e xml.StartElement) string {
+	t := formatElement(e.Name, "<")
+
+	if t == "<a>" {
+		// find the link
+		h := e.Attr[0].Name.Local
+		l := e.Attr[0].Value
+		t = "<" + e.Name.Local + " " + h + "=" + "\"" + l + "\"" + ">"
 	}
 	return t
 }

--- a/pkg/utils/xml2text_test.go
+++ b/pkg/utils/xml2text_test.go
@@ -7,7 +7,8 @@ import (
 
 var _ = Describe("XML conversions", func() {
 	const (
-		validXml = `System running in FIPS mode is indicated by kernel parameter<html:code>&#39;crypto.fips_enabled&#39;</html:code>. This parameter should be set to<html:code>1</html:code>in FIPS mode.&#xA;To enable FIPS mode, run the following command:<html:pre>fips-mode-setup --enable</html:pre>`
+		validXml         = `System running in FIPS mode is indicated by kernel parameter<html:code>&#39;crypto.fips_enabled&#39;</html:code>. This parameter should be set to<html:code>1</html:code>in FIPS mode.&#xA;To enable FIPS mode, run the following command:<html:pre>fips-mode-setup --enable</html:pre>`
+		validXmlWithLink = `User access to the cluster is managed through the identity provider. <html:a href="https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html">Understanding identity provider configuration | Authentication | OpenShift Container Platform</html:a>`
 	)
 
 	Context("XML to markdown", func() {
@@ -20,6 +21,14 @@ var _ = Describe("XML conversions", func() {
 
 		It("Should handle empty input", func() {
 			Expect(xmlToMarkdown("", false, false)).To(Equal(""))
+		})
+
+		It("Should perserve links", func() {
+			const (
+				text = "User access to the cluster is managed through the identity provider. Understanding identity provider configuration | Authentication | OpenShift Container Platform ( https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html )"
+			)
+			Expect(xmlToMarkdown(validXmlWithLink, false, false)).To(Equal(text))
+
 		})
 
 	})


### PR DESCRIPTION
The operator uses a handy library for converting HTML-like text to
markdown. This is nice for content text that informs users about what to
do with specific findings because it's formatted (e.g., adding lines
around formatted code snippet).

Unfortunately, the parser didn't account for links, which contain
multiple XML elements. The original `<a></a>` tag was preserved but the
actual link reference in `href=example.com` was dicarded.

This results in none of the links we put in content getting rendered in
the actual CRs where users can read and use them.

This commit adds some special handling for XML start elements to detect
cases where we're dealing with links and ensures they get propogated
into the final Markdown representation.
