### PR TITLE
CMP-3121: Increase unit test timeout to 20 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ E2E_TEST_TYPE?=all
 # E2E_CLEANUP_ON_ERROR=true make e2e
 E2E_CLEANUP_ON_ERROR?=false
 E2E_ARGS=-root=$(PROJECT_DIR) -globalMan=$(TEST_CRD) -namespacedMan=$(TEST_DEPLOY) -cleanupOnError=$(E2E_CLEANUP_ON_ERROR) -testType=$(E2E_TEST_TYPE)
-TEST_OPTIONS?=
+TEST_OPTIONS?=-timeout=20m
 # Skip pushing the container to your cluster
 E2E_SKIP_CONTAINER_PUSH?=false
 # Use default images in the e2e test run. Note that this takes precedence over E2E_SKIP_CONTAINER_PUSH


### PR DESCRIPTION
We're seeing arm64 builds timeout because 10 minutes isn't enough time
to run the unit tests. However, when testing this on a native arm64
machine, the run time difference is negligible. One possibility is that
because the Github Action runner is using amd64 under the hood, it's
taking longer to cross-compile and build for arm64.

This commit doubles the unit test timeout from 10m to 20m to see if this
helps improve arm64 build stability.
