### PR TITLE
Add an integration test to verify HTTP version usage

### DIFF
--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -2795,3 +2795,20 @@ func TestScheduledSuiteTimeoutFail(t *testing.T) {
 		t.Fatal("The scan should have the timeout annotation")
 	}
 }
+
+func TestResultServerHTTPVersion(t *testing.T) {
+	t.Parallel()
+	f := framework.Global
+	endpoints := []string{
+		fmt.Sprintf("https://metrics.%s.svc:8585/metrics-co", f.OperatorNamespace),
+		fmt.Sprintf("http://metrics.%s.svc:8383/metrics", f.OperatorNamespace),
+	}
+
+	expectedHTTPVersion := "HTTP/1.1"
+	for _, endpoint := range endpoints {
+		err := f.AssertMetricsEndpointUsesHTTPVersion(endpoint, expectedHTTPVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Since we're being explicit about which version we're using, let's make
sure we have a test for it.
