### PR TITLE
Fix OCP reference in golang builder image

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Step one: build compliance-operator
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19 AS builder
 
 WORKDIR /go/src/github.com/openshift/compliance-operator
 


### PR DESCRIPTION
The 4.17 builder image doesn't exist for golang 1.23. Instead, there is
one for 4.19, so let's use that so we can bump to golang 1.23.
