### PR TITLE
CMP-2130: Implement support for profile versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   more ergonomic to pause scans during maintenance periods. See the
   [enhancement](https://github.com/ComplianceAsCode/compliance-operator/pull/375)
   for more details.
+- Implemented support for an optional `version` attribute on `Profile` custom
+  resources.
 
 ### Fixes
 

--- a/bundle/manifests/compliance.openshift.io_compliancecheckresults.yaml
+++ b/bundle/manifests/compliance.openshift.io_compliancecheckresults.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: compliancecheckresults.compliance.openshift.io
 spec:

--- a/bundle/manifests/compliance.openshift.io_complianceremediations.yaml
+++ b/bundle/manifests/compliance.openshift.io_complianceremediations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: complianceremediations.compliance.openshift.io
 spec:

--- a/bundle/manifests/compliance.openshift.io_compliancescans.yaml
+++ b/bundle/manifests/compliance.openshift.io_compliancescans.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: compliancescans.compliance.openshift.io
 spec:

--- a/bundle/manifests/compliance.openshift.io_compliancesuites.yaml
+++ b/bundle/manifests/compliance.openshift.io_compliancesuites.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: compliancesuites.compliance.openshift.io
 spec:
@@ -323,6 +323,11 @@ spec:
                   scheduled scans will start running only after the initial results
                   are ready.
                 type: string
+              suspend:
+                default: false
+                description: Defines if a schedule should be suspended and is a boolean
+                  value, defaulting to False.
+                type: boolean
             required:
             - scans
             type: object

--- a/bundle/manifests/compliance.openshift.io_profilebundles.yaml
+++ b/bundle/manifests/compliance.openshift.io_profilebundles.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: profilebundles.compliance.openshift.io
 spec:

--- a/bundle/manifests/compliance.openshift.io_profiles.yaml
+++ b/bundle/manifests/compliance.openshift.io_profiles.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: profiles.compliance.openshift.io
 spec:
@@ -17,7 +17,14 @@ spec:
     singular: profile
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .version
+      name: Version
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Profile is the Schema for the profiles API
@@ -55,6 +62,8 @@ spec:
             nullable: true
             type: array
             x-kubernetes-list-type: atomic
+          version:
+            type: string
         required:
         - description
         - id
@@ -62,6 +71,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/bundle/manifests/compliance.openshift.io_rules.yaml
+++ b/bundle/manifests/compliance.openshift.io_rules.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: rules.compliance.openshift.io
 spec:

--- a/bundle/manifests/compliance.openshift.io_scansettingbindings.yaml
+++ b/bundle/manifests/compliance.openshift.io_scansettingbindings.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: scansettingbindings.compliance.openshift.io
 spec:
@@ -16,7 +16,11 @@ spec:
     singular: scansettingbinding
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ScanSettingBinding is the Schema for the scansettingbindings
@@ -124,6 +128,8 @@ spec:
                 - name
                 type: object
                 x-kubernetes-map-type: atomic
+              phase:
+                type: string
             type: object
         type: object
     served: true

--- a/bundle/manifests/compliance.openshift.io_scansettings.yaml
+++ b/bundle/manifests/compliance.openshift.io_scansettings.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: scansettings.compliance.openshift.io
 spec:
@@ -246,6 +246,11 @@ spec:
               to scan all the nodes or not. `true` means that the operator should
               be strict and error out. `false` means that we don't need to be strict
               and we can proceed.
+            type: boolean
+          suspend:
+            default: false
+            description: Defines if a schedule should be suspended and is a boolean
+              value, defaulting to False.
             type: boolean
           timeout:
             default: 30m

--- a/bundle/manifests/compliance.openshift.io_tailoredprofiles.yaml
+++ b/bundle/manifests/compliance.openshift.io_tailoredprofiles.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: tailoredprofiles.compliance.openshift.io
 spec:

--- a/bundle/manifests/compliance.openshift.io_variables.yaml
+++ b/bundle/manifests/compliance.openshift.io_variables.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   creationTimestamp: null
   name: variables.compliance.openshift.io
 spec:

--- a/config/crd/bases/compliance.openshift.io_profiles.yaml
+++ b/config/crd/bases/compliance.openshift.io_profiles.yaml
@@ -17,7 +17,14 @@ spec:
     singular: profile
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .version
+      name: Version
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Profile is the Schema for the profiles API
@@ -55,6 +62,8 @@ spec:
             nullable: true
             type: array
             x-kubernetes-list-type: atomic
+          version:
+            type: string
         required:
         - description
         - id
@@ -62,3 +71,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/pkg/apis/compliance/v1alpha1/profile_types.go
+++ b/pkg/apis/compliance/v1alpha1/profile_types.go
@@ -35,12 +35,16 @@ type ProfilePayload struct {
 	// +optional
 	// +listType=atomic
 	Values []ProfileValue `json:"values,omitempty"`
+	// +optional
+	Version string `json:"version"`
 }
 
 // +kubebuilder:object:root=true
 
 // Profile is the Schema for the profiles API
 // +kubebuilder:resource:path=profiles,scope=Namespaced,shortName=profs;prof
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=`.version`
 type Profile struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -311,6 +311,11 @@ func parseProfileFromNode(profileRoot *xmlquery.Node, pb *cmpv1alpha1.ProfileBun
 		if description == nil {
 			return LogAndReturnError("no description in profile")
 		}
+		v := profileObj.SelectElement("xccdf-1.2:version")
+		var version string
+		if v != nil {
+			version = v.InnerText()
+		}
 		log.Info("Found profile", "id", id)
 
 		// In case the profile sets its own CPE string
@@ -362,6 +367,7 @@ func parseProfileFromNode(profileRoot *xmlquery.Node, pb *cmpv1alpha1.ProfileBun
 				Description: utils.XmlNodeAsMarkdown(description),
 				Rules:       selectedrules,
 				Values:      selectedvalues,
+				Version:     version,
 			},
 		}
 

--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -55,6 +55,21 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
+func TestProfileVersion(t *testing.T) {
+	t.Parallel()
+	f := framework.Global
+
+	profile := &compv1alpha1.Profile{}
+	// We know this profile has a version and it's set in the ComplianceAsCode/content
+	profileName := "ocp4-cis"
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{Namespace: f.OperatorNamespace, Name: profileName}, profile); err != nil {
+		t.Fatalf("failed to get profile %s: %s", profileName, err)
+	}
+	if profile.Version == "" {
+		t.Fatalf("expected profile %s to have version set", profileName)
+	}
+}
+
 func TestProfileModification(t *testing.T) {
 	t.Parallel()
 	f := framework.Global


### PR DESCRIPTION
This commit adds support for an optional version attribute for Profile
custom resources. This attribute is parsed out of the datastream and set
on the Profile by the compliance operator. It's not intended for end
users to supply their own version.

Future patches may expand on this concept to support multiple versions
of a single profile.
