### PR TITLE
Update bundle annotations to include must-gather image

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -160,6 +160,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
+    must-gather-image: ghcr.io/complianceascode/must-gather-ocp:latest
     olm.skipRange: '>=0.1.17 <1.5.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance

--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -160,6 +160,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
+    must-gather-image: ghcr.io/complianceascode/must-gather-ocp:latest
     olm.skipRange: '>=0.1.17 <1.5.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance


### PR DESCRIPTION
Since we have a must-gather image, we should advertise that information
through the bundle. We typically do this using `RELATED_IMAGES`, which
the operator uses to find container images it needs to do things like
profile parsing or scanning.

While we can use `RELATED_IMAGES` for the must-gather image, the
Compliance Operator doesn't use the must-gather image directly. Instead,
we can put it in the annotation of the bundle CSV, so it's still
discoverable to users, while not polluting the operator environment with
variables it doesn't need.
