### PR TITLE
OCPBUGS-19690: Enable host network to access host sysctls

### DIFF
--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -289,6 +289,8 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 			NodeSelector: map[string]string{
 				corev1.LabelHostname: node.Labels[corev1.LabelHostname],
 			},
+			HostNetwork: true,
+			DNSPolicy: "ClusterFirstWithHostNet",
 			RestartPolicy: corev1.RestartPolicyOnFailure,
 			Volumes: []corev1.Volume{
 				{


### PR DESCRIPTION
* With `HostNetwork: true` the sysctl `net.core.bpf_jit_harden` becomes visible to the `scanner` container.
  Below is a pod that has access to the sysctls:
```yaml 
apiVersion: v1
kind: Pod
metadata:
  name: list-sysctls
spec:
  hostNetwork: true
  volumes:
    - name: host
      hostPath:
        path: /
        type: Directory
  containers:
  - name: list
    command:
      - cat
      - /host/proc/sys/net/ipv6/conf/all/accept_ra
      - /host/proc/sys/net/core/bpf_jit_harden
    image: registry.access.redhat.com/ubi8/ubi-minimal
    securityContext:
      runAsUser: 0
      privileged: true
    volumeMounts:
    - name: host
      mountPath: /host
``` 
`$ oc create -f list-syctls-proc.yaml`
`$ oc logs list-sysctls `

* `DNSPolicy: ClusterFirstWithHostNet` allows the CO to upload to `resultserver`, otherwise we get the following error:
`
{"level":"info","ts":"2024-03-15T18:45:57Z","logger":"cmd","msg":"Trying to upload to resultserver","url":"https://upstream-rhcos4-high-worker-rs:8443/"}
{"level":"error","ts":"2024-03-15T18:45:57Z","logger":"cmd","msg":"Failed to upload results to server","error":"Post \"https://upstream-rhcos4-high-worker-rs:8443/\": dial tcp: lookup upstream-rhcos4-high-worker-rs on 10.0.0.2:53: no such host","stacktrace":"github.com/ComplianceAsCode/compliance-operator/cmd/manager.uploadToResultServer.func1\n\tgithub.com/ComplianceAsCode/compliance-operator/cmd/manager/resultcollector.go:316\ngithub.com/cenkalti/backoff/v4.RetryNotifyWithTimer.Operation.withEmptyData.func1\n\tgithub.com/cenkalti/backoff/v4@v4.2.1/retry.go:18\ngithub.com/cenkalti/backoff/v4.doRetryNotify[...]\n\tgithub.com/cenkalti/backoff/v4@v4.2.1/retry.go:88\ngithub.com/cenkalti/backoff/v4.RetryNotifyWithTimer\n\tgithub.com/cenkalti/backoff/v4@v4.2.1/retry.go:61\ngithub.com/cenkalti/backoff/v4.RetryNotify\n\tgithub.com/cenkalti/backoff/v4@v4.2.1/retry.go:49\ngithub.com/cenkalti/backoff/v4.Retry\n\tgithub.com/cenkalti/backoff/v4@v4.2.1/retry.go:38\ngithub.com/ComplianceAsCode/compliance-operator/cmd/manager.uploadToResultServer\n\tgithub.com/ComplianceAsCode/compliance-operator/cmd/manager/resultcollector.go:299\ngithub.com/ComplianceAsCode/compliance-operator/cmd/manager.handleCompleteSCAPResults.func1\n\tgithub.com/ComplianceAsCode/compliance-operator/cmd/manager/resultcollector.go:390"}
`

* Use the content from https://github.com/ComplianceAsCode/content/pull/11722, to check whether the `scanner` container can access the sysctls correctly.
  ` oc compliance bind -S default-auto-apply -N test profile/upstream-rhcos4-moderate`

EDIT: I have re-tested and `DNSPolicy: ClusterFirstWithHostNet` indeed solves the `no such host` error when trying to upload to `resultserver`.