### PR TITLE
Fix broken docs link in the Compliance Operator bundle

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1672,7 +1672,7 @@ spec:
   - name: Compliance Operator upstream repository
     url: https://github.com/ComplianceAsCode/compliance-operator
   - name: Compliance Operator documentation
-    url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html
+    url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html
   maintainers:
   - email: support@redhat.com
     name: Red Hat Support

--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -1558,7 +1558,7 @@ spec:
   - name: Compliance Operator upstream repository
     url: https://github.com/ComplianceAsCode/compliance-operator
   - name: Compliance Operator documentation
-    url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html
+    url: https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html
   maintainers:
   - email: support@redhat.com
     name: Red Hat Support

--- a/images/testcontent/new_kubeletconfig/ssg-ocp4-ds.xml
+++ b/images/testcontent/new_kubeletconfig/ssg-ocp4-ds.xml
@@ -15517,7 +15517,7 @@ users to obtain unauthorized access to resources.</xccdf-1.2:rationale>
           </xccdf-1.2:Rule>
           <xccdf-1.2:Rule selected="false" id="xccdf_org.ssgproject.content_rule_scansettingbinding_exists" severity="medium">
             <xccdf-1.2:title>Ensure that Compliance Operator is scanning the cluster</xccdf-1.2:title>
-            <xccdf-1.2:description><html:a href="https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html#compliance-operator-understanding">The Compliance Operator</html:a>
+            <xccdf-1.2:description><html:a href="https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html">The Compliance Operator</html:a>
 scans the hosts and the platform (OCP)
 configurations for software flaws and improper configurations according
 to different compliance benchmarks. It uses OpenSCAP as a backend,
@@ -15559,7 +15559,7 @@ for all systems, to detect potential flaws and unauthorised access.</xccdf-1.2:r
           </xccdf-1.2:Rule>
           <xccdf-1.2:Rule selected="false" id="xccdf_org.ssgproject.content_rule_scansettings_have_schedule" severity="medium">
             <xccdf-1.2:title>Ensure that Compliance Operator scans are running periodically</xccdf-1.2:title>
-            <xccdf-1.2:description><html:a href="https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html#compliance-operator-understanding">The Compliance Operator</html:a>
+            <xccdf-1.2:description><html:a href="https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html">The Compliance Operator</html:a>
 scans the hosts and the platform (OCP)
 configurations for software flaws and improper configurations according
 to different compliance benchmarks. Compliance Operator allows its

--- a/tests/data/ssg-ocp4-ds-suppressed.xml
+++ b/tests/data/ssg-ocp4-ds-suppressed.xml
@@ -18451,7 +18451,7 @@ users to obtain unauthorized access to resources.</xccdf-1.2:rationale>
           </xccdf-1.2:Rule>
           <xccdf-1.2:Rule selected="false" id="xccdf_org.ssgproject.content_rule_scansettingbinding_exists" severity="medium">
             <xccdf-1.2:title>Ensure that Compliance Operator is scanning the cluster</xccdf-1.2:title>
-            <xccdf-1.2:description><html:a href="https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html#compliance-operator-understanding">The Compliance Operator</html:a>
+            <xccdf-1.2:description><html:a href="https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html">The Compliance Operator</html:a>
 scans the hosts and the platform (OCP)
 configurations for software flaws and improper configurations according
 to different compliance benchmarks. It uses OpenSCAP as a backend,
@@ -18493,7 +18493,7 @@ for all systems, to detect potential flaws and unauthorised access.</xccdf-1.2:r
           </xccdf-1.2:Rule>
           <xccdf-1.2:Rule selected="false" id="xccdf_org.ssgproject.content_rule_scansettings_have_schedule" severity="medium">
             <xccdf-1.2:title>Ensure that Compliance Operator scans are running periodically</xccdf-1.2:title>
-            <xccdf-1.2:description><html:a href="https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html#compliance-operator-understanding">The Compliance Operator</html:a>
+            <xccdf-1.2:description><html:a href="https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html">The Compliance Operator</html:a>
 scans the hosts and the platform (OCP)
 configurations for software flaws and improper configurations according
 to different compliance benchmarks. Compliance Operator allows its


### PR DESCRIPTION
The old link pointed to a section of the compliance operator documentation before it was overhauled and reorganized.

This commit updates the documentation reference in the bundle so it points to the right document, and doesn't return a 404.