### PR TITLE
Update UBI image to keep pace with GLIBC version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 RUN make manager
 
 # Step two: containerize compliance-operator
-FROM registry.access.redhat.com/ubi8/ubi-micro:latest
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
 
 ENV OPERATOR=/usr/local/bin/compliance-operator \
     USER_UID=1001 \


### PR DESCRIPTION
If you build the Compliance Operator from source and deploy it into a
cluster using `make deploy-local`, you'll see that the operator fails to
start because of a GLIBC error:

```
  compliance-operator: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by compliance-operator)
  compliance-operator: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by compliance-operator)
```

This is because the container image for golang:1.20 is referencing a
newer version fo GLIBC than what's available in the ubi8 minimal image.

This commit updates the ubi image so that we keep up with the GLIBC
version being referenced in newer golang versions.

 Fixes #372

