### PR TITLE
Add must-gather image builds to release on each push

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -66,3 +66,17 @@ jobs:
       prepare_command: |
         make catalog-docker BUNDLE_IMGS=ghcr.io/complianceascode/compliance-operator-bundle:latest
       platforms: "linux/amd64,linux/ppc64le,linux/s390x"
+
+  must-gather-latest:
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
+    with:
+      name: must-gather-ocp
+      registry_org: complianceascode
+      tag: latest
+      dockerfile_path: images/must-gather/Dockerfile.ocp
+      vendor: "Compliance Operator Authors"
+      platforms: "linux/amd64,linux/ppc64le,linux/s390x"


### PR DESCRIPTION
Previously, we were only updating the must-gather image when updating
specific must-gather files in utils and images. This commit adds it to
the release GitHub action so that it pushes a new container image for
each push to master, which should keep the image up-to-date.
