### PR TITLE
Allow access to clusterlogforwarder in observability API

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -996,6 +996,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - observability.openshift.io
+          resources:
+          - clusterlogforwarders
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - flowcontrol.apiserver.k8s.io
           resourceNames:
           - catch-all

--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -1093,6 +1093,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - observability.openshift.io
+          resources:
+          - clusterlogforwarders
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - flowcontrol.apiserver.k8s.io
           resourceNames:
           - catch-all

--- a/config/rbac/api_resource_collector_cluster_role.yaml
+++ b/config/rbac/api_resource_collector_cluster_role.yaml
@@ -760,6 +760,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - observability.openshift.io
+    resources:
+      - clusterlogforwarders
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - flowcontrol.apiserver.k8s.io
     resources:
       - flowschemas


### PR DESCRIPTION
In cluster logging operator 6.0 the `ClusterlogForwarder` moved from `logging.openshift.io` to `observability.openshift.io`.

CO will need to access `ClusterlogForwarder` from both APIs.