### PR TITLE
OCPBUGS-32216: Stop deleting the kubeletconfiglink

### DIFF
--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -134,7 +134,7 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 					Command: []string{
 						"sh",
 						"-c",
-						fmt.Sprintf("rm -rf %s && mkdir -p %s && ln -s %s %s | /bin/true", KubeletConfigLinkPath, KubeletConfigLinkFolder, KubeletConfigMapPath, KubeletConfigLinkPath),
+						fmt.Sprintf("mkdir -p %s && ln -s %s %s | /bin/true", KubeletConfigLinkFolder, KubeletConfigMapPath, KubeletConfigLinkPath),
 					},
 					ImagePullPolicy: corev1.PullAlways,
 					SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
Let's stop removing the symlink when launching Node scans.
This allows multiple node scans to be launched without disrupting access to the kubelet config.