### PR TITLE
OCPBUGS-34535: Ignore case when compare platform

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1243,6 +1243,14 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+            - config.openshift.io
+          resources:
+            - infrastructures
+          verbs:
+            - get
+            - list
+            - watch
         serviceAccountName: compliance-operator
       - rules:
         - apiGroups:

--- a/config/rbac/operator_cluster_role.yaml
+++ b/config/rbac/operator_cluster_role.yaml
@@ -22,7 +22,7 @@ rules:
   - apiGroups:
       - machineconfiguration.openshift.io
     resources:
-      - machineconfigs  # The compliance remediation controller operates on MachineConfigs
+      - machineconfigs # The compliance remediation controller operates on MachineConfigs
       - machineconfigpools
       - kubeletconfigs
     verbs:
@@ -154,6 +154,14 @@ rules:
       - cluster.open-cluster-management.io
     resources:
       - clusterclaims
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
     verbs:
       - get
       - list

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -122,6 +122,7 @@ type ReconcileComplianceScan struct {
 //+kubebuilder:rbac:groups=image.openshift.io,resources=imagestreamtags,verbs=get,list,watch
 //+kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=get,list,watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=get,list,watch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get,list,watch
 
 // Reconcile reads that state of the cluster for a ComplianceScan object and makes changes based on the state read
 // and what is in the ComplianceScan.Spec

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -490,6 +490,7 @@ func (r *ReconcileProfileBundle) newWorkloadForBundle(pb *compliancev1alpha1.Pro
 							},
 							Env: []corev1.EnvVar{
 								corev1.EnvVar{Name: "PLATFORM", Value: utils.GetPlatform()},
+								corev1.EnvVar{Name: "CONTROL_PLANE_TOPOLOGY", Value: utils.GetControlPlaneTopology()},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -328,7 +328,7 @@ func parseProfileFromNode(profileRoot *xmlquery.Node, pb *cmpv1alpha1.ProfileBun
 		// In case the profile sets its own CPE string
 		productType, productName := getProductTypeAndName(profileObj, defType, defName)
 
-		if strings.EqualFold(string(productType), "Platform") && strings.EqualFold(utils.GetPlatform(), "ROSA") {
+		if strings.EqualFold(string(productType), "Platform") && strings.EqualFold(utils.GetPlatform(), "ROSA") && utils.IsHostedControlPlane() {
 			log.Info("Skipping platform profile creation because it is not supported on this platform", "id", xccdf.GetProfileNameFromID(id))
 			continue
 		}
@@ -434,7 +434,6 @@ func parseProductTypeAndName(idref string, defaultType cmpv1alpha1.ComplianceSca
 	case "o":
 		productType = cmpv1alpha1.ScanTypeNode
 	default:
-		fmt.Printf("Unknown CPE part: %s for profile %s\n", cpePieces[partIdx], idref)
 		// We assume anything we don't know is a platform...
 		productType = cmpv1alpha1.ScanTypePlatform
 	}

--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -328,7 +328,7 @@ func parseProfileFromNode(profileRoot *xmlquery.Node, pb *cmpv1alpha1.ProfileBun
 		// In case the profile sets its own CPE string
 		productType, productName := getProductTypeAndName(profileObj, defType, defName)
 
-		if productType == "Platform" && utils.GetPlatform() == "ROSA" {
+		if strings.EqualFold(string(productType), "Platform") && strings.EqualFold(utils.GetPlatform(), "ROSA") {
 			log.Info("Skipping platform profile creation because it is not supported on this platform", "id", xccdf.GetProfileNameFromID(id))
 			continue
 		}
@@ -434,6 +434,7 @@ func parseProductTypeAndName(idref string, defaultType cmpv1alpha1.ComplianceSca
 	case "o":
 		productType = cmpv1alpha1.ScanTypeNode
 	default:
+		fmt.Printf("Unknown CPE part: %s for profile %s\n", cpePieces[partIdx], idref)
 		// We assume anything we don't know is a platform...
 		productType = cmpv1alpha1.ScanTypePlatform
 	}

--- a/pkg/utils/platform.go
+++ b/pkg/utils/platform.go
@@ -2,9 +2,13 @@ package utils
 
 import (
 	"os"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 const platformEnv = "PLATFORM"
+const controlPlaneTopologyEnv = "CONTROL_PLANE_TOPOLOGY"
 
 func GetPlatform() string {
 	p := os.Getenv(platformEnv)
@@ -12,4 +16,17 @@ func GetPlatform() string {
 		return "OpenShift"
 	}
 	return p
+}
+
+func GetControlPlaneTopology() string {
+	return os.Getenv(controlPlaneTopologyEnv)
+}
+
+func IsHostedControlPlane() bool {
+	topology := GetControlPlaneTopology()
+	if strings.EqualFold(topology, string(configv1.ExternalTopologyMode)) {
+		return true
+	} else {
+		return false
+	}
 }

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -135,6 +135,17 @@ func (f *Framework) PrintROSADebugInfo(t *testing.T) {
 
 	}
 
+	// List infrastructures
+	infraList := configv1.InfrastructureList{}
+	err = f.Client.List(context.TODO(), &infraList)
+	if err != nil {
+		t.Fatalf("Failed to list infrastructures: %v", err)
+	}
+	for _, infra := range infraList.Items {
+		t.Logf("Infrastructure: %s", infra.Name)
+		t.Logf("Infrastructure.Status.ControlPlaneTopology: %v", infra.Status.ControlPlaneTopology)
+	}
+
 	// print out logs for compliance-operator deployment
 	podList := corev1.PodList{}
 	err = f.Client.List(context.TODO(), &podList, client.InNamespace(f.OperatorNamespace))

--- a/tests/e2e/rosa/main_test.go
+++ b/tests/e2e/rosa/main_test.go
@@ -37,6 +37,7 @@ func TestInstallOnlyParsesNodeProfiles(t *testing.T) {
 	l := compv1alpha1.ProfileList{}
 	err := f.Client.List(context.TODO(), &l)
 	if err != nil {
+		f.PrintROSADebugInfo(t)
 		t.Fatalf("failed to get ProfileList: %s", err)
 	}
 
@@ -45,6 +46,7 @@ func TestInstallOnlyParsesNodeProfiles(t *testing.T) {
 	for _, p := range l.Items {
 		pt := p.Annotations[compv1alpha1.ProductTypeAnnotation]
 		if pt != "Node" {
+			f.PrintROSADebugInfo(t)
 			t.Fatalf("found an unexpected profile type: %s of type %s", p.GetName(), pt)
 		}
 	}


### PR DESCRIPTION
Let's ignore the case when comparing the case here, this should avoid issue if someone sets Platform environment to lower cased value. Such as rosa instead of ROSA.