### PR TITLE
Harden the deployment and the profilebundle

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1288,7 +1288,11 @@ spec:
                     memory: 20Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
                   readOnlyRootFilesystem: true
+                  runAsNonRoot: true
                 volumeMounts:
                 - mountPath: /var/run/secrets/serving-cert
                   name: serving-cert

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -27,6 +27,9 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
           resources:
             requests:
               memory: "20Mi"

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -450,6 +450,7 @@ func (r *ReconcileProfileBundle) newWorkloadForBundle(pb *compliancev1alpha1.Pro
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: &falseP,
 								ReadOnlyRootFilesystem:   &trueP,
+								RunAsNonRoot:             &trueP,
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
@@ -477,6 +478,7 @@ func (r *ReconcileProfileBundle) newWorkloadForBundle(pb *compliancev1alpha1.Pro
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: &falseP,
 								ReadOnlyRootFilesystem:   &trueP,
+								RunAsNonRoot:             &trueP,
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
@@ -513,6 +515,10 @@ func (r *ReconcileProfileBundle) newWorkloadForBundle(pb *compliancev1alpha1.Pro
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: &falseP,
 								ReadOnlyRootFilesystem:   &trueP,
+								RunAsNonRoot:             &trueP,
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
 							},
 							Command: []string{
 								"/bin/sh", "-c",


### PR DESCRIPTION
Drops caps and makes both run as non-root explicitly to suppress
warnings from PSA.
