### PR TITLE
Split out prebuild-check from actual build

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -5,8 +5,32 @@ on:
     branches: ["master"]
 
 jobs:
+  prebuild-check:
+    runs-on: ubuntu-latest
+    # use matrix to run for multiple architectures
+    strategy:
+      matrix:
+        arch: [linux/amd64, linux/ppc64le, linux/s390x]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build container images and push
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: build/Dockerfile.prebuild
+          tags: complianceascode/compliance-operator:${GITHUB_REF_NAME}-${{ matrix.arch }}
+          push: false
+          sbom: false
+          platforms: ${{ matrix.arch }}
   # Push to latest
   operator-container-push-latest:
+    needs: prebuild-check
     permissions:
       contents: read
       id-token: write
@@ -21,6 +45,7 @@ jobs:
       platforms: "linux/amd64,linux/ppc64le,linux/s390x"
 
   bundle-container-push-latest:
+    needs: prebuild-check
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -39,9 +39,35 @@ jobs:
         id: pr_number
         run: |
           echo "pr_number=$(cat pr_number)" >> "$GITHUB_OUTPUT"
+  
+  prebuild-check:
+    runs-on: ubuntu-latest
+    # use matrix to run for multiple architectures
+    strategy:
+      matrix:
+        arch: [linux/amd64, linux/ppc64le, linux/s390x]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build container images and push
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: build/Dockerfile.prebuild
+          tags: complianceascode/compliance-operator:${GITHUB_REF_NAME}-${{ matrix.arch }}
+          push: false
+          sbom: false
+          platforms: ${{ matrix.arch }}
 
   operator-container-push-pr:
-    needs: get-pr-number
+    needs:
+      - get-pr-number
+      - prebuild-check
     permissions:
       contents: read
       id-token: write
@@ -57,7 +83,9 @@ jobs:
       platforms: "linux/amd64,linux/ppc64le,linux/s390x"
 
   bundle-container-push-pr:
-    needs: get-pr-number
+    needs:
+      - get-pr-number
+      - prebuild-check
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,33 @@ on:
       - v**
 
 jobs:
+  prebuild-check:
+    runs-on: ubuntu-latest
+    # use matrix to run for multiple architectures
+    strategy:
+      matrix:
+        arch: [linux/amd64, linux/ppc64le, linux/s390x]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build container images and push
+        id: docker_build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: build/Dockerfile.prebuild
+          tags: complianceascode/compliance-operator:${GITHUB_REF_NAME}-${{ matrix.arch }}
+          push: false
+          sbom: false
+          platforms: ${{ matrix.arch }}
+    
   container-main:
+    needs:
+      - prebuild-check
     permissions:
       contents: read
       id-token: write
@@ -35,6 +61,8 @@ jobs:
       platforms: "linux/amd64,linux/ppc64le,linux/s390x"
 
   bundle-container:
+    needs:
+      - prebuild-check
     permissions:
       contents: read
       id-token: write
@@ -49,9 +77,8 @@ jobs:
       platforms: "linux/amd64,linux/ppc64le,linux/s390x"
 
   catalog-container-push-pr:
-    # Temporary workaround for SBOM issue https://github.com/metal-toolbox/container-push/pull/77
-    if: always()
     needs:
+      - prebuild-check
       - container-main
       - openscap-container
       - bundle-container

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -7,6 +7,8 @@ ENV GOFLAGS=-mod=vendor
 
 COPY . .
 
+RUN make prebuild-check
+
 RUN make manager
 
 # Step two: containerize compliance-operator

--- a/Dockerfile.prebuild
+++ b/Dockerfile.prebuild
@@ -1,0 +1,10 @@
+# Step one: build compliance-operator
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.14 AS builder
+
+WORKDIR /go/src/github.com/openshift/compliance-operator
+
+ENV GOFLAGS=-mod=vendor
+
+COPY . .
+
+RUN make prebuild-check

--- a/Makefile
+++ b/Makefile
@@ -417,8 +417,13 @@ images: image bundle-image  ## Build operator and bundle images.
 .PHONY: images-extra
 images-extra: openscap-image e2e-content-images  ## Build the openscap and test content images.
 
+.PHONY: prebuild-check
+prebuild-check: generate fmt vet test-unit 
+# Make sure no changes are present in the working directory
+	@git diff --exit-code > /dev/null || (echo "Working directory is not clean. Check git status." && exit 1)
+
 .PHONY: build
-build: generate fmt vet test-unit ## Build the operator binary.
+build: ## Build the operator binary.
 	$(GO) build \
 		-trimpath \
 		-ldflags=-buildid= \


### PR DESCRIPTION
Let's split prebuild-check from build to speed up the build process. It could greatly shorten our build time.