### PR TITLE
Add Makefile target for pushing must-gather image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -661,6 +661,10 @@ push-e2e-content: e2e-content-images  ## Build and push the e2e-content-images
 must-gather-image:  ## Build the must-gather image
 	$(RUNTIME) build -t $(MUST_GATHER_IMAGE_PATH):$(MUST_GATHER_IMAGE_TAG) -f images/must-gather/Dockerfile .
 
+.PHONY: must-gather-push
+must-gather-push: must-gather-image
+	$(RUNTIME) push $(MUST_GATHER_IMAGE_PATH):$(MUST_GATHER_IMAGE_TAG)
+
 .PHONY: must-gather
 must-gather: must-gather-image must-gather-push  ## Build and push the must-gather image
 


### PR DESCRIPTION
The must-gather target had a reference to a non-existent target called
`must-gather-push`, which resulted in the following error when you
attempted to build the must-gather image locally:

  make: *** No rule to make target 'must-gather-push', needed by 'must-gather'.  Stop.

This commit adds in the missing Makefile target to push the image to a
specific image registry so that you can build must-gather images locally
and push them to your own registry (e.g., useful for testing).
