### PR TITLE
Update bundle manifests

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -252,6 +252,7 @@ spec:
           - kubeapiservers
           - openshiftapiservers
           - networks
+          - kubedeschedulers
           verbs:
           - get
           - list
@@ -1251,6 +1252,14 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - ingresscontrollers
+          verbs:
+          - get
+          - list
+          - patch
         serviceAccountName: compliance-operator
       - rules:
         - apiGroups:
@@ -1669,7 +1678,5 @@ spec:
     name: operator
   - image: ghcr.io/complianceascode/k8scontent:latest
     name: profile
-  - image: ghcr.io/complianceascode/must-gather-ocp:latest
-    name: must-gather
   replaces: compliance-operator.v1.4.1
   version: 1.5.0


### PR DESCRIPTION
The github action we have for making sure we update the bundle in PRs
broke, causing some changes to slip into the operator without updating
the bundle manifests.

This commit updates the bundle by running `make verify-bundle` then
committing the changes.

The manifests changes reflect updates we made to the operator so that it
has the necessary permissions for ingresscontrollers and
kubedeschedulers.
