### PR TITLE
CMP-2526: Disable automatic remediation for ROSA HCP environments

### DIFF
--- a/tests/e2e/rosa/main_test.go
+++ b/tests/e2e/rosa/main_test.go
@@ -50,3 +50,28 @@ func TestInstallOnlyParsesNodeProfiles(t *testing.T) {
 	}
 
 }
+
+func TestScanSetting(t *testing.T) {
+	f := framework.Global
+	// prinout all scan settings
+	scanSettingList := compv1alpha1.ScanSettingList{}
+	err := f.Client.List(context.TODO(), &scanSettingList)
+	if err != nil {
+		t.Fatalf("Failed to list scan settings: %v", err)
+	}
+	for _, scanSetting := range scanSettingList.Items {
+		if scanSetting.Name == "default-auto-apply" {
+			f.PrintROSADebugInfo(t)
+			t.Fatalf("ScanSetting: %s is not expected", scanSetting.Name)
+		}
+		t.Logf("ScanSetting: %s", scanSetting.Name)
+		for _, role := range scanSetting.Roles {
+			if role == "master" {
+				f.PrintROSADebugInfo(t)
+				t.Fatalf("Role: %s is not expected", role)
+			}
+			t.Logf("Role: %s", role)
+
+		}
+	}
+}


### PR DESCRIPTION
Since the Compliance Operator is only going to support running on HCP environments, where end users don't have access to the master nodes (or control plane), it doesn't make sense to give them a scan setting with auto remediation functionality applied.

For this case, the Compliance Operator should detect if it is running on ROSA HCP and adjust, or just not create the `default-auto-apply` scan settings.