### PR TITLE
Run test-broken-content-latest action when updated

### DIFF
--- a/.github/workflows/test-broken-content-latest.yml
+++ b/.github/workflows/test-broken-content-latest.yml
@@ -2,6 +2,7 @@ on:
   push:
     paths:
       - "images/testcontent/**"
+      - ".github/workflows/test-broken-content-latest.yml"
 
 jobs:
   test-broken-content-container-push:


### PR DESCRIPTION
This commit updates the test-broken-content-latest github action so that
it will rebuild the test content when the action is changed or updated.
This means we don't need to look for minor changes to make in the
images/testcontent directory each time we want to incorporate a change
into the image becuase the workflow changed.
