### PR TITLE
Grant permissions required metal-toolbox workflow

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   # Push to latest
   operator-container-push-latest:
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
     with:
       name: compliance-operator
@@ -16,6 +20,10 @@ jobs:
       vendor: 'Compliance Operator Authors'
   
   bundle-container-push-latest:
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
     with:
       name: compliance-operator-bundle
@@ -25,6 +33,10 @@ jobs:
       vendor: 'Compliance Operator Authors'
   
   openscap-container-push-latest:
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
     with:
       name: openscap-ocp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   container-main:
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
     with:
       name: compliance-operator
@@ -16,6 +20,10 @@ jobs:
       vendor: 'Compliance Operator Authors'
 
   bundle-container:
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
     with:
       name: compliance-operator-bundle


### PR DESCRIPTION
The `release` and `release-latest` GitHub Actions are failing with `invalid` error:
https://github.com/ComplianceAsCode/compliance-operator/actions/runs/5895677716