### PR TITLE
add read permission for kataconfig

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1098,6 +1098,13 @@ spec:
           verbs:
           - get
           - list
+        - apiGroups:
+          - kataconfiguration.openshift.io
+          resources:
+          - kataconfigs
+          verbs:
+          - list
+          - get
         serviceAccountName: api-resource-collector
       - rules:
         - apiGroups:

--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -1176,6 +1176,13 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - kataconfiguration.openshift.io
+          resources:
+          - kataconfigs
+          verbs:
+          - list
+          - get
         serviceAccountName: api-resource-collector
       - rules:
         - apiGroups:

--- a/config/rbac/api_resource_collector_cluster_role.yaml
+++ b/config/rbac/api_resource_collector_cluster_role.yaml
@@ -867,3 +867,11 @@ rules:
     verbs:
       - get
       - list
+  # Necessary to check for sandboxed-containers config for BSI requirements
+  - apiGroups:
+      - kataconfiguration.openshift.io
+    verbs:
+      - list
+      - get
+    resources:
+      - kataconfigs


### PR DESCRIPTION
This PR adds permissions to read the kataconfigs for the api-resource-collector.

This is related to a complianceascode/content PR which checks, that a proper isolation between containers is guaranteed


first I only changed the file under config/rbac but this let the tests fail. so I followed what was done in:
https://github.com/ComplianceAsCode/compliance-operator/commit/90eb2a7d38700266b6bd9a02a537323dc8c0e026

this might or might not be the correct way, but fixes the failing test :)