### PR TITLE
OCPBUGS-37697: Remove newline in metrics doc literal

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -501,8 +501,7 @@ Testing for the metrics from the cli can also be done directly with a pod that
 curls the metrics service. This is useful for troubleshooting.
 
 ```
-oc run --rm -i --restart=Never --image=registry.fedoraproject.org/fedora-minimal:latest -n openshift-compliance metrics-test -- bash -c 'curl -ks -H "Authorization: Bea
-rer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://metrics.openshift-compliance.svc:8585/metrics-co' | grep compliance
+oc run --rm -i --restart=Never --image=registry.fedoraproject.org/fedora-minimal:latest -n openshift-compliance metrics-test -- bash -c 'curl -ks -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" https://metrics.openshift-compliance.svc:8585/metrics-co' | grep compliance
 ```
 
 ## To use PriorityClass for scans


### PR DESCRIPTION
We have an example in our documentation that tells users how to fetch
metrics using the command line. But, the command has a newline in the
middle of the authorization header, and if you copy/paste it from the
document, like most readers would, it returns an HTTP 404.

Remove the newline so the command works when you copy/paste it from the
documentation, which is the intention.
