### PR TITLE
Revert arm64 support for must-gather image

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -79,4 +79,4 @@ jobs:
       tag: latest
       dockerfile_path: images/must-gather/Dockerfile.ocp
       vendor: "Compliance Operator Authors"
-      platforms: "linux/amd64,linux/arm64"
+      platforms: "linux/amd64"


### PR DESCRIPTION
https://github.com/ComplianceAsCode/compliance-operator/pull/679 added
support for building arm64 images, but breaks with the must-gather image
because it uses quay.io/openshift/origin-cli:latest, which doesn't have
an arm64 build:

  ERROR: failed to solve: quay.io/openshift/origin-cli:latest: failed to
  resolve source metadata for quay.io/openshift/origin-cli:latest: no
  match for platform in manifest: not found

Backout this change so the Release Latest workflow doesn't fail on
must-gather builds.
