### PR TITLE
Use git describe for finding operator version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -660,7 +660,7 @@ package-version-to-tag: check-operator-version ## Explicitly override $TAG with 
 .PHONY: git-release
 git-release: fetch-git-tags package-version-to-tag changelog ## Update project files with new version information.
 	git checkout -b "release-v$(TAG)"
-	sed -i "s/\(replaces: \).*/\1$(PREVIOUS_VERSION)/" $(BUNDLE_CSV_FILE)
+	sed -i "s/\(replaces: \).*/\1$(APP_NAME).$(PREVIOUS_VERSION)/" $(BUNDLE_CSV_FILE)
 	sed -i "s/\(.*Version = \"\).*/\1$(TAG)\"/" version/version.go
 	sed -i "s/\(.*VERSION?=\).*/\1$(TAG)/" version.Makefile
 	git add version* bundle CHANGELOG.md config/manifests/bases

--- a/utils/get-current-version.sh
+++ b/utils/get-current-version.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
-CSV="$ROOT_DIR/bundle/manifests/compliance-operator.clusterserviceversion.yaml"
-
-OLD_VERSION=$(yq '.spec.version' "$CSV")
+OLD_VERSION=$(git describe --tags --abbrev=0)
 echo "$OLD_VERSION"


### PR DESCRIPTION
We need to be able to set the `replaces` attribute of the CSV file so
that OLM can build a relationship between dependencies, which is
important for disconnected installations and upgrades.

Previously, we were using the version in the CSV file, which worked but
it would change within the `make prepare-release` target depending on
when the command was invoked.

This commit updates the version script to use `git describe` instead,
which makes finding the current version more robust since tagging isn't
done until a subsequent step of the release process.
