### PR TITLE
Implement build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -422,7 +422,7 @@ build: generate fmt vet test-unit ## Build the operator binary.
 	$(GO) build \
 		-trimpath \
 		-ldflags=-buildid= \
-		-o $(TARGET_OPERATOR) $(MAIN_PKG)
+		-o $(TARGET_OPERATOR) $(BUILD_FLAGS) $(MAIN_PKG)
 
 .PHONY: manager
 manager: build  ## Alias for make build.


### PR DESCRIPTION
Add the ability to pass in build flags (e.g., from Dockerfiles) in cases
were we need to specify them. For example, this can be useful for
enabling FIPS builds.
