### PR TITLE
CMP-3117: Add arm64 label to bundle CSV

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -173,6 +173,7 @@ metadata:
     support: Red Hat Inc.
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
   name: compliance-operator.v1.6.2-dev

--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -171,6 +171,7 @@ metadata:
     support: Red Hat Inc.
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
   name: compliance-operator.v1.6.2-dev


### PR DESCRIPTION
This commit implements support for running the Compliance Operator on
ARM64 architecture.
