### PR TITLE
CMP-3149: Handle profile deprecation

### DIFF
--- a/pkg/apis/compliance/v1alpha1/profilebundle_types.go
+++ b/pkg/apis/compliance/v1alpha1/profilebundle_types.go
@@ -16,6 +16,9 @@ const ProfileBundleOwnerLabel = "compliance.openshift.io/profile-bundle"
 // ProfileImageDigestAnnotation is the parsed out digest of the content image
 const ProfileImageDigestAnnotation = "compliance.openshift.io/image-digest"
 
+// ProfileStatusAnnotation is the parsed out status from the data stream
+const ProfileStatusAnnotation = "compliance.openshift.io/profile-status"
+
 // DataStreamStatusType is the type for the data stream status
 type DataStreamStatusType string
 

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -369,12 +369,13 @@ func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.Com
 	err := r.notifyUseOfDeprecatedProfile(instance, logger)
 	if err != nil {
 		logger.Error(err, "Could not check whether the Profile used by ComplianceScan is deprecated", "ComplianceScan", instance.Name)
-		instance.Status.Phase = compv1alpha1.PhaseDone
-		instance.Status.Result = compv1alpha1.ResultError
-		instance.Status.ErrorMessage = "Could not check whether the Profile used by ComplianceScan is deprecated"
-		instance.Status.StartTimestamp = &metav1.Time{Time: time.Now()}
-		instance.Status.EndTimestamp = &metav1.Time{Time: time.Now()}
-		err = r.Client.Status().Update(context.TODO(), instance)
+		instanceCopy := instance.DeepCopy()
+		instanceCopy.Status.Phase = compv1alpha1.PhaseDone
+		instanceCopy.Status.Result = compv1alpha1.ResultError
+		instanceCopy.Status.ErrorMessage = "Could not check whether the Profile used by ComplianceScan is deprecated"
+		instanceCopy.Status.StartTimestamp = &metav1.Time{Time: time.Now()}
+		instanceCopy.Status.EndTimestamp = &metav1.Time{Time: time.Now()}
+		err = r.Client.Status().Update(context.TODO(), instanceCopy)
 		if err != nil {
 			logger.Error(err, "Cannot update the status")
 			return reconcile.Result{}, err

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -137,6 +137,9 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 						Size:          compv1alpha1.DefaultRawStorageSize,
 					},
 				},
+				ContentImage: "MyContentImage",
+				Content:      "MyContentFile",
+				Profile:      "xccdf_org.ssgproject.content_profile_unmoderate",
 			},
 		}
 		platformscaninstance = &compv1alpha1.ComplianceScan{
@@ -204,12 +207,44 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 			},
 		}
 
-		objs = append(objs, nodeinstance1, nodeinstance2, caSecret, serverSecret, clientSecret, ns)
+		profileList := &compv1alpha1.ProfileList{}
+		profile := &compv1alpha1.Profile{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Profile",
+				APIVersion: compv1alpha1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-product-unmoderate",
+				Namespace: common.GetComplianceOperatorNamespace(),
+			},
+			ProfilePayload: compv1alpha1.ProfilePayload{
+				Title:       "Unmoderate setteings",
+				Description: "Describes obnoxious recommendations",
+				ID:          "xccdf_org.ssgproject.content_profile_unmoderate",
+			},
+		}
+		profileBundleList := &compv1alpha1.ProfileBundleList{}
+		profileBundle := &compv1alpha1.ProfileBundle{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ProfileBundle",
+				APIVersion: compv1alpha1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-product",
+				Namespace: common.GetComplianceOperatorNamespace(),
+			},
+			Spec: compv1alpha1.ProfileBundleSpec{
+				ContentImage: "MyContentImage",
+				ContentFile:  "MyContentFile",
+			},
+		}
+
+		objs = append(objs, nodeinstance1, nodeinstance2, caSecret, serverSecret, clientSecret, ns, profile, profileBundle)
 		scheme := scheme.Scheme
-		scheme.AddKnownTypes(compv1alpha1.SchemeGroupVersion, compliancescaninstance, results)
+		scheme.AddKnownTypes(compv1alpha1.SchemeGroupVersion, compliancescaninstance, results, profile, profileList, profileBundle, profileBundleList)
 
 		statusObjs := []runtimeclient.Object{}
-		statusObjs = append(statusObjs, compliancescaninstance)
+		statusObjs = append(statusObjs, compliancescaninstance, profile)
 
 		client := fake.NewClientBuilder().
 			WithScheme(scheme).

--- a/pkg/controller/tailoredprofile/tailoredprofile_controller.go
+++ b/pkg/controller/tailoredprofile/tailoredprofile_controller.go
@@ -169,6 +169,15 @@ func (r *ReconcileTailoredProfile) Reconcile(ctx context.Context, request reconc
 			return r.setOwnership(tpCopy, p)
 		}
 
+		// Warn that TailoredProfile extends deprecated Profile
+		if p.GetAnnotations()[cmpv1alpha1.ProfileStatusAnnotation] == "deprecated" {
+			reqLogger.Info("TailoredProfile extends a deprecated profile", instance.Name, p.Name)
+			r.Recorder.Eventf(
+				instance, corev1.EventTypeWarning, "DeprecatedTailoredProfile",
+				"TailoredProfile %s is extending a deprecated Profile (%s) that will be removed in a future version of Compliance Operator. "+
+					"Please consider using a newer version of this profile", instance.Name, p.Name)
+		}
+
 	} else {
 		if !isValidationRequired(instance) {
 			// check if the TailoredProfile is empty without any extends

--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -310,6 +310,8 @@ func parseProfileFromNode(profileRoot *xmlquery.Node, pb *cmpv1alpha1.ProfileBun
 		if id == "" {
 			return LogAndReturnError("no id in profile")
 		}
+		// Profile status is an optional field and can be nil
+		status := profileObj.SelectElement("xccdf-1.2:status")
 		title := profileObj.SelectElement("xccdf-1.2:title")
 		if title == nil {
 			return LogAndReturnError("no title in profile")
@@ -387,6 +389,7 @@ func parseProfileFromNode(profileRoot *xmlquery.Node, pb *cmpv1alpha1.ProfileBun
 		}
 
 		annotateWithNonce(&p, nonce)
+		annotateWithStatus(&p, status)
 
 		err := action(&p)
 		if err != nil {
@@ -792,6 +795,17 @@ func annotateWithNonce(o metav1.Object, nonce string) {
 	}
 	annotations[cmpv1alpha1.ProfileImageDigestAnnotation] = nonce
 	o.SetAnnotations(annotations)
+}
+
+func annotateWithStatus(o metav1.Object, status *xmlquery.Node) {
+	if status != nil {
+		annotations := o.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[cmpv1alpha1.ProfileStatusAnnotation] = status.InnerText()
+		o.SetAnnotations(annotations)
+	}
 }
 
 type complianceStandard struct {

--- a/pkg/xccdf/tailoring.go
+++ b/pkg/xccdf/tailoring.go
@@ -88,6 +88,12 @@ func GetXCCDFProfileID(tp *cmpv1alpha1.TailoredProfile) string {
 	return fmt.Sprintf("xccdf_%s_profile_%s", XCCDFNamespace, tp.Name)
 }
 
+// GetNameFromXCCDFTailoredProfileID gets the name of a tailored profile
+// from the TailoredProfile ID
+func GetNameFromXCCDFTailoredProfileID(id string) string {
+	return strings.TrimPrefix(id, fmt.Sprintf("xccdf_%s_profile_", XCCDFNamespace))
+}
+
 // GetProfileNameFromID gets a profile name from the xccdf ID
 func GetProfileNameFromID(id string) string {
 	trimedName := strings.TrimPrefix(id, profileIDPrefix)

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -176,6 +176,28 @@ func (f *Framework) PrintROSADebugInfo(t *testing.T) {
 	}
 }
 
+func (f *Framework) CreateProfileBundle(pbName string, baselineImage string, contentFile string) (*compv1alpha1.ProfileBundle, error) {
+	origPb := &compv1alpha1.ProfileBundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pbName,
+			Namespace: f.OperatorNamespace,
+		},
+		Spec: compv1alpha1.ProfileBundleSpec{
+			ContentImage: baselineImage,
+			ContentFile:  contentFile,
+		},
+	}
+	// Pass nil in as the cleanupOptions since so we don't invoke all the
+	// cleanup function code in Create. Use defer to cleanup the
+	// ProfileBundle at the end of the test, instead of at the end of the
+	// suite.
+	log.Printf("Creating ProfileBundle %s", pbName)
+	if err := f.Client.Create(context.TODO(), origPb, nil); err != nil {
+		return nil, err
+	}
+	return origPb, nil
+}
+
 func (f *Framework) cleanUpProfileBundle(p string) error {
 	pb := &compv1alpha1.ProfileBundle{
 		ObjectMeta: metav1.ObjectMeta{

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -1231,7 +1231,7 @@ func (f *Framework) AssertScanIsCompliant(name, namespace string) error {
 		return err
 	}
 	if cs.Status.Result != compv1alpha1.ResultCompliant {
-		return fmt.Errorf("scan result was %s instead of %s", compv1alpha1.ResultCompliant, cs.Status.Result)
+		return fmt.Errorf("scan result was %s instead of %s", cs.Status.Result, compv1alpha1.ResultCompliant)
 	}
 	return nil
 }
@@ -1309,7 +1309,7 @@ func (f *Framework) AssertScanIsNonCompliant(name, namespace string) error {
 		return err
 	}
 	if cs.Status.Result != compv1alpha1.ResultNonCompliant {
-		return fmt.Errorf("scan result was %s instead of %s", compv1alpha1.ResultNonCompliant, cs.Status.Result)
+		return fmt.Errorf("scan result was %s instead of %s", cs.Status.Result, compv1alpha1.ResultNonCompliant)
 	}
 	return nil
 }
@@ -1322,7 +1322,7 @@ func (f *Framework) AssertScanIsNotApplicable(name, namespace string) error {
 		return err
 	}
 	if cs.Status.Result != compv1alpha1.ResultNotApplicable {
-		return fmt.Errorf("scan result was %s instead of %s", compv1alpha1.ResultNotApplicable, cs.Status.Result)
+		return fmt.Errorf("scan result was %s instead of %s", cs.Status.Result, compv1alpha1.ResultNotApplicable)
 	}
 	return nil
 }
@@ -1335,7 +1335,7 @@ func (f *Framework) AssertScanIsInError(name, namespace string) error {
 		return err
 	}
 	if cs.Status.Result != compv1alpha1.ResultError {
-		return fmt.Errorf("scan result was %s instead of %s", compv1alpha1.ResultError, cs.Status.Result)
+		return fmt.Errorf("scan result was %s instead of %s", cs.Status.Result, compv1alpha1.ResultError)
 	}
 	if cs.Status.ErrorMessage == "" {
 		return fmt.Errorf("scan 'errormsg' is empty, but it should be set")

--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -619,9 +619,10 @@ func TestSingleScanSucceeds(t *testing.T) {
 			Namespace: f.OperatorNamespace,
 		},
 		Spec: compv1alpha1.ComplianceScanSpec{
-			Profile: "xccdf_org.ssgproject.content_profile_moderate",
-			Content: framework.RhcosContentFile,
-			Rule:    "xccdf_org.ssgproject.content_rule_no_netrc_files",
+			Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+			Content:      framework.RhcosContentFile,
+			ContentImage: contentImagePath,
+			Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
 			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 				Debug: true,
 			},
@@ -685,9 +686,10 @@ func TestSingleScanTimestamps(t *testing.T) {
 			Namespace: f.OperatorNamespace,
 		},
 		Spec: compv1alpha1.ComplianceScanSpec{
-			Profile: "xccdf_org.ssgproject.content_profile_moderate",
-			Content: framework.RhcosContentFile,
-			Rule:    "xccdf_org.ssgproject.content_rule_no_netrc_files",
+			Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+			Content:      framework.RhcosContentFile,
+			ContentImage: contentImagePath,
+			Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
 			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 				Debug: true,
 			},
@@ -816,9 +818,10 @@ func TestSingleScanWithStorageSucceeds(t *testing.T) {
 			Namespace: f.OperatorNamespace,
 		},
 		Spec: compv1alpha1.ComplianceScanSpec{
-			Profile: "xccdf_org.ssgproject.content_profile_moderate",
-			Content: framework.RhcosContentFile,
-			Rule:    "xccdf_org.ssgproject.content_rule_no_netrc_files",
+			Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+			Content:      framework.RhcosContentFile,
+			ContentImage: contentImagePath,
+			Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
 			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 				RawResultStorage: compv1alpha1.RawResultStorageSettings{
 					Size: "2Gi",
@@ -919,9 +922,10 @@ func TestScanStorageOutOfLimitRangeFails(t *testing.T) {
 			Namespace: f.OperatorNamespace,
 		},
 		Spec: compv1alpha1.ComplianceScanSpec{
-			Profile: "xccdf_org.ssgproject.content_profile_moderate",
-			Content: framework.RhcosContentFile,
-			Rule:    "xccdf_org.ssgproject.content_rule_no_netrc_files",
+			Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+			Content:      framework.RhcosContentFile,
+			ContentImage: contentImagePath,
+			Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
 			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 				RawResultStorage: compv1alpha1.RawResultStorageSettings{
 					Size: "6Gi",
@@ -979,9 +983,10 @@ func TestSingleTailoredScanSucceeds(t *testing.T) {
 			Namespace: f.OperatorNamespace,
 		},
 		Spec: compv1alpha1.ComplianceScanSpec{
-			Profile: "xccdf_compliance.openshift.io_profile_test-tailoredprofile",
-			Content: framework.RhcosContentFile,
-			Rule:    "xccdf_org.ssgproject.content_rule_no_netrc_files",
+			Profile:      "xccdf_compliance.openshift.io_profile_test-tailoredprofile",
+			Content:      framework.RhcosContentFile,
+			ContentImage: contentImagePath,
+			Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
 			TailoringConfigMap: &compv1alpha1.TailoringConfigMapRef{
 				Name: tailoringCM.Name,
 			},
@@ -1085,6 +1090,7 @@ func TestScanWithNodeSelectorFiltersCorrectly(t *testing.T) {
 		Spec: compv1alpha1.ComplianceScanSpec{
 			Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 			Content:      framework.RhcosContentFile,
+			ContentImage: contentImagePath,
 			Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
 			NodeSelector: selectWorkers,
 			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
@@ -1135,6 +1141,7 @@ func TestScanWithNodeSelectorNoMatches(t *testing.T) {
 		Spec: compv1alpha1.ComplianceScanSpec{
 			Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 			Content:      framework.RhcosContentFile,
+			ContentImage: contentImagePath,
 			Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
 			NodeSelector: selectNone,
 			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
@@ -1169,9 +1176,10 @@ func TestScanWithInvalidScanTypeFails(t *testing.T) {
 			Namespace: f.OperatorNamespace,
 		},
 		Spec: compv1alpha1.ComplianceScanSpec{
-			Profile:  "xccdf_org.ssgproject.content_profile_moderate",
-			Content:  "ssg-ocp4-non-existent.xml",
-			ScanType: "BadScanType",
+			Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+			Content:      "ssg-ocp4-non-existent.xml",
+			ContentImage: contentImagePath,
+			ScanType:     "BadScanType",
 			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 				Debug: true,
 			},
@@ -1203,8 +1211,9 @@ func TestScanWithInvalidContentFails(t *testing.T) {
 			Namespace: f.OperatorNamespace,
 		},
 		Spec: compv1alpha1.ComplianceScanSpec{
-			Profile: "xccdf_org.ssgproject.content_profile_moderate",
-			Content: "ssg-ocp4-non-existent.xml",
+			Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+			Content:      "ssg-ocp4-non-existent.xml",
+			ContentImage: contentImagePath,
 			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 				Debug: true,
 			},
@@ -1236,8 +1245,9 @@ func TestScanWithInvalidProfileFails(t *testing.T) {
 			Namespace: f.OperatorNamespace,
 		},
 		Spec: compv1alpha1.ComplianceScanSpec{
-			Profile: "xccdf_org.ssgproject.content_profile_coreos-unexistent",
-			Content: framework.RhcosContentFile,
+			Profile:      "xccdf_org.ssgproject.content_profile_coreos-unexistent",
+			Content:      framework.RhcosContentFile,
+			ContentImage: contentImagePath,
 			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 				Debug: true,
 			},
@@ -1297,9 +1307,10 @@ func TestMalformedTailoredScanFails(t *testing.T) {
 			Namespace: f.OperatorNamespace,
 		},
 		Spec: compv1alpha1.ComplianceScanSpec{
-			Profile: "xccdf_compliance.openshift.io_profile_test-tailoredprofile",
-			Content: framework.RhcosContentFile,
-			Rule:    "xccdf_org.ssgproject.content_rule_no_netrc_files",
+			Profile:      "xccdf_compliance.openshift.io_profile_test-tailoredprofile",
+			Content:      framework.RhcosContentFile,
+			ContentImage: contentImagePath,
+			Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
 			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 				Debug: true,
 			},
@@ -1334,9 +1345,10 @@ func TestScanWithEmptyTailoringCMNameFails(t *testing.T) {
 			Namespace: f.OperatorNamespace,
 		},
 		Spec: compv1alpha1.ComplianceScanSpec{
-			Profile: "xccdf_org.ssgproject.content_profile_moderate",
-			Content: framework.RhcosContentFile,
-			Rule:    "xccdf_org.ssgproject.content_rule_no_netrc_files",
+			Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+			Content:      framework.RhcosContentFile,
+			ContentImage: contentImagePath,
+			Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
 			TailoringConfigMap: &compv1alpha1.TailoringConfigMapRef{
 				Name: "",
 			},
@@ -1369,9 +1381,10 @@ func TestScanWithMissingTailoringCMFailsAndRecovers(t *testing.T) {
 			Namespace: f.OperatorNamespace,
 		},
 		Spec: compv1alpha1.ComplianceScanSpec{
-			Profile: "xccdf_compliance.openshift.io_profile_test-tailoredprofile",
-			Content: framework.RhcosContentFile,
-			Rule:    "xccdf_org.ssgproject.content_rule_no_netrc_files",
+			Profile:      "xccdf_compliance.openshift.io_profile_test-tailoredprofile",
+			Content:      framework.RhcosContentFile,
+			ContentImage: contentImagePath,
+			Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
 			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 				Debug: true,
 			},
@@ -1449,9 +1462,10 @@ func TestMissingPodInRunningState(t *testing.T) {
 			Namespace: f.OperatorNamespace,
 		},
 		Spec: compv1alpha1.ComplianceScanSpec{
-			Profile: "xccdf_org.ssgproject.content_profile_moderate",
-			Content: framework.RhcosContentFile,
-			Rule:    "xccdf_org.ssgproject.content_rule_no_netrc_files",
+			Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+			Content:      framework.RhcosContentFile,
+			ContentImage: contentImagePath,
+			Rule:         "xccdf_org.ssgproject.content_rule_no_netrc_files",
 			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 				Debug: true,
 			},

--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -716,45 +716,65 @@ func TestNonExistentDeprecatedProfile(t *testing.T) {
 	}
 }
 
-func TestScanDeprecatedProfile(t *testing.T) {
+func TestScanTailoredProfileIsDeprecated(t *testing.T) {
 	t.Parallel()
 	f := framework.Global
 
-	pbName := framework.GetObjNameFromTest(t)
-	baselineImage := fmt.Sprintf("%s:%s", brokenContentImagePath, "deprecated_profile")
-	pb, err := f.CreateProfileBundle(pbName, baselineImage, framework.OcpContentFile)
-	if err != nil {
-		t.Fatalf("failed to create ProfileBundle: %s", err)
-	}
-	// This should get cleaned up at the end of the test
-	defer f.Client.Delete(context.TODO(), pb)
-
-	if err := f.WaitForProfileBundleStatus(pbName, compv1alpha1.DataStreamValid); err != nil {
-		t.Fatalf("failed waiting for the ProfileBundle to become available: %s", err)
-	}
-
-	scanName := framework.GetObjNameFromTest(t)
-	testScan := &compv1alpha1.ComplianceScan{
+	tpName := "test-tailored-profile-is-deprecated"
+	tp := &compv1alpha1.TailoredProfile{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      scanName,
+			Name:      tpName,
 			Namespace: f.OperatorNamespace,
+			Annotations: map[string]string{
+				compv1alpha1.ProfileStatusAnnotation: "deprecated",
+			},
 		},
-		Spec: compv1alpha1.ComplianceScanSpec{
-			Profile:      "xccdf_org.ssgproject.content_profile_cis-1-4",
-			Content:      framework.OcpContentFile,
-			ContentImage: baselineImage,
-			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
-				Debug: true,
+		Spec: compv1alpha1.TailoredProfileSpec{
+			Extends:     "ocp4-cis",
+			Title:       "TestScanTailoredProfileIsDeprecated",
+			Description: "TestScanTailoredProfileIsDeprecated",
+			EnableRules: []compv1alpha1.RuleReferenceSpec{
+				{
+					Name:      "ocp4-cluster-version-operator-exists",
+					Rationale: "Test tailored profile extends deprecated",
+				},
 			},
 		},
 	}
-	// use Context's create helper to create the object and add a cleanup function for the new object
-	if err = f.Client.Create(context.TODO(), testScan, nil); err != nil {
-		t.Fatalf("failed to create scan %s: %s", scanName, err)
+	err := f.Client.Create(context.TODO(), tp, nil)
+	if err != nil {
+		t.Fatal(err)
 	}
-	defer f.Client.Delete(context.TODO(), testScan)
+	defer f.Client.Delete(context.TODO(), tp)
 
-	if err = f.WaitForProfileDeprecatedWarning(t, scanName, fmt.Sprintf("%s-cis-1-4", pbName)); err != nil {
+	suiteName := framework.GetObjNameFromTest(t)
+	ssb := &compv1alpha1.ScanSettingBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      suiteName,
+			Namespace: f.OperatorNamespace,
+		},
+		Profiles: []compv1alpha1.NamedObjectReference{
+			{
+				APIGroup: "compliance.openshift.io/v1alpha1",
+				Kind:     "TailoredProfile",
+				Name:     tpName,
+			},
+		},
+		SettingsRef: &compv1alpha1.NamedObjectReference{
+			APIGroup: "compliance.openshift.io/v1alpha1",
+			Kind:     "ScanSetting",
+			Name:     "default",
+		},
+	}
+	err = f.Client.Create(context.TODO(), ssb, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Client.Delete(context.TODO(), ssb)
+
+	// When using SSB with TailoredProfile, the scan has same name as the TP
+	scanName := tpName
+	if err = f.WaitForProfileDeprecatedWarning(t, scanName, tpName); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -1230,20 +1230,12 @@ func TestUpdateRemediation(t *testing.T) {
 	)
 
 	pbName := framework.GetObjNameFromTest(t)
-	rhcosPb := &compv1alpha1.ProfileBundle{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pbName,
-			Namespace: f.OperatorNamespace,
-		},
-		Spec: compv1alpha1.ProfileBundleSpec{
-			ContentImage: origImage,
-			ContentFile:  framework.RhcosContentFile,
-		},
-	}
-	if err := f.Client.Create(context.TODO(), rhcosPb, nil); err != nil {
+	rhcosPb, err := f.CreateProfileBundle(pbName, origImage, framework.RhcosContentFile)
+	if err != nil {
 		t.Fatal(err)
 	}
 	defer f.Client.Delete(context.TODO(), rhcosPb)
+
 	if err := f.WaitForProfileBundleStatus(pbName, compv1alpha1.DataStreamValid); err != nil {
 		t.Fatal(err)
 	}
@@ -1275,7 +1267,7 @@ func TestUpdateRemediation(t *testing.T) {
 		},
 	}
 
-	err := f.Client.Create(context.TODO(), origSuite, nil)
+	err = f.Client.Create(context.TODO(), origSuite, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1436,17 +1428,8 @@ func TestVariableTemplate(t *testing.T) {
 	pbName := framework.GetObjNameFromTest(t)
 	prefixName := func(profName, ruleBaseName string) string { return profName + "-" + ruleBaseName }
 
-	ocpPb := &compv1alpha1.ProfileBundle{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pbName,
-			Namespace: f.OperatorNamespace,
-		},
-		Spec: compv1alpha1.ProfileBundleSpec{
-			ContentImage: baselineImage,
-			ContentFile:  framework.OcpContentFile,
-		},
-	}
-	if err := f.Client.Create(context.TODO(), ocpPb, nil); err != nil {
+	ocpPb, err := f.CreateProfileBundle(pbName, baselineImage, framework.OcpContentFile)
+	if err != nil {
 		t.Fatal(err)
 	}
 	defer f.Client.Delete(context.TODO(), ocpPb)
@@ -1581,17 +1564,8 @@ func TestKubeletConfigRemediation(t *testing.T) {
 	pbName := framework.GetObjNameFromTest(t)
 	prefixName := func(profName, ruleBaseName string) string { return profName + "-" + ruleBaseName }
 
-	ocpPb := &compv1alpha1.ProfileBundle{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pbName,
-			Namespace: f.OperatorNamespace,
-		},
-		Spec: compv1alpha1.ProfileBundleSpec{
-			ContentImage: baselineImage,
-			ContentFile:  framework.OcpContentFile,
-		},
-	}
-	if err := f.Client.Create(context.TODO(), ocpPb, nil); err != nil {
+	ocpPb, err := f.CreateProfileBundle(pbName, baselineImage, framework.OcpContentFile)
+	if err != nil {
 		t.Fatal(err)
 	}
 	defer f.Client.Delete(context.TODO(), ocpPb)
@@ -1657,7 +1631,7 @@ func TestKubeletConfigRemediation(t *testing.T) {
 		},
 	}
 
-	err := f.Client.Create(context.TODO(), ssb, nil)
+	err = f.Client.Create(context.TODO(), ssb, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -1240,6 +1240,16 @@ func TestUpdateRemediation(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	pbNameMod := fmt.Sprintf("%s-%s", pbName, "mod")
+	rhcosPbMod, err := f.CreateProfileBundle(pbNameMod, modImage, framework.RhcosContentFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Client.Delete(context.TODO(), rhcosPbMod)
+	if err := f.WaitForProfileBundleStatus(pbNameMod, compv1alpha1.DataStreamValid); err != nil {
+		t.Fatal(err)
+	}
+
 	origSuite := &compv1alpha1.ComplianceSuite{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      origSuiteName,


### PR DESCRIPTION
The Content Profiles can now be set as deprecated.
The Compliance Operator needs to be able to identify them and warn users of the need to make adjustments.

- When Parsing Content, it annotates deprecated profiles with `compliance.openshift.io/profile-status: deprecated`
- Whenever a `ComplianceScan` is started using a deprecated profile we add a warning to the object.
  - - From the `ComplianceScanSpec`, it find the `ProfileBundle` that matches the `ContentImage` and `ContentFile`. 
  Once a matching `ProfileBundle` is found it simply grabs the profile whose ID matches the `ComplianceScanSpec` and checks for its deprecated annotation.