### PR TITLE
OCPBUGS-51267: Fix an issue in the ComplianceScan controller

### DIFF
--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -297,7 +297,7 @@ func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.Com
 	if instance.NeedsTimeoutRescan() {
 		instanceCopy := instance.DeepCopy()
 		delete(instanceCopy.Annotations, compv1alpha1.ComplianceScanTimeoutAnnotation)
-		delete(instanceCopy.Annotations, compv1alpha1.ComplianceScanTimeoutAnnotation)
+		delete(instanceCopy.Annotations, compv1alpha1.ComplianceCheckCountAnnotation)
 		err := r.Client.Update(context.TODO(), instanceCopy)
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
We were doing two updates without re‐fetching. This fixes it by ensuring we re-fetch before going to do the next step.

This will help with the stability of the controller logic.