### PR TITLE
CMP-3156: Simplify similar cases in ComplianceScan pending phase

### DIFF
--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -285,19 +285,11 @@ func (r *ReconcileComplianceScan) validate(instance *compv1alpha1.ComplianceScan
 func (r *ReconcileComplianceScan) phasePendingHandler(instance *compv1alpha1.ComplianceScan, logger logr.Logger) (reconcile.Result, error) {
 	logger.Info("Phase: Pending")
 	// Remove annotation if needed
-	if instance.NeedsRescan() {
+	if instance.NeedsRescan() || instance.NeedsTimeoutRescan() {
 		instanceCopy := instance.DeepCopy()
 		delete(instanceCopy.Annotations, compv1alpha1.ComplianceCheckCountAnnotation)
 		delete(instanceCopy.Annotations, compv1alpha1.ComplianceScanRescanAnnotation)
 		delete(instanceCopy.Annotations, compv1alpha1.ComplianceScanTimeoutAnnotation)
-		err := r.Client.Update(context.TODO(), instanceCopy)
-		return reconcile.Result{}, err
-	}
-
-	if instance.NeedsTimeoutRescan() {
-		instanceCopy := instance.DeepCopy()
-		delete(instanceCopy.Annotations, compv1alpha1.ComplianceScanTimeoutAnnotation)
-		delete(instanceCopy.Annotations, compv1alpha1.ComplianceCheckCountAnnotation)
 		err := r.Client.Update(context.TODO(), instanceCopy)
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -299,6 +299,54 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 			Expect(compliancescaninstance.Status.Result).To(Equal(compv1alpha1.ResultNotAvailable))
 		})
 
+		It("should remove annotations when performing a rescan", func() {
+			compliancescaninstance.Annotations = make(map[string]string)
+			compliancescaninstance.Annotations[compv1alpha1.ComplianceScanRescanAnnotation] = ""
+			if err := reconciler.Client.Update(context.TODO(), compliancescaninstance); err != nil {
+				s := fmt.Sprintf("failed to set %s annotation on %s", compv1alpha1.ComplianceScanRescanAnnotation, compliancescaninstance.Name)
+				Fail(s)
+			}
+
+			result, err := reconciler.phasePendingHandler(compliancescaninstance, logger)
+			Expect(result).NotTo(BeNil())
+			Expect(err).To(BeNil())
+
+			actual := &compv1alpha1.ComplianceScan{}
+			key := types.NamespacedName{
+				Name:      compliancescaninstance.Name,
+				Namespace: compliancescaninstance.Namespace,
+			}
+			if err = reconciler.Client.Get(context.TODO(), key, actual); err != nil {
+				s := fmt.Sprintf("failed to get ComplianceScan %s", compliancescaninstance.Name)
+				Fail(s)
+			}
+			Expect(actual.Annotations).To(BeNil())
+		})
+
+		It("should remove annotations when performing a rescan due to timeout", func() {
+			compliancescaninstance.Annotations = make(map[string]string)
+			compliancescaninstance.Annotations[compv1alpha1.ComplianceScanTimeoutAnnotation] = ""
+			if err := reconciler.Client.Update(context.TODO(), compliancescaninstance); err != nil {
+				s := fmt.Sprintf("failed to set %s annotation on %s", compv1alpha1.ComplianceScanTimeoutAnnotation, compliancescaninstance.Name)
+				Fail(s)
+			}
+
+			result, err := reconciler.phasePendingHandler(compliancescaninstance, logger)
+			Expect(result).NotTo(BeNil())
+			Expect(err).To(BeNil())
+
+			actual := &compv1alpha1.ComplianceScan{}
+			key := types.NamespacedName{
+				Name:      compliancescaninstance.Name,
+				Namespace: compliancescaninstance.Namespace,
+			}
+			if err = reconciler.Client.Get(context.TODO(), key, actual); err != nil {
+				s := fmt.Sprintf("failed to get ComplianceScan %s", compliancescaninstance.Name)
+				Fail(s)
+			}
+			Expect(actual.Annotations).To(BeNil())
+		})
+
 		Context("With correct custom RawResultStorage.Size", func() {
 			It("should update the compliancescan instance to phase LAUNCHING", func() {
 				compliancescaninstance.Spec.RawResultStorage.Size = "2Gi"


### PR DESCRIPTION
We need to remove annotations when rerunning a scan, regardless of it
being rerun for a timeout or a rescan. We handled these cases
separately, but didn't need to since we're using `delete()`, which
performs a no-op if the annotation doesn't exist.
    
This PR simplifies the code by reducing both conditionals into a single
case.
