### PR TITLE
Remove unnecessary subscription from operator Dockerfile

### DIFF
--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -14,7 +14,6 @@ FROM registry.redhat.io/ubi9/ubi:latest
 
 RUN INSTALL_PKGS="tar" && \
     if [ ! -e /usr/bin/dnf ]; then ln -s /usr/bin/microdnf /usr/bin/dnf; fi && \
-        subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey") && \
         dnf update glibc -y && \
         dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
         dnf clean all && rm -rf /var/cache/*


### PR DESCRIPTION
Konflux is erroring out because the system is already registered, even
though it's from a previous container. Remove the second subscription
registration so that we don't error out installing dependencies we need
for the operator container image.
