### PR TITLE
OCPBUGS-50924: Bump up content pauser memory limit

### DIFF
--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -530,7 +530,7 @@ func (r *ReconcileProfileBundle) newWorkloadForBundle(pb *compliancev1alpha1.Pro
 									corev1.ResourceCPU:    resource.MustParse("10m"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("15Mi"),
+									corev1.ResourceMemory: resource.MustParse("30Mi"),
 									corev1.ResourceCPU:    resource.MustParse("10m"),
 								},
 							},


### PR DESCRIPTION
The content-pauser pod is experiencing out-of-memory (OOM) errors in certain environments, resulting in unexpected restarts. This PR increases its memory limit to prevent OOM kills and improve overall stability.