### PR TITLE
Fix platform role detection for Power and Z architecture

### DIFF
--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -116,6 +116,14 @@ var (
 			"master",
 			"worker",
 		},
+		PlatformOpenShiftOnPower: {
+			"master",
+			"worker",
+		},
+		PlatformOpenShiftOnZ: {
+			"master",
+			"worker",
+		},
 		PlatformGeneric: {
 			compv1alpha1.AllRoles,
 		},


### PR DESCRIPTION
We recently updated Compliance Operator support to only load ocp4
profiles when running on Power and Z systems, since those are currently
the only profiles that are supported on those architectures.

In the process, we added architecture detection so the operator knows if
it's running OpenShift on amd64, ppc64le, or s390x. However, the
operator will also create default scan settings based on the
architecture and platform, which didn't take these into account.

Since we were using new architecture/platform keys in the support
mapping, they weren't being handled correctly when the operator created
the default scan settings. This caused it to use a generic catch all to
schedule scans on all available nodes. While this is fine for some
platforms, like EKS, it doesn't work when nodes are in different node
pools because they will constantly get different results and be
INCONSISTENT.
