### PR TITLE
Add ability to deploy CO on Hosted Cluster through OLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Enhancements
 
--
+- The operator can now be deployed on HyperShift HostedCluster using OLM with 
+  a special subscription file in `config/catalog/subscriptions-hypershift.yaml`.
+  This can be used to deploy from both downstream and upstream source. See
+  `doc/usage.md` for more details.
 
 ### Fixes
 
@@ -58,7 +61,7 @@ allow for smoother upgrades.
   are not available in json format, and we need to convert it to json format so that
   it can be read by OpenSCAP.
 
-- Added documentation on how to run platform scan on HyperShift Management
+- Added documentation on how to run a platform scan on HyperShift Management
   Cluster in `doc/usage.md`.
 
 ### Removals

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,10 @@ CATALOG_DIR=config/catalog
 CATALOG_SRC_FILE=$(CATALOG_DIR)/catalog-source.yaml
 CATALOG_GROUP_FILE=$(CATALOG_DIR)/operator-group.yaml
 CATALOG_SUB_FILE=$(CATALOG_DIR)/subscription.yaml
-
+# If plafform is set to hypershift, we will use a different subscription file
+ifeq ($(PLATFORM), hypershift)
+	CATALOG_SUB_FILE=$(CATALOG_DIR)/subscription-hypershift.yaml
+endif
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin

--- a/config/catalog/subscription-hypershift.yaml
+++ b/config/catalog/subscription-hypershift.yaml
@@ -1,0 +1,16 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: compliance-operator-sub
+  namespace: openshift-compliance
+spec:
+  channel: alpha
+  name: compliance-operator
+  source: compliance-operator
+  sourceNamespace: openshift-marketplace
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/worker: ""
+    env: 
+    - name: PLATFORM
+      value: "HyperShift"

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -573,7 +573,7 @@ error result.
 
 ## How to Use Compliance Operator with HyperShift Management Cluster
 
-Compliance Operator is able to run platform scan on the HyperShift Managment cluster
+Compliance Operator is able to run a platform scan on the HyperShift Managment cluster
 for the Hosted Cluster with a tailoredProfile.
 
 Currently, we only support CIS profile and PCI-DSS profile, in order to scan Hosted
@@ -617,3 +617,38 @@ settingsRef:
  kind: ScanSetting
  apiGroup: compliance.openshift.io/v1alpha1
  ```
+
+## How to Use Compliance Operator with HyperShift Hosted Cluster
+
+Compliance Operator is able to run a platform scan on the HyperShift Hosted cluster
+without any tailoredProfile. Any unsupport rules will be hidden from the `ComplianceCheckResult`.
+
+However, you need to use a special subscription file to install Compliance Operator on the
+Hosted Cluster from the OperatorHub. You can either add `spec.config` section from the following
+example to the existing subscription object, or use the following subscription file directly:
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: compliance-operator-
+  namespace: openshift-compliance
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: compliance-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: compliance-operator.v1.0.0
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/worker: ""
+    env: 
+    - name: PLATFORM
+      value: "HyperShift"
+```
+
+To install Compliance Operator on the Hosted Cluster from upstream using OLM, you can run the following command:
+
+`make catalog-deploy PLATFORM=HyperShift`
+


### PR DESCRIPTION
Added Subscription file needed for deploying CO on HyperShift Hosted Cluster through OLM, it can be used from both upstream or downstream sources.