### PR TITLE
Fix e2e for TestManualRulesTailoredProfile

### DIFF
--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -2712,7 +2712,7 @@ func TestManualRulesTailoredProfile(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      suiteName,
 			Namespace: f.OperatorNamespace,
-			Labels: map[string]string{
+			Annotations: map[string]string{
 				compv1alpha1.DisableOutdatedReferenceValidation: "true",
 			},
 		},


### PR DESCRIPTION
We were using DisableOutdatedReferenceValidation as a label instead of an annotation, this commit fixes it