### PR TITLE
Manually upgrade glibc

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,6 +15,11 @@ ENV OPERATOR=/usr/local/bin/compliance-operator \
     USER_UID=1001 \
     USER_NAME=compliance-operator
 
+RUN true \
+    && microdnf upgrade glibc \
+    && microdnf clean all \
+    && true
+
 # install operator binary
 COPY --from=builder /go/src/github.com/openshift/compliance-operator/build/_output/bin/compliance-operator ${OPERATOR}
 

--- a/images/openscap/Dockerfile
+++ b/images/openscap/Dockerfile
@@ -10,6 +10,7 @@ LABEL \
 
 RUN true \
     && microdnf install -y openscap-scanner \
+    && microdnf upgrade glibc \
     && microdnf clean all \
     && true
 


### PR DESCRIPTION
Manually upgrade glibc to address
https://github.com/advisories/GHSA-m77w-6vjw-wh2f until we get a new UBI
image.
