### PR TITLE
Add PCI-DSS v4.0 reference parser

### DIFF
--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -830,6 +830,10 @@ func newStandardParser() *referenceParser {
 	if pcidssperr != nil {
 		log.Error(nciperr, "Could not register PCI-DSS reference parser") // not much we can do here..
 	}
+	pcidss4perr := p.registerStandard("PCI-DSS-4-0", `^https://docs-prv\.pcisecuritystandards\.org/PCI%20DSS/Standard/PCI-DSS-v4_0\.pdf$`)
+	if pcidss4perr != nil {
+		log.Error(nciperr, "Could not register PCI-DSS-4-0 reference parser") // not much we can do here..
+	}
 	stigperr := p.registerStandard("STIG", `^https://public\.cyber\.mil/stigs/downloads/\?_dl_facet_stigs=container-platform`)
 	if stigperr != nil {
 		log.Error(stigperr, "Could not register STIG reference parser") // not much we can do here..


### PR DESCRIPTION
This ensures the rules part of PCI-DSS v4 profile contains annotations with supported requirement number.

```
$ CONTENT_IMAGE=ghcr.io/complianceascode/k8scontent:12309 make deploy-local
$ oc get rule ocp4-api-server-tls-cert -oyaml
...
id: xccdf_org.ssgproject.content_rule_api_server_tls_cert
kind: Rule
metadata:
  annotations:
    compliance.openshift.io/image-digest: pb-upstream-ocp45qsp7
    compliance.openshift.io/profiles: upstream-ocp4-high,upstream-ocp4-nerc-cip,upstream-ocp4-cis-1-4,upstream-ocp4-moderate-rev-4,upstream-ocp4-cis,upstream-ocp4-cis-1-5,upstream-ocp4-moderate,upstream-ocp4-pci-dss,upstream-ocp4-pci-dss-3-2,upstream-ocp4-high-rev-4,upstream-ocp4-pci-dss-4-0
    compliance.openshift.io/rule: api-server-tls-cert
    control.compliance.openshift.io/CIS-OCP: 1.2.28
    control.compliance.openshift.io/NERC-CIP: CIP-003-8 R4.2;CIP-007-3 R5.1
    control.compliance.openshift.io/NIST-800-53: SC-8;SC-8(1);SC-8(2)
    control.compliance.openshift.io/PCI-DSS: Req-2.2;Req-2.2.3;Req-2.3
    control.compliance.openshift.io/PCI-DSS-4-0: 2.2.5;2.2.7;4.2.1
    control.compliance.openshift.io/STIG: SRG-APP-000441-CTR-001090;SRG-APP-000442-CTR-001095
    policies.open-cluster-management.io/controls: CIP-003-8 R4.2,CIP-007-3 R5.1,SC-8,SC-8(1),SC-8(2),Req-2.2,Req-2.2.3,Req-2.3,SRG-APP-000441-CTR-001090,SRG-APP-000442-CTR-001095,1.2.28,2.2.5,2.2.7,4.2.1
    policies.open-cluster-management.io/standards: NERC-CIP,NIST-800-53,PCI-DSS,STIG,CIS-OCP,PCI-DSS-4-0
...
```