### PR TITLE
Build the operator for FIPS enabled environments

### DIFF
--- a/cmd/manager/fips.go
+++ b/cmd/manager/fips.go
@@ -1,0 +1,18 @@
+//go:build fips_enabled
+// +build fips_enabled
+
+// FIXME(rhmdnd): This was copied from openshift/boilerplate. We should
+// consider migrating our `make` targets to using boilerplate, which include
+// handy approaches and tools to enabling things consistently across
+// operators.
+
+package manager
+
+import (
+	_ "crypto/tls/fipsonly"
+	"fmt"
+)
+
+func init() {
+	fmt.Println("***** Starting with FIPS crypto enabled *****")
+}


### PR DESCRIPTION
This commit does a few things to make sure the Compliance Operator is built
so that it can run in FIPS-enabled clusters.

- Uses ubi8-minimal for openssl for container image builds
- Set CGO_ENABLE=1
- Use a boilerplate base image for building the operator container image
- Set the appropriate flags so that go builds with FIPS enabled and
  links dynamically to the necessary openssl libraries
- Includes a FIPS-enabled go source file that implements a "FIPS or Die"
  feature

The ubi9-micro image we were using was ideal for minimal dependencies,
but it doesn't include openssl, which  we need to support FIPS. This
commit changes the operator container image to fix this.

Set CGO_ENABLE=1 so that go can link dynamically to the openssl library.

Use an image from app-sre/boilerplate to build the operator binary. This
is needed so that golang links the necessary libraries.

Set the appropriate golang experimental flags at build time so the
complier knows to build for FIPS-enabled clusters. The other part of
this change is a golang file we need to keep in-tree. If we're missing
either, the build won't produce container images for FIPS-enabled
environments.

This commit is a smattering of openshift/boilerplate code that enables
FIPS for operator builds. Eventually, we should reconsider maintaining
our hand-rolled Makefiles for boilerplate, which contains handy tools
and scripts for maintaining common operator components.
