### PR TITLE
OCPBUGS-48461: enhance error handling for PrometheusMetricTargets

### DIFF
--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -459,7 +459,7 @@ func TestServiceMonitoringMetricsTarget(t *testing.T) {
 	}
 	defer f.CleanUpRBACForMetricsTest()
 
-	metricsTargets, err := f.GetPrometheusMetricTargets()
+	metricsTargets, err := f.WaitForPrometheusMetricTargets()
 	if err != nil {
 		t.Fatalf("failed to get prometheus metric targets: %s", err)
 	}


### PR DESCRIPTION
Wrap the `GetPrometheusMetricTargets` call with wait.Poll so it retries on transient oc command failures, preventing the `error getting output: exit status 1` failures

[OCPBUGS-48461](https://issues.redhat.com/browse/OCPBUGS-48461)
