### PR TITLE
CMP-1096: Add must-gather image to relatedImages

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1669,5 +1669,7 @@ spec:
     name: operator
   - image: ghcr.io/complianceascode/k8scontent:latest
     name: profile
+  - image: ghcr.io/complianceascode/must-gather-ocp:latest
+    name: must-gather
   replaces: compliance-operator.v1.4.1
   version: 1.5.0


### PR DESCRIPTION
Even though the must-gather plugin image isn't necessary for running the
operator, is helps users collect information when reporting issues.

By including the image reference in the `relatedImages` of the CSV, it's
more discoverable and users can query it out of the CSV directly,
instead of having to hunt through documentation and container
registries.
