### PR TITLE
Update TailoredProfile title description in parallel e2e

### DIFF
--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -2540,8 +2540,8 @@ func TestScanSettingBindingWatchesTailoredProfile(t *testing.T) {
 			Namespace: f.OperatorNamespace,
 		},
 		Spec: compv1alpha1.TailoredProfileSpec{
-			Title:       "TestScanProducesRemediations",
-			Description: "TestScanProducesRemediations",
+			Title:       "TestScanSettingBindingWatchesTailoredProfile",
+			Description: "TestScanSettingBindingWatchesTailoredProfile",
 			DisableRules: []compv1alpha1.RuleReferenceSpec{
 				{
 					Name:      "no-such-rule",


### PR DESCRIPTION
One of the parallel tests was using the name and description from
another test in its TailoredProfile. While this doesn't necessarily
cause issues, it can be confusing.

This commit updates the TailoredProfile name and title so they're
consistent with the test name.
