### PR TITLE
CMP-2614: Implement update timestamps on ComplianceCheckResults

### DIFF
--- a/cmd/manager/common.go
+++ b/cmd/manager/common.go
@@ -2,10 +2,11 @@ package manager
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/discovery"
 	"os"
 	"path/filepath"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
 
 	ocpcfgv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -25,7 +26,8 @@ import (
 )
 
 const (
-	maxRetries = 15
+	maxRetries             = 15
+	maxRetriesForTimestamp = 3
 )
 
 var cmdLog = logf.Log.WithName("cmd")

--- a/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancecheckresult_types.go
@@ -22,6 +22,9 @@ const ComplianceCheckResultHasRemediation = "compliance.openshift.io/automated-r
 // across the target nodes
 const ComplianceCheckInconsistentLabel = "compliance.openshift.io/inconsistent-check"
 
+// LastScannedTimestampAnnotation
+const LastScannedTimestampAnnotation = "compliance.openshift.io/last-scanned-timestamp"
+
 // ComplianceCheckResultRuleAnnotation exposes the DNS-friendly name of a rule as a label.
 // This provides a way to link a result to a Rule object.
 const ComplianceCheckResultRuleAnnotation = "compliance.openshift.io/rule"

--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -651,6 +651,63 @@ func TestSingleScanSucceeds(t *testing.T) {
 	}
 }
 
+func TestSingleScanTimestamps(t *testing.T) {
+	t.Parallel()
+	f := framework.Global
+
+	scanName := framework.GetObjNameFromTest(t)
+	testScan := &compv1alpha1.ComplianceScan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scanName,
+			Namespace: f.OperatorNamespace,
+		},
+		Spec: compv1alpha1.ComplianceScanSpec{
+			Profile: "xccdf_org.ssgproject.content_profile_moderate",
+			Content: framework.RhcosContentFile,
+			Rule:    "xccdf_org.ssgproject.content_rule_no_netrc_files",
+			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+				Debug: true,
+			},
+		},
+	}
+	// use Context's create helper to create the object and add a cleanup function for the new object
+	err := f.Client.Create(context.TODO(), testScan, nil)
+	if err != nil {
+		t.Fatalf("failed to create scan %s: %s", scanName, err)
+	}
+	defer f.Client.Delete(context.TODO(), testScan)
+
+	err = f.WaitForScanStatus(f.OperatorNamespace, scanName, compv1alpha1.PhaseDone)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assertComplianceCheckResultTimestamps checks that the timestamps are set
+	// and that they are set to the same value of startTimestamp of the scan
+	err = f.AssertComplianceCheckResultTimestamps(scanName, f.OperatorNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// rerun the scan
+	err = f.ReRunScan(scanName, f.OperatorNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = f.WaitForScanStatus(f.OperatorNamespace, scanName, compv1alpha1.PhaseDone)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// assertComplianceCheckResultTimestamps checks that the timestamps are set
+	// and that they are set to the same value of startTimestamp of the scan
+	err = f.AssertComplianceCheckResultTimestamps(scanName, f.OperatorNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
 func TestScanProducesRemediations(t *testing.T) {
 	t.Parallel()
 	f := framework.Global


### PR DESCRIPTION
Adding the lastscanned timestamp annotation in each `complianceCheckResult`, added annotation `compliance.openshift.io/last-scanned-timestamp` with a value equal to `scan.status.StartTimestamp`

example of CCR
```yaml
kind: ComplianceCheckResult
metadata:
  annotations:
    compliance.openshift.io/last-scanned-timestamp: "2024-08-15T04:26:11Z"
    compliance.openshift.io/rule: scc-limit-root-containers
  creationTimestamp: "2024-08-15T04:26:43Z"
  generation: 1
  labels:
    compliance.openshift.io/check-severity: medium
    compliance.openshift.io/check-status: MANUAL
    compliance.openshift.io/profile-guid: a230315d-3e4a-5b58-b00f-f96f1553e036
    compliance.openshift.io/scan-name: ocp4-cis
    compliance.openshift.io/suite: ocp4-cis-ssb
  name: ocp4-cis-scc-limit-root-containers
  namespace: openshift-compliance
```
```yaml
[vincent@node compliance-operator]$ oc get scan ocp4-cis -o yaml
apiVersion: compliance.openshift.io/v1alpha1
kind: ComplianceScan
metadata:
  creationTimestamp: "2024-08-15T04:26:10Z"
  finalizers:
  - scan.finalizers.compliance.openshift.io
  generation: 1
  labels:
    compliance.openshift.io/profile-guid: a230315d-3e4a-5b58-b00f-f96f1553e036
    compliance.openshift.io/suite: ocp4-cis-ssb
  name: ocp4-cis
  namespace: openshift-compliance
  ownerReferences:
  - apiVersion: compliance.openshift.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: ComplianceSuite
    name: ocp4-cis-ssb
    uid: b80577a9-de77-4b7f-af6c-cfb7eee7e36f
  resourceVersion: "5290391"
  uid: 7abb45d7-1a61-491a-bbc1-306406d75e04
spec:
  content: ssg-ocp4-ds.xml
  contentImage: ghcr.io/complianceascode/k8scontent:latest
  maxRetryOnTimeout: 3
  profile: xccdf_org.ssgproject.content_profile_cis
  rawResultStorage:
    nodeSelector:
      node-role.kubernetes.io/master: ""
    pvAccessModes:
    - ReadWriteOnce
    rotation: 3
    size: 1Gi
    tolerations:
    - effect: NoSchedule
      key: node-role.kubernetes.io/master
      operator: Exists
    - effect: NoExecute
      key: node.kubernetes.io/not-ready
      operator: Exists
      tolerationSeconds: 300
    - effect: NoExecute
      key: node.kubernetes.io/unreachable
      operator: Exists
      tolerationSeconds: 300
    - effect: NoSchedule
      key: node.kubernetes.io/memory-pressure
      operator: Exists
  scanTolerations:
  - operator: Exists
  scanType: Platform
  showNotApplicable: false
  strictNodeScan: true
  timeout: 30m
status:
  conditions:
  - lastTransitionTime: "2024-08-15T04:26:14Z"
    message: Compliance scan run is running the scans
    reason: Running
    status: "True"
    type: Processing
  - lastTransitionTime: "2024-08-15T04:26:11Z"
    message: Compliance scan doesn't have results yet
    reason: Processing
    status: "False"
    type: Ready
  phase: AGGREGATING
  remainingRetries: 3
  result: NOT-AVAILABLE
  resultsStorage:
    name: ocp4-cis
    namespace: openshift-compliance
  startTimestamp: "2024-08-15T04:26:11Z"
```