### PR TITLE
CMP-2401: Add STIG reference parser

### DIFF
--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -822,6 +822,10 @@ func newStandardParser() *referenceParser {
 	if pcidssperr != nil {
 		log.Error(nciperr, "Could not register PCI-DSS reference parser") // not much we can do here..
 	}
+	stigperr := p.registerStandard("STIG", `^https://public\.cyber\.mil/stigs/downloads/\?_dl_facet_stigs=container-platform`)
+	if stigperr != nil {
+		log.Error(stigperr, "Could not register STIG reference parser") // not much we can do here..
+	}
 
 	p.registerFormatter(profileOperatorFormatter)
 	p.registerFormatter(rhacmFormatter)


### PR DESCRIPTION
This ensures that rules part of STIG profile contain annotations with the STIGID.

One can see the STIG references as annotation on the rule when deployed together with content from https://github.com/ComplianceAsCode/content/pull/11593 

```
$ CONTENT_IMAGE=ghcr.io/complianceascode/k8scontent:11593 make deploy-local
$ oc get rule  ocp4-api-server-tls-security-profile -oyaml
...
metadata:
  annotations:
    compliance.openshift.io/image-digest: pb-ocp4vkwnn
    compliance.openshift.io/profiles: ocp4-moderate-rev-4,ocp4-stig,ocp4-high-rev-4,ocp4-stig-v1r1,ocp4-moderate,ocp4-high,ocp4-nerc-cip
    compliance.openshift.io/rule: api-server-tls-security-profile
    control.compliance.openshift.io/NIST-800-53: SC-8;SC-8(1)
    control.compliance.openshift.io/STIG: CNTR-OS-000020
    policies.open-cluster-management.io/controls: SC-8,SC-8(1),CNTR-OS-000020
    policies.open-cluster-management.io/standards: NIST-800-53,STIG
...
```