### PR TITLE
Add BSI reference parser

### DIFF
--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -814,6 +814,10 @@ func newStandardParser() *referenceParser {
 	if err != nil {
 		log.Error(err, "Could not register NIST-800-53 reference parser") // not much we can do here..
 	}
+	bsiperr := p.registerStandard("BSI", `^https://www\.bsi\.bund\.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022\.pdf$`)
+	if bsiperr != nil {
+		log.Error(bsiperr, "Could not register BSI reference parser") // not much we can do here..
+	}
 	cocperr := p.registerStandard("CIS-OCP", `^https://www\.cisecurity\.org/benchmark/kubernetes/$`)
 	if cocperr != nil {
 		log.Error(cocperr, "Could not register CIS OpenShift reference parser") // not much we can do here..


### PR DESCRIPTION
This adds BSI to the standards annotation:
`policies.open-cluster-management.io/standards: BSI`

And adds the requirement number to the following annotaions::
- `control.compliance.openshift.io/BSI`
- `policies.open-cluster-management.io/controls`

For example:
`$ oc get rule upstream-ocp4-kubeadmin-removed -oyaml`
```yaml
apiVersion: compliance.openshift.io/v1alpha1
...
kind: Rule
metadata:
  annotations:
    compliance.openshift.io/image-digest: pb-upstream-ocp49577j
    compliance.openshift.io/profiles: upstream-ocp4-high-rev-4,upstream-ocp4-pci-dss,upstream-ocp4-high,upstream-ocp4-pci-dss-3-2,upstream-ocp4-cis-1-4,upstream-ocp4-cis-1-5,upstream-ocp4-cis,upstream-ocp4-stig-v1r1,upstream-ocp4-nerc-cip,upstream-ocp4-bsi,upstream-ocp4-bsi-2022,upstream-ocp4-moderate-rev-4,upstream-ocp4-moderate,upstream-ocp4-pci-dss-4-0,upstream-ocp4-stig
    compliance.openshift.io/rule: kubeadmin-removed
    control.compliance.openshift.io/BSI: APP.4.4.A3
    control.compliance.openshift.io/CIS-OCP: 3.1.1;5.1.1
    control.compliance.openshift.io/NERC-CIP: CIP-004-6 R2.2.2;CIP-004-6 R2.2.3;CIP-007-3
      R.1.3;CIP-007-3 R2;CIP-007-3 R5;CIP-007-3 R5.1.1;CIP-007-3 R5.1.3;CIP-007-3
      R5.2.1;CIP-007-3 R5.2.3;CIP-007-3 R6.1;CIP-007-3 R6.2;CIP-007-3 R6.3;CIP-007-3
      R6.4
    control.compliance.openshift.io/NIST-800-53: AC-2(2);AC-2(7);AC-2(9);AC-2(10);AC-12(1);IA-2(5);MA-4;SC-12(1)
    control.compliance.openshift.io/PCI-DSS: Req-2.1
    control.compliance.openshift.io/STIG: SRG-APP-000023-CTR-000055;CNTR-OS-000030;CNTR-OS-000040;CNTR-OS-000440
    policies.open-cluster-management.io/controls: APP.4.4.A3,CIP-004-6 R2.2.2,CIP-004-6
      R2.2.3,CIP-007-3 R.1.3,CIP-007-3 R2,CIP-007-3 R5,CIP-007-3 R5.1.1,CIP-007-3
      R5.1.3,CIP-007-3 R5.2.1,CIP-007-3 R5.2.3,CIP-007-3 R6.1,CIP-007-3 R6.2,CIP-007-3
      R6.3,CIP-007-3 R6.4,AC-2(2),AC-2(7),AC-2(9),AC-2(10),AC-12(1),IA-2(5),MA-4,SC-12(1),Req-2.1,SRG-APP-000023-CTR-000055,3.1.1,5.1.1,CNTR-OS-000030,CNTR-OS-000040,CNTR-OS-000440
    policies.open-cluster-management.io/standards: BSI,NERC-CIP,NIST-800-53,PCI-DSS,STIG,CIS-OCP
  creationTimestamp: "2024-08-30T09:28:16Z"
...
```