### PR TITLE
Fix panic due to logging issue

### DIFF
--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -329,7 +329,7 @@ func parseProfileFromNode(profileRoot *xmlquery.Node, pb *cmpv1alpha1.ProfileBun
 		productType, productName := getProductTypeAndName(profileObj, defType, defName)
 
 		if productType == "Platform" && utils.GetPlatform() == "ROSA" {
-			log.Info("Skipping platform profile creation because it is not supported on this platform", xccdf.GetProfileNameFromID(id))
+			log.Info("Skipping platform profile creation because it is not supported on this platform", "id", xccdf.GetProfileNameFromID(id))
 			continue
 		}
 		log.Info("Platform info", "type", productType, "name", productName)


### PR DESCRIPTION
We're seeing a panic in the log when parsing profiles on managed
offerings:

  "msg":"odd number of arguments passed as key-value pairs for logging","ignored key"

This is likely related to https://github.com/ComplianceAsCode/compliance-operator/pull/518

This commit updates the log to use a key-value pair so that the panic
goes away.
