### PR TITLE
Run 'make bundle' to commit bundle manifest changes

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1027,6 +1027,8 @@ spec:
           - compliance.openshift.io
           resources:
           - compliancesuites
+          - scansettings
+          - scansettingbindings
           verbs:
           - get
           - list


### PR DESCRIPTION
In cac/content testing, we are now using nightly operator images, which
are built after every commit to cac/compliance-operator. However,
bundle manifests are only refreshed on release, which means that some
code changes like rbac modifications are not reflected.

This causes CI failures in cac/content unless we release.
