### PR TITLE
CMP-2196: Update cluster role permissions for ingresscontrollers

### DIFF
--- a/config/rbac/operator_cluster_role.yaml
+++ b/config/rbac/operator_cluster_role.yaml
@@ -166,3 +166,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - ingresscontrollers # Necessary for Compliance Operator to apply remediations that update TLS ciphers.
+    verbs:
+      - get
+      - list
+      - patch


### PR DESCRIPTION
We have a rule in the compliance content that will check the
ingresscontroller's TLS ciphers. It also comes with a remediation to
update the ciphers so they're either Recommended or Secure. However,
the remediation errors out when it's loaded after a scan because the
Compliance Operator doesn't have the necessary permissions to get the
ingresscontrollers, or apply the remediation.

This commit updates the Compliance Operator's cluster role so that it
has the ability to update the TLS cipher configuration for
ingresscontrollers.
