### PR TITLE
Adding test for  network policy regex

### DIFF
--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -1217,6 +1217,14 @@ func (f *Framework) AssertScanSettingBindingConditionIsReady(name string, namesp
 
 }
 
+func (f *Framework) AssertVariableExists(name, namespace string) error {
+	v := &compv1alpha1.Variable{}
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, v)
+	if err != nil {
+		return fmt.Errorf("Failed to get Variable %s: %w", name, err)
+	}
+	return nil
+}
 func (f *Framework) AssertScanSettingBindingConditionIsSuspended(name string, namespace string) error {
 	ssb := &compv1alpha1.ScanSettingBinding{}
 	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, ssb)

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -1953,7 +1953,8 @@ func TestConfigureNetworkPolicy(t *testing.T) {
 
 	err = f.AssertVariableExists(variableName, f.OperatorNamespace)
 	if err != nil {
-		t.Fatal(err)
+		t.Skip("Content doesn't have variable '%s' required for testing", variableName)
+		return
 	}
 
 	nsList := corev1.NamespaceList{}


### PR DESCRIPTION
Added e2e test for configure-network-policies-namespaces rule, test if whitelist-regex works as expected.

This works in-conjunction with https://github.com/ComplianceAsCode/content/pull/11952