### PR TITLE
OCPBUGS-17828: Fix rule instruction

### DIFF
--- a/pkg/utils/parse_arf_result.go
+++ b/pkg/utils/parse_arf_result.go
@@ -467,12 +467,15 @@ func GetInstructionsForRule(rule *xmlquery.Node, ocilTable NodeByIdHashTable, va
 	}
 
 	// if found, strip the last line
-	textSlice := strings.Split(strings.TrimSpace(textNodeStr), "\n")
+	textSlice := strings.Split(textNodeStr, "\n")
+	for i, line := range textSlice {
+		textSlice[i] = strings.TrimSpace(line)
+	}
 	if len(textSlice) > 1 {
 		textSlice = textSlice[:len(textSlice)-1]
 	}
 
-	return strings.TrimSpace(strings.Join(textSlice, "\n")), valuesRendered
+	return strings.Join(textSlice, "\n"), valuesRendered
 }
 
 // ParseContent parses the DataStream and returns the XML document


### PR DESCRIPTION
This is to fix the rule instruction so that we can display as multiline string instead of pre-wrap text, and user is able to copy and run oc command in the instruction without having to remove escape. The issue was caused by space before newline made it not able to output multiline yaml formate.