### PR TITLE
CMP-2176: Implement `replaces` in bundle CSV

### DIFF
--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -1557,4 +1557,5 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  version: 0.1.53
+  replaces: 1.3.1
+  version: 1.4.0

--- a/utils/get-current-version.sh
+++ b/utils/get-current-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+CSV="$ROOT_DIR/bundle/manifests/compliance-operator.clusterserviceversion.yaml"
+
+OLD_VERSION=$(yq '.spec.version' "$CSV")
+echo "$OLD_VERSION"


### PR DESCRIPTION
The `replaces` attribute of an operator's CSV helps OLM build
relationships between operators, making it easier for users to install
older versions of an operator (or know which version supercedes the
version they're using).

This commit reintroduces the `replaces` attribute, since it was being
deleted before as a side-effect of an operator-sdk update. It should be
safe to include again.
