### PR TITLE
OCPBUGS-55181: Update NERC-CIP reference

### DIFF
--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -840,7 +840,7 @@ func newStandardParser() *referenceParser {
 	if crherr != nil {
 		log.Error(crherr, "Could not register CIS Red Hat Linux reference parser") // not much we can do here..
 	}
-	nciperr := p.registerStandard("NERC-CIP", `^https://www\.nerc\.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop\.xlsx$`)
+	nciperr := p.registerStandard("NERC-CIP", `^https://www\.nerc\.com/pa/Stand/AlignRep/One%20Stop%20Shop\.xlsx$`)
 	if nciperr != nil {
 		log.Error(nciperr, "Could not register NERC-CIP reference parser") // not much we can do here..
 	}


### PR DESCRIPTION
The NERC-CIP references in the ComplianceAsCode/content were updated
recently because they were pointing to a dead link (HTTP 404).

  https://github.com/ComplianceAsCode/content/pull/12892

This commit updates the profile parser to use the same link. Without
doing this, the rules won't contain annotations or controls for the
NERC-CIP profile, even though the Compliance Operator has a profile for
it.
