### PR TITLE
Remove product validation in ScanSettingBinding

### DIFF
--- a/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
@@ -747,7 +747,7 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("Should not create a suite", func() {
+		It("Should create a suite", func() {
 			_, err := reconciler.Reconcile(context.TODO(), reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: ssb.Namespace,
@@ -762,10 +762,10 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 			}, ssb)
 			Expect(err).To(BeNil())
 			Expect(ssb.Status.Conditions.GetCondition("Ready")).ToNot(BeNil())
-			Expect(ssb.Status.Conditions.IsTrueFor("Ready")).To(BeFalse())
+			Expect(ssb.Status.Conditions.IsTrueFor("Ready")).To(BeTrue())
 
 			err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: ssb.Name, Namespace: ssb.Namespace}, suite)
-			Expect(err).ToNot(BeNil())
+			Expect(err).To(BeNil())
 		})
 	})
 

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -326,6 +326,20 @@ func TestMixProductScan(t *testing.T) {
 				if s.Phase != compv1alpha1.PhaseDone {
 					t.Fatalf("expected scan %s to be done", scan)
 				}
+				// E2e tests have been flaky because of the file_permissions_var_log_kube_audit
+				// rule. This is because there is a bug in the API-server in old versions of OCP[1][2].
+				// For now, we'll just check that the scan is not inconsistent until we upgrade
+				// to a version that has the fix.
+				// [1]https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+				// [2]https://github.com/ComplianceAsCode/content/commit/6343659d1d25e97c66a5c1eaf8eb2ee20d1af920
+				if s.Result == compv1alpha1.ResultInconsistent {
+					// check if the scan is "ocp4-moderate-node-master"
+					if scan != "ocp4-moderate-node-master" {
+						t.Fatalf("expected scan %s not to be inconsistent", scan)
+					}
+				} else if s.Result != compv1alpha1.ResultCompliant && s.Result != compv1alpha1.ResultNonCompliant {
+					t.Fatalf("expected scan %s to be compliant or non-compliant", scan)
+				}
 				break
 			}
 		}

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -326,18 +326,7 @@ func TestMixProductScan(t *testing.T) {
 				if s.Phase != compv1alpha1.PhaseDone {
 					t.Fatalf("expected scan %s to be done", scan)
 				}
-				// E2e tests have been flaky because of the file_permissions_var_log_kube_audit
-				// rule. This is because there is a bug in the API-server in old versions of OCP[1][2].
-				// For now, we'll just check that the scan is not inconsistent until we upgrade
-				// to a version that has the fix.
-				// [1]https://bugzilla.redhat.com/show_bug.cgi?id=2001442
-				// [2]https://github.com/ComplianceAsCode/content/commit/6343659d1d25e97c66a5c1eaf8eb2ee20d1af920
-				if s.Result == compv1alpha1.ResultInconsistent {
-					// check if the scan is "ocp4-moderate-node-master"
-					if scan != "ocp4-moderate-node-master" {
-						t.Fatalf("expected scan %s not to be inconsistent", scan)
-					}
-				} else if s.Result != compv1alpha1.ResultCompliant && s.Result != compv1alpha1.ResultNonCompliant {
+				if s.Result != compv1alpha1.ResultCompliant && s.Result != compv1alpha1.ResultNonCompliant {
 					t.Fatalf("expected scan %s to be compliant or non-compliant", scan)
 				}
 				break


### PR DESCRIPTION
This commit removes product validation in ScanSettingBinding so we can launch both `rhcos4` and `ocp4-node` scan in one SSB.

ex.

```
apiVersion: compliance.openshift.io/v1alpha1
kind: ScanSettingBinding
metadata:
  name: ocp4-rhcos4-moderate-mix
  namespace: openshift-compliance
profiles:
- apiGroup: compliance.openshift.io/v1alpha1
  kind: Profile
  name: ocp4-moderate-node
- apiGroup: compliance.openshift.io/v1alpha1
  kind: Profile
  name: rhcos4-moderate
- apiGroup: compliance.openshift.io/v1alpha1
  kind: Profile
  name: ocp4-moderate
settingsRef:
  apiGroup: compliance.openshift.io/v1alpha1
  kind: ScanSetting
  name: default
```