### PR TITLE
:broom: Fix golang formatting in scan.go

### DIFF
--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -289,8 +289,8 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 			NodeSelector: map[string]string{
 				corev1.LabelHostname: node.Labels[corev1.LabelHostname],
 			},
-			HostNetwork: true,
-			DNSPolicy: "ClusterFirstWithHostNet",
+			HostNetwork:   true,
+			DNSPolicy:     "ClusterFirstWithHostNet",
 			RestartPolicy: corev1.RestartPolicyOnFailure,
 			Volumes: []corev1.Volume{
 				{


### PR DESCRIPTION
gofmt is attempting to fix formatting in scan.go. Pull this out in to a
separate change and clean it up.
