### PR TITLE
CMP-3152: Implement an action to check PR titles

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -1,0 +1,31 @@
+name: "Check PR title"
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-title:
+    runs-on: ubuntu-latest
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - name: Check if the PR title is well dressed
+        if: github.event.pull_request.user.login != 'renovate[bot]' ||  github.event.pull_request.user.login != 'red-hat-konflux[bot]' 
+        env:
+          JIRA: '([A-Z]+-[0-9]+, ?)*[A-Z]+-[0-9]+'
+          TEXT: ': .+'
+        run: |
+          # Either conventional or JIRA-nnn prefix followed by ': ' and random text:
+          REGEX="($JIRA)($TEXT)"
+          test_regex() { echo -nE "$1" | grep --perl-regexp --line-regexp "$REGEX" ; }
+
+          echo "Examples:"
+          test_regex 'CMP-123: text'
+          test_regex 'CMP-123, OCPBUGS-12345: text'
+
+          if ! test_regex "$PR_TITLE"
+          then
+            echo "::error::Please update the PR title so that it follows the convention."
+            exit 1
+          fi


### PR DESCRIPTION
This makes it so we have an action that will fail if the PR doesn't
reference a Jira ticket, helping us track work in the repository to
items in Jira.
