### PR TITLE
Refactor image pull specs in update_csv.go

### DIFF
--- a/bundle-hack/update_csv.go
+++ b/bundle-hack/update_csv.go
@@ -12,6 +12,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Konflux pull specs used across multiple functions
+var (
+	konfluxOperatorPullSpec   = "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-release@sha256:8b07d699804a263a567715422f86c8086c39a45baccbcae3734b062b57c67b1e"
+	konfluxContentPullSpec    = "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-release@sha256:8b07d699804a263a567715422f86c8086c39a45baccbcae3734b062b57c67b1e"
+	konfluxOpenscapPullSpec   = "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-openscap-release@sha256:c27b9680fdee28b566fbfa636777c18b03c4332a5694ac07ca3ada30420698e3"
+	konfluxMustGatherPullSpec = "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-must-gather-release@sha256:b9a914216870c2a3b78ff641add7d0548e1805d70a411880109b645efa724262"
+)
+
 func readCSV(csvFilename string, csv *map[string]interface{}) {
 	yamlFile, err := os.ReadFile(csvFilename)
 	if err != nil {
@@ -152,22 +160,16 @@ func getPullSpecSha(pullSpec string) string {
 }
 
 func replaceImages(csv map[string]interface{}) {
-//	defer recoverFromReplaceImages()
+	//	defer recoverFromReplaceImages()
 
 	// Konflux will automatically update the image sha based on the most
 	// recent builds. We want to peel off the SHA and append it to the Red
 	// Hat registry so that the bundle image will work when it's available
 	// there.
-	konfluxOperatorPullSpec := "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-release@sha256:8b07d699804a263a567715422f86c8086c39a45baccbcae3734b062b57c67b1e"
-	konfluxContentPullSpec := "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-release@sha256:8b07d699804a263a567715422f86c8086c39a45baccbcae3734b062b57c67b1e"
-	konfluxOpenscapPullSpec := "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-openscap-release@sha256:c27b9680fdee28b566fbfa636777c18b03c4332a5694ac07ca3ada30420698e3"
-	konfluxMustGatherPullSpec := "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-must-gather-release@sha256:b9a914216870c2a3b78ff641add7d0548e1805d70a411880109b645efa724262"
-
 	imageShaOperator := getPullSpecSha(konfluxOperatorPullSpec)
 	imageShaOpenscap := getPullSpecSha(konfluxOpenscapPullSpec)
 	imageShaContent := getPullSpecSha(konfluxContentPullSpec)
 	imageShaMustGather := getPullSpecSha(konfluxMustGatherPullSpec)
-
 
 	env, ok := csv["spec"].(map[string]interface{})["install"].(map[string]interface{})["spec"].(map[string]interface{})["deployments"].([]interface{})[0].(map[string]interface{})["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]interface{})[0].(map[string]interface{})["env"].([]interface{})
 	if !ok {
@@ -176,10 +178,10 @@ func replaceImages(csv map[string]interface{}) {
 
 	delimiter := "@"
 	registryPrefix := "registry.redhat.io/compliance/"
-	newPullSpecs := map[string]string {
-		"RELATED_IMAGE_OPERATOR": registryPrefix + "openshift-compliance-rhel8-operator" + delimiter + imageShaOperator,
-		"RELATED_IMAGE_OPENSCAP": registryPrefix + "openshift-compliance-openscap-rhel8" + delimiter + imageShaOpenscap,
-		"RELATED_IMAGE_PROFILE": registryPrefix + "openshift-compliance-content-rhel8" + delimiter + imageShaContent,
+	newPullSpecs := map[string]string{
+		"RELATED_IMAGE_OPERATOR":    registryPrefix + "openshift-compliance-rhel8-operator" + delimiter + imageShaOperator,
+		"RELATED_IMAGE_OPENSCAP":    registryPrefix + "openshift-compliance-openscap-rhel8" + delimiter + imageShaOpenscap,
+		"RELATED_IMAGE_PROFILE":     registryPrefix + "openshift-compliance-content-rhel8" + delimiter + imageShaContent,
 		"RELATED_IMAGE_MUST_GATHER": registryPrefix + "openshift-compliance-must-gather-rhel8" + delimiter + imageShaMustGather,
 	}
 
@@ -224,14 +226,30 @@ func replaceImages(csv map[string]interface{}) {
 	fmt.Println("Updated the deployment manifest to use downstream builds")
 }
 
-func removeRelated(csv map[string]interface{}) {
+func updateRelatedImages(csv map[string]interface{}) {
 	spec, ok := csv["spec"].(map[string]interface{})
 	if !ok {
 		log.Fatal("Error: 'spec' does not exist in the CSV content")
 	}
 
-	delete(spec, "relatedImages")
-	fmt.Println("Removed the operator from operator manifest")
+	// Create or update the relatedImages section
+	relatedImages := []map[string]string{
+		{
+			"name":  "openscap",
+			"image": konfluxOpenscapPullSpec,
+		},
+		{
+			"name":  "operator",
+			"image": konfluxOperatorPullSpec,
+		},
+		{
+			"name":  "profile",
+			"image": konfluxContentPullSpec,
+		},
+	}
+
+	spec["relatedImages"] = relatedImages
+	fmt.Println("Updated relatedImages with Konflux pull specs")
 }
 
 func main() {
@@ -250,7 +268,7 @@ func main() {
 	replaceVersion(oldVersion, newVersion, csv)
 	replaceIcon(csv)
 	replaceImages(csv)
-	removeRelated(csv)
+	updateRelatedImages(csv)
 
 	outputCSVFilename := getOutputCSVFilePath(manifestsDir, newVersion)
 	replaceCSV(csvFilename, outputCSVFilename, csv)


### PR DESCRIPTION
Ensure the deployment manifest is updated to use the downstream builds convention correctly.