### PR TITLE
Docs: Fix URI for must-gather image

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -404,10 +404,10 @@ including advanced topics such as content building.
 ## Must-gather support
 
 An `oc adm must-gather` image for collecting operator information for debugging
-or support is available at `ghcr.io/complianceascode/compliance-operator-must-gather:latest`:
+or support is available at `ghcr.io/complianceascode/must-gather-ocp:latest`:
 
 ```
-$ oc adm must-gather --image=ghcr.io/complianceascode/compliance-operator-must-gather:latest
+$ oc adm must-gather --image=ghcr.io/complianceascode/must-gather-ocp:latest
 ```
 
 ## Metrics


### PR DESCRIPTION
The `must-gather` image's name is `must-gather-ocp`.

See https://github.com/orgs/ComplianceAsCode/packages?repo_name=compliance-operator