### PR TITLE
[WIP] Add timestamp annotation

### DIFF
--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -76,7 +76,7 @@ func stateCompare(lowPhase ComplianceScanStatusPhase, scanPhase ComplianceScanSt
 	return lowPhase
 }
 
-// Represents the result of the compliance scan
+// ComplianceScanStatusResult represents the result of the compliance scan
 type ComplianceScanStatusResult string
 
 // CmScanResultAnnotation holds the processed scanner result
@@ -86,7 +86,7 @@ const CmScanResultAnnotation = "compliance.openshift.io/scan-result"
 const CmScanResultErrMsg = "compliance.openshift.io/scan-error-msg"
 
 const (
-	// ResultNot available represents the compliance scan not having finished yet
+	// ResultNotAvailable available represents the compliance scan not having finished yet
 	ResultNotAvailable ComplianceScanStatusResult = "NOT-AVAILABLE"
 	// ResultCompliant represents the compliance scan having succeeded
 	ResultCompliant ComplianceScanStatusResult = "COMPLIANT"

--- a/pkg/apis/compliance/v1alpha1/rule_types.go
+++ b/pkg/apis/compliance/v1alpha1/rule_types.go
@@ -15,6 +15,9 @@ const RuleIDAnnotationKey = "compliance.openshift.io/rule"
 // ComplianceCheckResult
 const RuleHideTagAnnotationKey = "compliance.openshift.io/hide-tag"
 
+// LastScannedTimestampKey indicates when the last scanned happened.
+const LastScannedTimestampKey = "compliance.openshift.io/last-scanned-timestamp"
+
 // RuleVariableAnnotationKey store list of xccdf variables used to render the rule
 const RuleVariableAnnotationKey = "compliance.openshift.io/rule-variable"
 

--- a/pkg/utils/parse_arf_result.go
+++ b/pkg/utils/parse_arf_result.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/template"
 	"text/template/parse"
+	"time"
 
 	"github.com/antchfx/xmlquery"
 	"github.com/pkg/errors"
@@ -588,6 +589,9 @@ func newComplianceCheckResult(result *xmlquery.Node, rule *xmlquery.Node, ruleId
 			renderError = err
 		}
 	}
+
+	// ISO 8601 time, e.g. 2024-05-02T12:18:54Z
+	annotations[compv1alpha1.LastScannedTimestampKey] = time.Now().UTC().Format(time.RFC3339)
 
 	return &compv1alpha1.ComplianceCheckResult{
 		ObjectMeta: v1.ObjectMeta{


### PR DESCRIPTION
Add timestamp annotation to CheckResult objects.
The goal is to be able to identify when a ComplianceScan is done and has successful update all CheckResults.
Additionally, from a client perspective I want to be able to identify when I received all updated CheckResults. Prior to this change it was not possible to know when a check was done if the result didn't changed.

Specification:

- Add `compliance.openshift.io/last-scanned-timestamp` to CheckResult object
- `compliance.openshift.io/last-scanned-timestamp` annotation is always updated
- CheckResult objects are updated, even if the Result did not changed.