### PR TITLE
Add events to must-gather image

### DIFF
--- a/utils/must-gather/gather_compliance
+++ b/utils/must-gather/gather_compliance
@@ -47,7 +47,7 @@ wait
 
 # Pod logs, describes
 NAMESPACES=(openshift-compliance)
-APIRESOURCES=(configmaps pods routes roles rolebindings serviceaccounts services leases)
+APIRESOURCES=(configmaps pods routes roles rolebindings serviceaccounts services leases events pvc pv)
 
 for NAMESPACE in ${NAMESPACES[@]}
 do


### PR DESCRIPTION
Events are really helpful in debugging what's happening in the
openshift-compliance namespace. Add them to the must-gather image so
they get populated in must-gather reports by default.
