### PR TITLE
Update action workflows on PR image generation

### DIFF
--- a/.github/workflows/pr-image-trigger.yml
+++ b/.github/workflows/pr-image-trigger.yml
@@ -1,0 +1,29 @@
+---
+name: PR Image Trigger
+
+on:
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  get-pr-number:
+    name: Get PR number
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr/

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,22 +1,45 @@
 name: Release PR image
 
 on:
-  pull_request:
+  workflow_run:
+    workflows: [PR Image Trigger]
     types:
-    - opened
-    - reopened
-    - synchronize
+      - completed
 
 jobs:
   get-pr-number:
     name: Get PR number
     runs-on: ubuntu-latest
     outputs:
-      pr-number: ${{ steps.get-pr-number.outputs.pr-number }}
+      pr-number: ${{ steps.pr_number.outputs.pr_number }}
     steps:
-      - name: Get PR number
-        id: get-pr-number
-        run: echo "::set-output name=pr-number::$(echo ${GITHUB_REF#refs/pull/} | cut -d'/' -f1)"
+      - name: 'Download artifacts'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_number"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+      - name: 'Unzip artifact'
+        run: unzip pr_number.zip
+      - name: 'Read PR number'
+        id: pr_number
+        run: |
+          echo "pr_number=$(cat pr_number)" >> "$GITHUB_OUTPUT"
+
   operator-container-push-pr:
     needs: get-pr-number
     permissions:
@@ -30,6 +53,7 @@ jobs:
       tag: ${{ needs.get-pr-number.outputs.pr-number }}
       dockerfile_path: build/Dockerfile
       vendor: 'Compliance Operator Authors'
+      checkout_ref: refs/pull/${{ needs.get-pr-number.outputs.pr-number }}/head
   
   bundle-container-push-pr:
     needs: get-pr-number
@@ -44,7 +68,8 @@ jobs:
       tag: ${{ needs.get-pr-number.outputs.pr-number }}
       dockerfile_path: bundle.Dockerfile
       vendor: 'Compliance Operator Authors'
-  
+      checkout_ref: refs/pull/${{ needs.get-pr-number.outputs.pr-number }}/head
+
   openscap-container-push-pr:
     needs: get-pr-number
     permissions:
@@ -58,76 +83,26 @@ jobs:
       tag: ${{ needs.get-pr-number.outputs.pr-number }}
       dockerfile_path: images/openscap/Dockerfile
       vendor: 'Compliance Operator Authors'
+      checkout_ref: refs/pull/${{ needs.get-pr-number.outputs.pr-number }}/head
 
   catalog-container-push-pr:
-    runs-on: ubuntu-latest
     needs:
     - get-pr-number
     - bundle-container-push-pr
-    if: always() # remove this after we fix signing
-
     permissions:
-      packages: write
       contents: read
-
-    outputs:
-      image-digest: ${{ steps.container_info.outputs.image-digest }}
-      image-tags: ${{ steps.container_info.outputs.image-tags }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.6.0
-
-      - name: Login to ghcr.io
-        uses: docker/login-action@v3.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/complianceascode/compliance-operator-catalog
-          tags: |
-            type=raw,value=${{ needs.get-pr-number.outputs.pr-number }}
-            type=sha,format=long
-          labels: |
-            org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
-            org.opencontainers.image.title=compliance-operator-catalog
-            org.opencontainers.image.version=latest
-            org.opencontainers.image.licenses='Apache-2.0'
-            org.opencontainers.image.vendor='Compliance Operator Authors'
-        
-      - name: Generate catalog dockerfile
-        id: generate_catalog_dockerfile
-        run: |
-          make catalog-docker BUNDLE_IMGS=ghcr.io/complianceascode/compliance-operator-bundle:${{ needs.get-pr-number.outputs.pr-number }}
-
-      - name: Build container images and push
-        id: docker_build
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: catalog.Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: true
-          platforms: 'linux/amd64'
-
-      - name: Get container info
-        id: container_info
-        run: |
-          image_tags="${{ needs.get-pr-number.outputs.pr-number }}"
-          echo "::set-output name=image-digest::${{ steps.docker_build.outputs.digest }}"
-          echo "::set-output name=image-tags::${image_tags}"
+      id-token: write
+      packages: write
+    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
+    with:
+      name: compliance-operator-catalog
+      registry_org: complianceascode
+      tag: ${{ needs.get-pr-number.outputs.pr-number }}
+      dockerfile_path: catalog.Dockerfile
+      vendor: 'Compliance Operator Authors'
+      checkout_ref: refs/pull/${{ needs.get-pr-number.outputs.pr-number }}/head
+      prepare_command: |
+        make catalog-deploy CATALOG_IMG=ghcr.io/complianceascode/compliance-operator-catalog:${{ needs.get-pr-number.outputs.pr-number }}
 
   comment-pr:
     needs: 


### PR DESCRIPTION
Update the action to build image for each PR, so image can be built even when PR is created from a fork.