### PR TITLE
Build test content using arm64

### DIFF
--- a/.github/workflows/test-broken-content-latest.yml
+++ b/.github/workflows/test-broken-content-latest.yml
@@ -71,6 +71,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          platforms: "linux/amd64,linux/ppc64le,linux/s390x"
+          platforms: "linux/amd64,linux/ppc64le,linux/s390x,linux/arm64"
           build-args: |
             "xml_path=images/testcontent/${{ matrix.TAG }}"


### PR DESCRIPTION
TestManualRulesTailoredProfile is failing on arm64 clusters because the
test content we're using isn't built for arm64, resulting in the
following test case error:

   waiting ProfileBundle test-manual-rules-tailored-profile to become VALID (INVALID)
   ProfileBundle test-manual-rules-tailored-profile failed to reach state VALID

This commit updates the github action we use to build the test image so
that it starts building for arm64.
