### PR TITLE
CMP-3138: Only build broken test content on master

### DIFF
--- a/.github/workflows/test-broken-content-latest.yml
+++ b/.github/workflows/test-broken-content-latest.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - master
     paths:
       - "images/testcontent/**"
       - ".github/workflows/test-broken-content-latest.yml"


### PR DESCRIPTION
If we don't do this, the action will run for older branches which might
not contain all the architectures we currently support.
