### PR TITLE
Fix Release Image Action

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -154,4 +154,4 @@ jobs:
             ```
             make catalog-deploy CATALOG_IMG=ghcr.io/complianceascode/compliance-operator-catalog:${{ needs.get-pr-number.outputs.pr-number }}-${{ needs.get-pr-number.outputs.commit_sha }}
             ```
-          pr_number: ${{ needs.get-pr-number.outputs.pr-number }}
+          pr-number: ${{ needs.get-pr-number.outputs.pr-number }}


### PR DESCRIPTION
Our github action to build images for each PR for testing was failing
with the following trace:

 Warning: Unexpected input(s) 'pr_number', valid inputs are ['message',
 'file-path', 'github-token', 'reactions', 'pr-number', 'comment-tag',
 'mode', 'create-if-not-exists']

I think this was causing the job to fail because it wasn't getting the
PR number to leave the comment:

  Error: No issue/pull request in input neither in current context.

This commit attempts to fix this issue by using the correct key
(pr-number).
