### PR TITLE
Fix GHA for bundle tests

### DIFF
--- a/.github/workflows/bundle_tests.yaml
+++ b/.github/workflows/bundle_tests.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
   pull_request:
-      - master
+    branches: [ master ]
 jobs:
   main:
     name: tests


### PR DESCRIPTION
The bundle test action has been failing with:

  Error
  Invalid type for `on`

This commit attempts to fix that by updating the `on` configuration to
use branches, which is what we do elsewhere in our actions.
