### PR TITLE
CMP-3009: Update manifest to include new aggregator permissions

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1542,8 +1542,10 @@ spec:
           verbs:
           - create
           - get
+          - list
           - update
           - patch
+          - delete
         - apiGroups:
           - compliance.openshift.io
           resources:


### PR DESCRIPTION
A recent change improved how the aggregator pod handled compliance check
results, by allowing it to find all existing results, and prune results
that were stale. This makes the state of the Compliance Check Results
consistent with the latest run:

  https://github.com/ComplianceAsCode/compliance-operator/pull/221

To do this though, we needed to give the aggregator pod permissions to
list and delete Compliance Check Results. But, in that patch we forgot
to update the bundle build to include those new permissions. This means
bundle installs are currently broken for all scans because the
aggregator pod gets stuck in a crashloop, due to failing permissions.

This commit updates the manifest for the bundles so that bundle installs
work again.
