### PR TITLE
Fix must-gather base image

### DIFF
--- a/images/must-gather/Dockerfile.ocp
+++ b/images/must-gather/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.17:cli
+FROM quay.io/openshift/origin-cli:latest
 
 COPY utils/must-gather/gather* /usr/bin/
 COPY utils/must-gather/fetch-raw-results-pod-template.yaml /usr/share/


### PR DESCRIPTION
The image we were using wasn't accessible through GitHub actions,
because it's in a CI registry. Use an equivalent image from Quay so that
we can build must-gather images with GitHub actions.
