### PR TITLE
Reduce timeout from 30 minutes to 10 minutes in serial tests

### DIFF
--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -369,6 +369,9 @@ func TestMixProductScan(t *testing.T) {
 			Schedule:              "0 1 * * *",
 			Suspend:               false,
 		},
+		ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+			Timeout: "10m",
+		},
 		Roles: []string{"master", "worker"},
 	}
 	if err := f.Client.Create(context.TODO(), &scanSetting, nil); err != nil {
@@ -1626,6 +1629,9 @@ func TestSuspendScanSetting(t *testing.T) {
 			Schedule:              "0 1 * * *",
 			Suspend:               false,
 		},
+		ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+			Timeout: "10m",
+		},
 		Roles: []string{"master", "worker"},
 	}
 	if err := f.Client.Create(context.TODO(), &scanSetting, nil); err != nil {
@@ -1861,6 +1867,9 @@ func TestSuspendScanSettingDoesNotCreateScan(t *testing.T) {
 			AutoApplyRemediations: false,
 			Schedule:              "0 1 * * *",
 			Suspend:               true,
+		},
+		ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+			Timeout: "10m",
 		},
 		Roles: []string{"master", "worker"},
 	}


### PR DESCRIPTION
Before, we were waiting for 30 minutes for a scan to timeout. 30 minutes
is a long time, and we have some retry logic in the operator to rekick
scans after a timeout. Let's reduce the timeout for tests to see if we
can improve resilience to flaky scans.
