### PR TITLE
Disable HTTP2 for metrics and the results server

### DIFF
--- a/cmd/manager/resultserver.go
+++ b/cmd/manager/resultserver.go
@@ -181,6 +181,7 @@ func server(c *resultServerConfig) {
 
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"http/1.1"},
 	}
 	// Configures TLS 1.2
 	tlsConfig = libgocrypto.SecureTLSConfig(tlsConfig)

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -140,6 +140,7 @@ func (m *Metrics) Start(ctx context.Context) error {
 
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"http/1.1"},
 	}
 	tlsConfig = libgocrypto.SecureTLSConfig(tlsConfig)
 	server := &http.Server{


### PR DESCRIPTION
Let's use HTTP 1.1 in these cases to mitigate the risk of resource
consumption through streams.
