### PR TITLE
Enable ppc and s390x build for konflux

### DIFF
--- a/.tekton/compliance-operator-must-gather-pull-request.yaml
+++ b/.tekton/compliance-operator-must-gather-pull-request.yaml
@@ -30,6 +30,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: images/must-gather/Containerfile
   - name: hermetic

--- a/.tekton/compliance-operator-must-gather-push.yaml
+++ b/.tekton/compliance-operator-must-gather-push.yaml
@@ -26,6 +26,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: images/must-gather/Containerfile
   - name: hermetic

--- a/.tekton/compliance-operator-openscap-pull-request.yaml
+++ b/.tekton/compliance-operator-openscap-pull-request.yaml
@@ -30,6 +30,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: images/openscap/Containerfile
   - name: path-context

--- a/.tekton/compliance-operator-openscap-push.yaml
+++ b/.tekton/compliance-operator-openscap-push.yaml
@@ -26,6 +26,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: images/openscap/Containerfile
   - name: path-context

--- a/.tekton/compliance-operator-pull-request.yaml
+++ b/.tekton/compliance-operator-pull-request.yaml
@@ -29,6 +29,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: images/operator/Dockerfile
   - name: hermetic

--- a/.tekton/compliance-operator-push.yaml
+++ b/.tekton/compliance-operator-push.yaml
@@ -26,6 +26,8 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: images/operator/Dockerfile
   - name: hermetic


### PR DESCRIPTION
This commit enables power and Z builds for the operator, openscap, and
must-gather images.

Subsequent patches will enable it for the bundle build, which needs to
enable hermetic builds, too.
