### PR TITLE
Remove SBOM workaround

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -49,8 +49,6 @@ jobs:
       platforms: "linux/amd64,linux/ppc64le,linux/s390x"
 
   catalog-container-push-pr:
-    # Temporary workaround for SBOM issue https://github.com/metal-toolbox/container-push/pull/77
-    if: always()
     needs:
       - operator-container-push-latest
       - bundle-container-push-latest

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -89,8 +89,6 @@ jobs:
       platforms: "linux/amd64,linux/ppc64le,linux/s390x"
 
   catalog-container-push-pr:
-    # Temporary workaround for SBOM issue https://github.com/metal-toolbox/container-push/pull/77
-    if: always()
     needs:
       - get-pr-number
       - operator-container-push-pr
@@ -112,8 +110,6 @@ jobs:
       platforms: "linux/amd64,linux/ppc64le,linux/s390x"
 
   comment-pr:
-    # Temporary workaround for SBOM issue https://github.com/metal-toolbox/container-push/pull/77
-    if: always()
     needs:
       - operator-container-push-pr
       - bundle-container-push-pr
@@ -134,3 +130,4 @@ jobs:
             ```
             make catalog-deploy CATALOG_IMG=ghcr.io/complianceascode/compliance-operator-catalog:${{ needs.get-pr-number.outputs.pr-number }}
             ```
+          pr_number: ${{ needs.get-pr-number.outputs.pr-number }}


### PR DESCRIPTION
Let's remove the workaround since we have sbom issues fixed. ex:https://github.com/ComplianceAsCode/compliance-operator/actions/runs/9563061573/job/26377079635. This also adding the missing pr_number in the comment step.