### PR TITLE
Fix false positive trivy filesystem scan result

### DIFF
--- a/.github/workflows/container-scan-trivy.yml
+++ b/.github/workflows/container-scan-trivy.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           scan-type: 'fs'
           scan-ref: '.'
+          skip-files: 'vendor/github.com/securego/gosec/v2/rules/hardcoded_credentials.go'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true


### PR DESCRIPTION
Trivy is warning us about an issue in gosec where it thinks a secret is
being exposed, but it's actually just a regular expression. Let's
exclude it by the specific file that contains the violation so it stops
failing.
