### PR TITLE
Update Konflux docker file to use golang 1.23

### DIFF
--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 as builder
 
 WORKDIR /go/src/github.com/ComplianceAsCode/compliance-operator
 


### PR DESCRIPTION
We recently made some changes to use golang 1.23, but we didn't include the Konflux docker files.

This commit bumps the golang builder image to use golang 1.23 which is what we're using in CI and in go.mod.