### PR TITLE
CMP-3157: Fix check pr title action

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -11,7 +11,9 @@ jobs:
       PR_TITLE: ${{ github.event.pull_request.title }}
     steps:
       - name: Check if the PR title is well dressed
-        if: github.event.pull_request.user.login != 'renovate[bot]' ||  github.event.pull_request.user.login != 'red-hat-konflux[bot]' 
+        if: >-
+          github.event.pull_request.user.login != 'renovate[bot]' &&
+          github.event.pull_request.user.login != 'red-hat-konflux[bot]'
         env:
           JIRA: '([A-Z]+-[0-9]+, ?)*[A-Z]+-[0-9]+'
           TEXT: ': .+'


### PR DESCRIPTION
Only run the action if the PR is proposed by someone other than renovate
or konflux users. Make the logic so that the action needs to meet both
conditions, instead of just one.

Following the guidance from GitHub's documentation:

  https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#accessing-and-using-event-properties
