### PR TITLE
Fix dpanic during remediation logging

### DIFF
--- a/pkg/controller/compliancescan/forwarder.go
+++ b/pkg/controller/compliancescan/forwarder.go
@@ -31,7 +31,7 @@ func (f logForwarder) SendComplianceCheckResult(c *compv1alpha1.ComplianceCheckR
 }
 
 func (f logForwarder) SendComplianceRemediation(r *compv1alpha1.ComplianceRemediation) error {
-	logf.Log.Info("ComplianceRemediation", r.Spec, r.Status)
+	logf.Log.Info("ComplianceRemediation", "ComplianceRemediation.Name", r.Name)
 	return nil
 }
 


### PR DESCRIPTION
If a scan has debug enabled, the aggregator will log the remedation
information. Previously, you'd see a `dpanic` in the logs because the
keys passed into the logger were invalid.

This commit updates the logging implementation to use the correct key
pairs for the log.
