### PR TITLE
Allow must-gather pod to run on master nodes

### DIFF
--- a/utils/must-gather/fetch-raw-results-pod-template.yaml
+++ b/utils/must-gather/fetch-raw-results-pod-template.yaml
@@ -19,6 +19,10 @@ spec:
         allowPrivilegeEscalation: false
         capabilities:
           drop: [ALL]
+  tolerations:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
   volumes:
     - name: results-vol
       persistentVolumeClaim:


### PR DESCRIPTION
After running CO's `must-gather` image,  there were no raw-results collected.

```
[must-gather-9qghh] POD 2024-12-05T13:16:30.192357799Z + oc create -n openshift-compliance -f /must-gather/openshift-compliance/raw-results//extract-pods//must-gather-raw-results-ocp4-cis-node-worker-pod.yaml                              
[must-gather-9qghh] POD 2024-12-05T13:16:30.201245730Z + CLAIMNAME=ocp4-cis               
[must-gather-9qghh] POD 2024-12-05T13:16:30.201289161Z + EXTRACT_POD_NAME=must-gather-raw-results-ocp4-cis                                                                                                                                    
[must-gather-9qghh] POD 2024-12-05T13:16:30.201289161Z + sed s/%CLAIMNAME%/ocp4-cis/g /usr/share/fetch-raw-results-pod-template.yaml                                                                                                          
[must-gather-9qghh] POD 2024-12-05T13:16:30.204334081Z + oc create -n openshift-compliance -f /must-gather/openshift-compliance/raw-results//extract-pods//must-gather-raw-results-ocp4-cis-pod.yaml
[must-gather-9qghh] POD 2024-12-05T13:16:30.210048980Z + CLAIMNAME=ocp4-cis-node-master                                                                                                                                                       
[must-gather-9qghh] POD 2024-12-05T13:16:30.210728787Z + EXTRACT_POD_NAME=must-gather-raw-results-ocp4-cis-node-master                                                                                                                        
[must-gather-9qghh] POD 2024-12-05T13:16:30.210728787Z + sed s/%CLAIMNAME%/ocp4-cis-node-master/g /usr/share/fetch-raw-results-pod-template.yaml                                                                                              
[must-gather-9qghh] POD 2024-12-05T13:16:30.213622313Z + oc create -n openshift-compliance -f /must-gather/openshift-compliance/raw-results//extract-pods//must-gather-raw-results-ocp4-cis-node-master-pod.yaml                              
[must-gather-9qghh] POD 2024-12-05T13:16:30.298190265Z pod/must-gather-raw-results-ocp4-cis-node-worker created
[must-gather-9qghh] POD 2024-12-05T13:16:30.303047951Z + oc wait -n openshift-compliance --for=condition=Ready pod/must-gather-raw-results-ocp4-cis-node-worker                                                                               
[must-gather-9qghh] POD 2024-12-05T13:16:30.316625885Z pod/must-gather-raw-results-ocp4-cis created                                                                                                                                           
[must-gather-9qghh] POD 2024-12-05T13:16:30.320706001Z + oc wait -n openshift-compliance --for=condition=Ready pod/must-gather-raw-results-ocp4-cis
[must-gather-9qghh] POD 2024-12-05T13:16:30.327363294Z pod/must-gather-raw-results-ocp4-cis-node-master created                                                                                                                               
[must-gather-9qghh] POD 2024-12-05T13:16:30.330668210Z + oc wait -n openshift-compliance --for=condition=Ready pod/must-gather-raw-results-ocp4-cis-node-master
[must-gather-9qghh] POD 2024-12-05T13:17:00.401868909Z error: timed out waiting for the condition on pods/must-gather-raw-results-ocp4-cis-node-worker
[must-gather-9qghh] POD 2024-12-05T13:17:00.404516399Z + oc cp -n openshift-compliance must-gather-raw-results-ocp4-cis-node-worker:/scan-results /must-gather/openshift-compliance/raw-results//ocp4-cis-node-worker
[must-gather-9qghh] POD 2024-12-05T13:17:00.419921158Z error: timed out waiting for the condition on pods/must-gather-raw-results-ocp4-cis
[must-gather-9qghh] POD 2024-12-05T13:17:00.423023081Z + oc cp -n openshift-compliance must-gather-raw-results-ocp4-cis:/scan-results /must-gather/openshift-compliance/raw-results//ocp4-cis
[must-gather-9qghh] POD 2024-12-05T13:17:00.423783701Z error: timed out waiting for the condition on pods/must-gather-raw-results-ocp4-cis-node-master
[must-gather-9qghh] POD 2024-12-05T13:17:00.426640166Z + oc cp -n openshift-compliance must-gather-raw-results-ocp4-cis-node-master:/scan-results /must-gather/openshift-compliance/raw-results//ocp4-cis-node-master
[must-gather-9qghh] POD 2024-12-05T13:17:00.488990571Z Error from server (BadRequest): pod must-gather-raw-results-ocp4-cis-node-worker does not have a host assigned
[must-gather-9qghh] POD 2024-12-05T13:17:00.492517734Z + oc delete pod -n openshift-compliance must-gather-raw-results-ocp4-cis-node-worker
[must-gather-9qghh] POD 2024-12-05T13:17:00.512846314Z Error from server (BadRequest): pod must-gather-raw-results-ocp4-cis does not have a host assigned
[must-gather-9qghh] POD 2024-12-05T13:17:00.514363714Z Error from server (BadRequest): pod must-gather-raw-results-ocp4-cis-node-master does not have a host assigned
[must-gather-9qghh] POD 2024-12-05T13:17:00.516027558Z + oc delete pod -n openshift-compliance must-gather-raw-results-ocp4-cis
[must-gather-9qghh] POD 2024-12-05T13:17:00.518140814Z + oc delete pod -n openshift-compliance must-gather-raw-results-ocp4-cis-node-master
[must-gather-9qghh] POD 2024-12-05T13:17:00.601800074Z pod "must-gather-raw-results-ocp4-cis-node-worker" deleted
[must-gather-9qghh] POD 2024-12-05T13:17:00.628436251Z pod "must-gather-raw-results-ocp4-cis" deleted
[must-gather-9qghh] POD 2024-12-05T13:17:00.637039309Z pod "must-gather-raw-results-ocp4-cis-node-master" deleted
```

The pod status shows the following:
```
status:                                                                                                                                                                                                                                       
  conditions:                                                                                                                                                                                                                                 
  - lastProbeTime: null                                                                                                                                                                                                                       
    lastTransitionTime: "2024-12-05T13:20:21Z"                                                                                                                                                                                                
    message: '0/6 nodes are available: 1 node(s) had untolerated taint {node.cloudprovider.kubernetes.io/uninitialized:                                                                                                                       
      true}, 2 node(s) had volume node affinity conflict, 3 node(s) had untolerated                                                                                                                                                           
      taint {node-role.kubernetes.io/master: }. preemption: 0/6 nodes are available:                                                                                                                                                          
      6 Preemption is not helpful for scheduling.'                                                                                                                                                                                            
    reason: Unschedulable                                                                                                                                                                                                                     
    status: "False"                                                                                                                                                                                                                           
    type: PodScheduled                                                                                                                                                                                                                        
  phase: Pending                                                                                                                                                                                                                              
  qosClass: BestEffort   
```


This aligns with `oc-compliance` fetch raw-results pods:
https://github.com/openshift/oc-compliance/blob/c46c6947ec8c02c16753746539cb2fa404af189d/internal/fetchraw/compliancescans.go#L335
