### PR TITLE
OCPBUGS-33067: Don't fatal error when filter cannot iterate

### DIFF
--- a/cmd/manager/scap_test.go
+++ b/cmd/manager/scap_test.go
@@ -316,6 +316,20 @@ var _ = Describe("Testing filtering", func() {
 				Expect(filterErr).Should(MatchError(MoreThanOneObjErr))
 			})
 		})
+		Context("Piped Filtering", func() {
+			var rawmc []byte
+			BeforeEach(func() {
+				nsFile, err := os.Open("../../tests/data/empty_machineconfig.json")
+				Expect(err).To(BeNil())
+				var readErr error
+				rawmc, readErr = io.ReadAll(nsFile)
+				Expect(readErr).To(BeNil())
+			})
+			It("skips filter piping errors", func() {
+				_, filterErr := filter(context.TODO(), rawmc, `[.items[] | select(.metadata.name | test("^rendered-worker-[0-9a-z]+$|^rendered-master-[0-9a-z]+$"))] | map(.spec.fips == true)`)
+				Expect(filterErr).Should(MatchError(NullValErr))
+			})
+		})
 	})
 })
 

--- a/tests/data/empty_machineconfig.json
+++ b/tests/data/empty_machineconfig.json
@@ -1,0 +1,4 @@
+{
+  "metadata": {},
+  "items": null
+}


### PR DESCRIPTION
A jq filter may expect to iterate over a list of results, but it can happen that no result is returned.
Let's not fatal error when this happens.

In an HyperShift environment, when no MC config exists, the following error occurs:

```
$ oc logs pod/ocp4-pci-dss-api-checks-pod --all-containers
...
Fetching URI: '/apis/machineconfiguration.openshift.io/v1/machineconfigs'
debug: Applying filter '[.items[] | select(.metadata.name | test("^rendered-worker-[0-9a-z]+$|^rendered-master-[0-9a-z]+$"))] | map(.spec.fips == true)' to path '/apis/machineconfiguration.openshift.io/v1/machineconfigs'
debug: Error while filtering: cannot iterate over: null
debug: Persisting warnings to output file
FATAL:Error fetching resources: couldn't filter '{
  "metadata": {},
  "items": null 
}': cannot iterate over: null
```

After creating a dummy `MachineConfig`, the URI fetching succeeds:
```
$ oc logs pod/ocp4-pci-dss-api-checks-pod --all-containers
...
Fetching URI: '/apis/machineconfiguration.openshift.io/v1/machineconfigs'
debug: Applying filter '[.items[] | select(.metadata.name | test("^rendered-worker-[0-9a-z]+$|^rendered-master-[0-9a-z]+$"))] | map(.spec.fips == true)' to path '/apis/machineconfiguration.openshift.io/v1/machineconfigs'
Fetching URI: '/apis/machineconfiguration.openshift.io/v1/machineconfigs'
debug: Applying filter '[.items[] | select(.metadata.name | test("^rendered-worker-[0-9a-z]+$|^rendered-master-[0-9a-z]+$"))] | map(.spec.config.storage.luks[0].clevis != null)' to path '/apis/machineconfiguration.openshift.io/v1/machineconfigs'
Fetching URI: '/apis/machine.openshift.io/v1beta1/machinesets?limit=500'
```