### PR TITLE
:broom: Remove double quotes in RBAC manifests

### DIFF
--- a/config/rbac/operator_role.yaml
+++ b/config/rbac/operator_role.yaml
@@ -101,9 +101,9 @@ rules:
     resources:
       - servicemonitors
     verbs:
-      - "get"
-      - "create"
-      - "update"
+      - get
+      - create
+      - update
   - apiGroups:
       - apps
     resources:
@@ -111,7 +111,7 @@ rules:
     resourceNames:
       - compliance-operator
     verbs:
-      - "update"
+      - update
   - apiGroups:
       - batch
     resources:


### PR DESCRIPTION
There were a few cases where we used double-quotes for verbs, but most
of the manifest is written without them. This is just a consistency fix
so they're all the same.
