### PR TITLE
Allow setting the OSCAP_DEBUG_LEVEL to tune OpenScap debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   This can be used to deploy from both downstream and upstream source. See
   `doc/usage.md` for more details.
 
+- The `SCAP_DEBUG_LEVEL` variable can now be used to set a custom OpenScap debug level
+  including the highest level `DEVEL`. This can be useful when debugging failed scans or issues
+  in the OpenScap scanner itself. Setting the variable takes precedence over the
+  `debug` attribute of the `ComplianceScan` CR. See `doc/usage.md` for more details.
+
 ### Fixes
 
 - The operator now parses links from the compliance content and renders it in

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -652,3 +652,33 @@ To install Compliance Operator on the Hosted Cluster from upstream using OLM, yo
 
 `make catalog-deploy PLATFORM=HyperShift`
 
+## Verbose OpenScap debugging information
+
+Compliance Operator uses OpenScap under the hood to perform the scans. In order to
+enable verbose debugging information from OpenScap, you can set the `OSCAP_DEBUG_LEVEL`
+environment variable.
+
+Setting the variable depends on your deployment method: if you installed the operator
+directly from upstream manifests, just add the variable to the main operator deployment
+(`.spec.template.spec.containers[0].env`), and then wait for restart of the operator pod.
+
+If the operator was installed through OLM, you can set the variable in the Subscription
+object, e.g.:
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+  name: compliance-operator-sub
+  namespace: openshift-compliance
+spec:
+  channel: alpha
+  name: compliance-operator
+  source: compliance-operator
+  sourceNamespace: openshift-marketplace
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/worker: ""
+    env:
+      - name: OSCAP_DEBUG_LEVEL
+        value: DEVEL
+ ```


### PR DESCRIPTION
In some cases it's handy to enable the DEVEL debug level for OpenScap,
e.g. to diagnose issues in the scanner itself.

In order to keep the semantics of the current `debug` attribute of the
scans, but still allow setting the very verbose debug level, let's
take the value of the `OSCAP_DEBUG_LEVEL` environment variable into
account.

The variable can be set either directly in the operator deployment or
through OLM Subscription.
