### PR TITLE
OLM: Provide an OCP-specific bundle kustomize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -432,7 +432,11 @@ bundle: check-operator-version operator-sdk manifests update-skip-range kustomiz
 	$(SDK_BIN) generate kustomize manifests --apis-dir=./pkg/apis -q
 	@echo "kustomize using deployment image $(IMG)"
 	cd config/manager && $(KUSTOMIZE) edit set image $(APP_NAME)=$(IMG)
+	if [ $(PLATFORM) = "openshift" ]; then \
+		sed -i 's%../default-bundle%../openshift-bundle%' config/manifests/kustomization.yaml; \
+	fi
 	$(KUSTOMIZE) build config/manifests | $(SDK_BIN) generate bundle -q $(BUNDLE_SA_OPTS) --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	git restore config/manifests/kustomization.yaml
 	@echo "Replacing RELATED_IMAGE_OPERATOR env reference in $(BUNDLE_CSV_FILE)"
 	@sed -i 's%$(DEFAULT_OPERATOR_IMAGE)%$(OPERATOR_IMAGE)%' $(BUNDLE_CSV_FILE)
 	$(SDK_BIN) bundle validate ./bundle

--- a/config/openshift-bundle/kustomization.yaml
+++ b/config/openshift-bundle/kustomization.yaml
@@ -1,0 +1,15 @@
+# bundle variant
+# Adds namespace to all resources.
+namespace: openshift-compliance
+
+bases:
+- ../crd
+- ../rbac
+- ../manager
+- ../ns
+
+patches:
+- path: manager_patch.yaml
+  target:
+    kind: Deployment
+    name: compliance-operator

--- a/config/openshift-bundle/manager_patch.yaml
+++ b/config/openshift-bundle/manager_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: compliance-operator
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"


### PR DESCRIPTION
Commit 03ef0398dd26d85737bfdbf6fe14f37b116abbb6 removed the OCP-specific
nodeSelector and tolerations from the default deployment at
`config/manager/deployment.yaml`. This would mean that the bundle
wouldn't have them at all, which is fine for generic Kube deployments,
but we still want to have them on OCP.

This patch introduces an OCP specific bundle kustomization that applies
a patch to the manager config that patches back the nodeSelector and the
tolerations.
