### PR TITLE
CMP-2693: Use CLI image for base image in must-gather

### DIFF
--- a/.github/workflows/must-gather-latest.yml
+++ b/.github/workflows/must-gather-latest.yml
@@ -15,6 +15,6 @@ jobs:
       name: must-gather-ocp
       registry_org: complianceascode
       tag: latest
-      dockerfile_path: images/must-gather/Dockerfile
+      dockerfile_path: images/must-gather/Dockerfile.ocp
       vendor: "Compliance Operator Authors"
       platforms: "linux/amd64,linux/ppc64le,linux/s390x"

--- a/Makefile
+++ b/Makefile
@@ -659,7 +659,7 @@ push-e2e-content: e2e-content-images  ## Build and push the e2e-content-images
 
 .PHONY: must-gather-image
 must-gather-image:  ## Build the must-gather image
-	$(RUNTIME) build -t $(MUST_GATHER_IMAGE_PATH):$(MUST_GATHER_IMAGE_TAG) -f images/must-gather/Dockerfile .
+	$(RUNTIME) build -t $(MUST_GATHER_IMAGE_PATH):$(MUST_GATHER_IMAGE_TAG) -f images/must-gather/Dockerfile.ocp .
 
 .PHONY: must-gather
 must-gather: must-gather-image must-gather-push  ## Build and push the must-gather image

--- a/images/must-gather/Dockerfile
+++ b/images/must-gather/Dockerfile
@@ -1,9 +1,0 @@
-FROM quay.io/openshift/origin-must-gather:latest
-
-# Save original gather script
-RUN mv /usr/bin/gather /usr/bin/gather_original
-
-# Copy all collection scripts to /usr/bin
-COPY utils/must-gather/* /usr/bin/
-
-ENTRYPOINT /usr/bin/gather

--- a/images/must-gather/Dockerfile.ocp
+++ b/images/must-gather/Dockerfile.ocp
@@ -1,0 +1,5 @@
+FROM registry.ci.openshift.org/ocp/4.17:cli
+
+COPY utils/must-gather/* /usr/bin/
+
+ENTRYPOINT /usr/bin/gather


### PR DESCRIPTION
The original approach for building a must-gather image specifically for
Compliance Operator usage grabbed the latest stock must-gather image
(the one for collecting everything in an ordinary deployment), and then
pushing the original scripts out of the way and replacing them with
Compliance Operator specific scripts to collect the information we
wanted.

While this worked, we can simplify the image dependency by just relying
on the CLI image directly, since that's what the upstream must-gather
image does, then just wire up the entry point to the collection scripts
we already have, following the same pattern that the upstream
must-gather image uses.

This commit also updates the `Dockerfile` name to include `.ocp` suffix,
since we're relying on a Red Hat registry to pull the CLI image.
