### PR TITLE
CMP-2547: Implement ROSA e2e test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -609,6 +609,12 @@ e2e-parallel: e2e-set-image prep-e2e ## Run non-destructive end-to-end tests con
 e2e-serial: e2e-set-image prep-e2e ## Run destructive end-to-end tests serially.
 	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/serial $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
 
+## Convert --platform to using $PLATFORM if we make this target more generic
+## for other offerings.
+.PHONY: e2e-rosa
+e2e-rosa: e2e-set-image prep-e2e ## Run tests against managed ROSA environment concurrently
+	@$(GO) test ./tests/e2e/rosa $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) --platform rosa | tee tests/e2e-test.log
+
 .PHONY: prep-e2e
 prep-e2e: kustomize
 	rm -rf $(TEST_SETUP_DIR)

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -209,14 +209,16 @@ func (f *Framework) addFrameworks() error {
 	}
 
 	// MCO objects
-	mcoObjs := [2]dynclient.ObjectList{
-		&mcfgv1.MachineConfigPoolList{},
-		&mcfgv1.MachineConfigList{},
-	}
-	for _, obj := range mcoObjs {
-		err := AddToFrameworkScheme(mcfgapi.Install, obj)
-		if err != nil {
-			return fmt.Errorf("failed to add custom resource scheme to framework: %v", err)
+	if f.Platform != "rosa" {
+		mcoObjs := [2]dynclient.ObjectList{
+			&mcfgv1.MachineConfigPoolList{},
+			&mcfgv1.MachineConfigList{},
+		}
+		for _, obj := range mcoObjs {
+			err := AddToFrameworkScheme(mcfgapi.Install, obj)
+			if err != nil {
+				return fmt.Errorf("failed to add custom resource scheme to framework: %v", err)
+			}
 		}
 	}
 
@@ -476,6 +478,10 @@ func (f *Framework) deleteScanSettings(name string) error {
 }
 
 func (f *Framework) createMachineConfigPool(n string) error {
+	if f.Platform == "rosa" {
+		fmt.Printf("bypassing MachineConfigPool test setup because it's not supported on %s\n", f.Platform)
+		return nil
+	}
 	// get the worker pool
 	w := "worker"
 	p := &mcfgv1.MachineConfigPool{}
@@ -594,6 +600,10 @@ func (f *Framework) createMachineConfigPool(n string) error {
 }
 
 func (f *Framework) createInvalidMachineConfigPool(n string) error {
+	if f.Platform == "rosa" {
+		fmt.Printf("bypassing MachineConfigPool test setup because it's not supported on %s\n", f.Platform)
+		return nil
+	}
 	p := &mcfgv1.MachineConfigPool{
 		ObjectMeta: metav1.ObjectMeta{Name: n},
 		Spec: mcfgv1.MachineConfigPoolSpec{
@@ -621,6 +631,10 @@ func (f *Framework) createInvalidMachineConfigPool(n string) error {
 }
 
 func (f *Framework) cleanUpMachineConfigPool(n string) error {
+	if f.Platform == "rosa" {
+		fmt.Printf("bypassing MachineConfigPool cleanup because it's not supported on %s\n", f.Platform)
+		return nil
+	}
 	p := &mcfgv1.MachineConfigPool{}
 	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: n}, p)
 	if err != nil {
@@ -635,6 +649,10 @@ func (f *Framework) cleanUpMachineConfigPool(n string) error {
 }
 
 func (f *Framework) restoreNodeLabelsForPool(n string) error {
+	if f.Platform == "rosa" {
+		fmt.Printf("bypassing node label restoration because MachineConfigPools are not supported on %s\n", f.Platform)
+		return nil
+	}
 	p := &mcfgv1.MachineConfigPool{}
 	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: n}, p)
 	if err != nil {

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -60,6 +60,7 @@ type Framework struct {
 	NamespacedManPath *string
 	OperatorNamespace string
 	WatchNamespace    string
+	Platform          string
 
 	restMapper *restmapper.DeferredDiscoveryRESTMapper
 
@@ -82,6 +83,7 @@ type frameworkOpts struct {
 	testType          string
 	isLocalOperator   bool
 	cleanupOnError    bool
+	platform          string
 }
 
 const (
@@ -99,6 +101,7 @@ const (
 	LocalOperatorArgs     = "localOperatorArgs"
 	CleanupOnErrorFlag    = "cleanupOnError"
 	TestTypeFlag          = "testType"
+	PlatformFlag          = "platform"
 
 	TestOperatorNamespaceEnv = "TEST_OPERATOR_NAMESPACE"
 	TestWatchNamespaceEnv    = "TEST_WATCH_NAMESPACE"
@@ -119,6 +122,8 @@ func (opts *frameworkOpts) addToFlagSet(flagset *flag.FlagSet) {
 			"in which case test resources are automatically cleaned up.")
 	flagset.StringVar(&opts.testType, TestTypeFlag, TestTypeAll,
 		"Defines the type of tests to run. (Options: all, serial, parallel)")
+	flagset.StringVar(&opts.platform, PlatformFlag, "openshift",
+		"The type of deployment hosting the tests. Options include \"openshift\" and \"rosa\".")
 }
 
 func newFramework(opts *frameworkOpts) (*Framework, error) {
@@ -163,6 +168,7 @@ func newFramework(opts *frameworkOpts) (*Framework, error) {
 		Scheme:            scheme,
 		NamespacedManPath: &opts.namespacedManPath,
 		OperatorNamespace: operatorNamespace,
+		Platform:          opts.platform,
 		LocalOperator:     opts.isLocalOperator,
 
 		projectRoot:       opts.projectRoot,

--- a/tests/e2e/rosa/main_test.go
+++ b/tests/e2e/rosa/main_test.go
@@ -1,0 +1,28 @@
+package rosa_e2e
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/ComplianceAsCode/compliance-operator/tests/e2e/framework"
+)
+
+var brokenContentImagePath string
+var contentImagePath string
+
+func TestMain(m *testing.M) {
+	f := framework.NewFramework()
+	err := f.SetUp()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	exitCode := m.Run()
+	if exitCode == 0 || (exitCode > 0 && f.CleanUpOnError()) {
+		if err = f.TearDown(); err != nil {
+			log.Fatal(err)
+		}
+	}
+	os.Exit(exitCode)
+}


### PR DESCRIPTION
We have to handle some differences in how we setup e2e testing on
managed OpenShift offerings, like ROSA. This commit stands up a separate
e2e suite that will be specific to ROSA test cases and wires it up to a
Makefile target for easy use.
