### PR TITLE
Introduce a file for assertions

### DIFF
--- a/tests/e2e/framework/assertions.go
+++ b/tests/e2e/framework/assertions.go
@@ -1,0 +1,36 @@
+package framework
+
+import (
+	"context"
+	"testing"
+
+	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (f *Framework) AssertMustHaveParsedProfiles(t *testing.T, pbName, productType, productName string) {
+	var l compv1alpha1.ProfileList
+	o := &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			compv1alpha1.ProfileBundleOwnerLabel: pbName,
+		}),
+	}
+	if err := f.Client.List(context.TODO(), &l, o); err != nil {
+		t.Fatalf("failed checking profiles in ProfileBundle: %s", err)
+	}
+	if len(l.Items) <= 0 {
+		t.Fatalf("failed to get profiles from ProfileBundle %s. Expected at least one but got %d", pbName, len(l.Items))
+	}
+
+	for _, p := range l.Items {
+		if p.Annotations[compv1alpha1.ProductTypeAnnotation] != productType {
+			t.Fatalf("expected %s to be %s, got %s instead", compv1alpha1.ProductTypeAnnotation, productType, p.Annotations[compv1alpha1.ProductTypeAnnotation])
+		}
+
+		if p.Annotations[compv1alpha1.ProductAnnotation] != productName {
+			t.Fatalf("expected %s to be %s, got %s instead", compv1alpha1.ProductAnnotation, productName, p.Annotations[compv1alpha1.ProductAnnotation])
+		}
+	}
+}

--- a/tests/e2e/framework/utils.go
+++ b/tests/e2e/framework/utils.go
@@ -33,32 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (f *Framework) AssertMustHaveParsedProfiles(pbName, productType, productName string) error {
-	var l compv1alpha1.ProfileList
-	o := &client.ListOptions{
-		LabelSelector: labels.SelectorFromSet(map[string]string{
-			compv1alpha1.ProfileBundleOwnerLabel: pbName,
-		}),
-	}
-	if err := f.Client.List(context.TODO(), &l, o); err != nil {
-		return err
-	}
-	if len(l.Items) <= 0 {
-		return fmt.Errorf("failed to get profiles from ProfileBundle %s. Expected at least one but got %d", pbName, len(l.Items))
-	}
-
-	for _, p := range l.Items {
-		if p.Annotations[compv1alpha1.ProductTypeAnnotation] != productType {
-			return fmt.Errorf("expected %s to be %s, got %s instead", compv1alpha1.ProductTypeAnnotation, productType, p.Annotations[compv1alpha1.ProductTypeAnnotation])
-		}
-
-		if p.Annotations[compv1alpha1.ProductAnnotation] != productName {
-			return fmt.Errorf("expected %s to be %s, got %s instead", compv1alpha1.ProductAnnotation, productName, p.Annotations[compv1alpha1.ProductAnnotation])
-		}
-	}
-	return nil
-}
-
 // AssertScanHasTotalCheckCounts asserts that the scan has the expected total check counts
 func (f *Framework) AssertScanHasTotalCheckCounts(namespace, scanName string) error {
 	// check if scan has annotation

--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -108,9 +108,7 @@ func TestProfileModification(t *testing.T) {
 	if err := f.WaitForProfileBundleStatus(pbName, compv1alpha1.DataStreamValid); err != nil {
 		t.Fatalf("failed waiting for the ProfileBundle to become available: %s", err)
 	}
-	if err := f.AssertMustHaveParsedProfiles(pbName, string(compv1alpha1.ScanTypeNode), "redhat_enterprise_linux_coreos_4"); err != nil {
-		t.Fatalf("failed checking profiles in ProfileBundle: %s", err)
-	}
+	f.AssertMustHaveParsedProfiles(t, pbName, string(compv1alpha1.ScanTypeNode), "redhat_enterprise_linux_coreos_4")
 
 	// Check that the rule we removed exists in the original profile
 	removedRuleName := prefixName(pbName, removedRule)
@@ -215,9 +213,7 @@ func TestProfileISTagUpdate(t *testing.T) {
 	if err := f.WaitForProfileBundleStatus(pbName, compv1alpha1.DataStreamValid); err != nil {
 		t.Fatalf("failed waiting for the ProfileBundle to become available: %s", err)
 	}
-	if err := f.AssertMustHaveParsedProfiles(pbName, string(compv1alpha1.ScanTypeNode), "redhat_enterprise_linux_coreos_4"); err != nil {
-		t.Fatalf("failed checking profiles in ProfileBundle: %s", err)
-	}
+	f.AssertMustHaveParsedProfiles(t, pbName, string(compv1alpha1.ScanTypeNode), "redhat_enterprise_linux_coreos_4")
 
 	// Check that the rule we removed exists in the original profile
 	removedRuleName := prefixName(pbName, removedRule)
@@ -324,9 +320,7 @@ func TestProfileISTagOtherNs(t *testing.T) {
 	if err := f.WaitForProfileBundleStatus(pbName, compv1alpha1.DataStreamValid); err != nil {
 		t.Fatalf("failed waiting for ProfileBundle to parse: %s", err)
 	}
-	if err := f.AssertMustHaveParsedProfiles(pbName, string(compv1alpha1.ScanTypeNode), "redhat_enterprise_linux_coreos_4"); err != nil {
-		t.Fatalf("failed to assert profiles in ProfileBundle %s: %s", pbName, err)
-	}
+	f.AssertMustHaveParsedProfiles(t, pbName, string(compv1alpha1.ScanTypeNode), "redhat_enterprise_linux_coreos_4")
 
 	// Check that the rule we removed exists in the original profile
 	removedRuleName := prefixName(pbName, removedRule)


### PR DESCRIPTION
We have a smattering of assertions in different files within the
`framework` package. Even if you rely on your IDE to fill these in for
you, organizing them is good practice.

This commit adds a new file specifically for assertions, and populates
it with an existing assertion used in tests.

It also implements the ability for assertions to handle test outcomes,
instead of returning booleans, forcing the callers to handle test
outcomes. Although having test outcomes (e.g., `FailNow`) in the test is
clear, we check and call `Fatal` a lot across the test code. Moving the
outcome into the assertion allows the code to be a little more dry, and
clear if everyone agrees assertions should accept that reponsibility.
