### PR TITLE
Remove multi-arch support from must-gather image

### DIFF
--- a/.github/workflows/must-gather-latest.yml
+++ b/.github/workflows/must-gather-latest.yml
@@ -17,4 +17,4 @@ jobs:
       tag: latest
       dockerfile_path: images/must-gather/Dockerfile.ocp
       vendor: "Compliance Operator Authors"
-      platforms: "linux/amd64,linux/ppc64le,linux/s390x"
+      platforms: "linux/amd64"

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -79,4 +79,4 @@ jobs:
       tag: latest
       dockerfile_path: images/must-gather/Dockerfile.ocp
       vendor: "Compliance Operator Authors"
-      platforms: "linux/amd64,linux/ppc64le,linux/s390x"
+      platforms: "linux/amd64"


### PR DESCRIPTION
We're struggling to find a multi-arch image we can use for building the
must-gather image. This causes the GitHub action we have wired up to
build the image automatically to fail.

This commit removes power and z support for now so we can get some
builds produces that incorporate the new must-gather tooling.
