### PR TITLE
CMP-2615: Add a check aggregate to the compliance scan metadata

### DIFF
--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -22,6 +22,10 @@ const ComplianceScanRescanAnnotation = "compliance.openshift.io/rescan"
 // "api-checks" in the annotation.
 const ComplianceScanTimeoutAnnotation = "compliance.openshift.io/timeout"
 
+// ComplianceCheckCountAnnotation indicates the number of checks
+// that a ComplianceScan has generated during the scan
+const ComplianceCheckCountAnnotation = "compliance.openshift.io/check-count"
+
 // ComplianceScanLabel serves as an indicator for which ComplianceScan
 // owns the referenced object
 const ComplianceScanLabel = "compliance.openshift.io/scan-name"

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -876,6 +876,13 @@ func (f *Framework) WaitForScanStatus(namespace, name string, targetStatus compv
 			return false, nil
 		}
 
+		if exampleComplianceScan.Status.Phase != compv1alpha1.PhaseDone && exampleComplianceScan.Status.Phase != compv1alpha1.PhasePending {
+			// check we should not have checkCount annotation
+			if exampleComplianceScan.Annotations[compv1alpha1.ComplianceCheckCountAnnotation] != "" {
+				return true, fmt.Errorf("compliancescan %s has unset checkCount annotation", name)
+			}
+		}
+
 		if exampleComplianceScan.Status.Phase == targetStatus {
 			return true, nil
 		}


### PR DESCRIPTION
Implement a total check count as an annotation of the ComplianceScan, we will add an annotation `compliance.openshift.io/check-count` to every `compliancescan` object when a scan is in `Done` state. 

Noted: This annotation is removed when a new scanPhase begins.

example of output
```yaml
[vincent@node test-file]$ oc get scan ocp4-cis -o yaml
apiVersion: compliance.openshift.io/v1alpha1
kind: ComplianceScan
metadata:
  annotations:
    compliance.openshift.io/check-count: "89"
  creationTimestamp: "2024-08-15T04:42:36Z"
  finalizers:
  - scan.finalizers.compliance.openshift.io
  generation: 1
  labels:
    compliance.openshift.io/profile-guid: a230315d-3e4a-5b58-b00f-f96f1553e036
    compliance.openshift.io/suite: ocp4-cis-ssb
  name: ocp4-cis
```