### PR TITLE
CMP-3155: Fix e2e test for checkcount

### DIFF
--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -877,10 +877,16 @@ func (f *Framework) WaitForScanStatus(namespace, name string, targetStatus compv
 			return false, nil
 		}
 
-		if exampleComplianceScan.Status.Phase != compv1alpha1.PhaseDone && exampleComplianceScan.Status.Phase != compv1alpha1.PhasePending {
-			// check we should not have checkCount annotation
+		switch exampleComplianceScan.Status.Phase {
+		case compv1alpha1.PhaseLaunching:
+			// assert exampleComplianceScan.Annotations[compv1alpha1.ComplianceCheckCountAnnotation] is empty
 			if exampleComplianceScan.Annotations[compv1alpha1.ComplianceCheckCountAnnotation] != "" {
-				return true, fmt.Errorf("compliancescan %s has unset checkCount annotation", name)
+				return true, fmt.Errorf("compliancescan %s should not have checkCount annotation", name)
+			}
+		case compv1alpha1.PhaseRunning:
+			// assert exampleComplianceScan.Annotations[compv1alpha1.ComplianceCheckCountAnnotation] is empty
+			if exampleComplianceScan.Annotations[compv1alpha1.ComplianceCheckCountAnnotation] != "" {
+				return true, fmt.Errorf("compliancescan %s should not have checkCount annotation", name)
 			}
 		}
 


### PR DESCRIPTION
We should not expect checkCount to be unset during PhaseAggregating, because we are setting the checkcount during that phase, this might casue transient issues in between the waiting period