### PR TITLE
Fetch CO deployment object for Platform CPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Update Kustomize and make target to be able to deploy on generic Kubernetes cluster.
 
+- Added an ability to identify which platform we are on using a CPE. We always
+  fetch api-checks-pod pod object, and save it to a dump file
+  when api-resource collector is running, CPE can use the dump file to
+  check the command line arguments to see if we are running on a specific
+  platform.
+
 ### Deprecations
 
 -
@@ -101,7 +107,6 @@ allow for smoother upgrades.
   e.g. `1h30m`. If the scan is not completed within the timeout, the
   corresponding scan will either fail or retry.
   See [To use timeout option for scan](https://github.com/ComplianceAsCode/compliance-operator/blob/master/doc/usage.md#to-use-timeout-option-for-scan) in `doc/usage.md` for details usage.
-
 
 ### Fixes
 

--- a/cmd/manager/api-resource-collector.go
+++ b/cmd/manager/api-resource-collector.go
@@ -17,6 +17,7 @@ package manager
 
 import (
 	"flag"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -71,6 +72,7 @@ func defineAPIResourceCollectorFlags(cmd *cobra.Command) {
 	cmd.Flags().String("profile", "", "The scan profile.")
 	cmd.Flags().String("warnings-output-file", "", "A file containing the warnings output.")
 	cmd.Flags().Bool("debug", false, "Print debug messages.")
+	cmd.Flags().String("platform", "", "The platform flag used by CPE detection.")
 
 	flags := cmd.Flags()
 

--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -293,7 +293,12 @@ func RunOperator(cmd *cobra.Command, args []string) {
 		setupLog.Error(err, "")
 		os.Exit(1)
 	}
-	pflag, _ := flags.GetString("platform")
+	// We need to set PLATFORM env var if the PLATFORM flag is set
+	pflag := os.Getenv("PLATFORM")
+	if pflag == "" {
+		pflag, _ = flags.GetString("platform")
+		os.Setenv("PLATFORM", pflag)
+	}
 	platform := getValidPlatform(pflag)
 
 	skipMetrics, _ := flags.GetBool("skip-metrics")

--- a/cmd/manager/scap.go
+++ b/cmd/manager/scap.go
@@ -163,6 +163,8 @@ func openNonEmptyFile(filename string) (*os.File, error) {
 
 func (c *scapContentDataStream) FigureResources(profile string) error {
 	// Always stage the clusteroperators/openshift-apiserver object for version detection.
+	namespace := os.Getenv("POD_NAMESPACE")
+	podName := os.Getenv("POD_NAME")
 	found := []utils.ResourcePath{
 		{
 			ObjPath:  "/version",
@@ -183,6 +185,10 @@ func (c *scapContentDataStream) FigureResources(profile string) error {
 		{
 			ObjPath:  "/api/v1/nodes",
 			DumpPath: "/api/v1/nodes",
+		},
+		{
+			ObjPath:  fmt.Sprintf("/api/v1/namespaces/%s/pods/%s", namespace, podName),
+			DumpPath: "/api/v1/namespaces/openshift-compliance/pods/api-checks-pod",
 		},
 	}
 

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -3,6 +3,7 @@ package compliancescan
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"strings"
 
@@ -311,6 +312,7 @@ func (r *ReconcileComplianceScan) newPlatformScanPod(scanInstance *compv1alpha1.
 		"--resultdir=" + PlatformScanDataRoot,
 		"--profile=" + scanInstance.Spec.Profile,
 		"--warnings-output-file=/reports/warning_output",
+		"--platform=" + os.Getenv("PLATFORM"),
 	}
 	if scanInstance.Spec.TailoringConfigMap != nil {
 		// NOTE(jaosorior): Adding the tailoring volume is handled in the
@@ -409,6 +411,24 @@ func (r *ReconcileComplianceScan) newPlatformScanPod(scanInstance *compv1alpha1.
 						{
 							Name:      "report-dir",
 							MountPath: "/reports",
+						},
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name: "POD_NAMESPACE",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.namespace",
+								},
+							},
+						},
+						{
+							Name: "POD_NAME",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.name",
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Added an ability to identify which platform we are on using a CPE. We always fetch the api-checks-pod object, and save it to a dump file when API-resource collector is running, CPE can use the dump file to check the command line arguments to see if we are running on a specific platform.

We now read the PLATFORM env variable, and override the platform command set in the deployment, because env can be set by the OLM subscription file.