### PR TITLE
Update ocp branch references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -677,9 +677,9 @@ push-release: package-version-to-tag ## Create a commit for the release change, 
 	git tag "v$(TAG)"
 	git push $(GIT_REMOTE) "v$(TAG)"
 	git push $(GIT_REMOTE) "release-v$(TAG)"
-	git checkout ocp-0.1
+	git checkout ocp-1.0
 	git merge "release-v$(TAG)"
-	git push $(GIT_REMOTE) ocp-0.1
+	git push $(GIT_REMOTE) ocp-1.0
 
 .PHONY: release-images
 release-images: package-version-to-tag push catalog ## Build container images, bundle images, and catalog images and push them to an image registry (default: ghcr.io/complianceascode).

--- a/doc/contributor.md
+++ b/doc/contributor.md
@@ -227,8 +227,8 @@ an offical image registry. You can build new images and push using `make
 release-images`. Note that this operation also requires you have proper
 permissions on the remote registry.
 
-### Purpose of `ocp-0.1` Branch
+### Purpose of `ocp-1.0` Branch
 
-In order to fetch the source for OCP downstream pipeline, we have added a branch `ocp-0.1`,
+In order to fetch the source for OCP downstream pipeline, we have added a branch `ocp-1.0`,
 this branch should be synced to the latest upstream release branch. The sync process has 
 been included in `push-release` make target.


### PR DESCRIPTION
Now that we've graduated the operator to v1.0 and we have a specific
branch for that version called `ocp-1.0`, we should update those
references in the Makefile and documentation so the automation continues
to do what it should for Compliance Operator builds.
