### PR TITLE
bump co version 1.6.2 dev

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -161,7 +161,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
     must-gather-image: ghcr.io/complianceascode/must-gather-ocp:latest
-    olm.skipRange: '>=0.1.17 <1.6.0'
+    olm.skipRange: '>=0.1.17 <1.6.2-dev'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
@@ -175,7 +175,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: compliance-operator.v1.6.0
+  name: compliance-operator.v1.6.2-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1687,5 +1687,5 @@ spec:
     name: operator
   - image: ghcr.io/complianceascode/k8scontent:latest
     name: profile
-  replaces: compliance-operator.v1.5.0
-  version: 1.6.0
+  replaces: compliance-operator.v1.6.1
+  version: 1.6.2-dev

--- a/catalog/preamble.json
+++ b/catalog/preamble.json
@@ -13,8 +13,8 @@
     "package": "compliance-operator",
     "entries": [
         {
-            "name": "compliance-operator.v1.6.0",
-            "skipRange": ">=0.1.17 <1.6.0"
+            "name": "compliance-operator.v1.6.2-dev",
+            "skipRange": ">=0.1.17 <1.6.2-dev"
         }
     ]
 }

--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -161,7 +161,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
     must-gather-image: ghcr.io/complianceascode/must-gather-ocp:latest
-    olm.skipRange: '>=0.1.17 <1.6.0'
+    olm.skipRange: '>=0.1.17 <1.6.2-dev'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
@@ -173,7 +173,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: compliance-operator.v0.1.53
+  name: compliance-operator.v1.6.2-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1566,5 +1566,5 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  replaces: compliance-operator.v1.5.0
-  version: 1.6.0
+  replaces: compliance-operator.v1.6.1
+  version: 1.6.2-dev

--- a/version.Makefile
+++ b/version.Makefile
@@ -2,4 +2,4 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 
-VERSION?=1.6.0
+VERSION?=1.6.2-dev

--- a/version.Makefile
+++ b/version.Makefile
@@ -2,4 +2,5 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 
+PREVIOUS_VERSION?=1.6.1
 VERSION?=1.6.2-dev


### PR DESCRIPTION
- **Bump CO version for 1.6.2 development**
- **Use make to set versions in manifests**
- **Update manifests to include 1.6.2-dev**
