### PR TITLE
Only build when relevant files changed

### DIFF
--- a/.tekton/compliance-operator-bundle-release-1-7-pull-request.yaml
+++ b/.tekton/compliance-operator-bundle-release-1-7-pull-request.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.7"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.7" &&
+      ("bundle-hack/***".pathChanged() || "bundle/***".pathChanged() || ".tekton/*bundle-release*.yaml".pathChanged() ||
+      "bundle.openshift.Dockerfile".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-release-1-7

--- a/.tekton/compliance-operator-bundle-release-1-7-push.yaml
+++ b/.tekton/compliance-operator-bundle-release-1-7-push.yaml
@@ -7,7 +7,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.7"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.7" &&
+      ("bundle-hack/***".pathChanged() || "bundle/***".pathChanged() || ".tekton/*bundle-release*.yaml".pathChanged() ||
+      "bundle.openshift.Dockerfile".pathChanged())
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-release-1-7

--- a/.tekton/compliance-operator-must-gather-release-1-7-pull-request.yaml
+++ b/.tekton/compliance-operator-must-gather-release-1-7-pull-request.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.7" && ( "images/must-gather/***".pathChanged() || ".tekton/compliance-operator-must-gather-release-1-7-pull-request.yaml".pathChanged() || "images/must-gather/Containerfile".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.7" &&
+      ( "images/must-gather/***".pathChanged() || ".tekton/*-must-gather-release-*.yaml".pathChanged() ||
+      "images/must-gather/Containerfile".pathChanged() || "utils/***".pathChanged() || "LICENSE".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-release-1-7

--- a/.tekton/compliance-operator-must-gather-release-1-7-push.yaml
+++ b/.tekton/compliance-operator-must-gather-release-1-7-push.yaml
@@ -9,6 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.7"
+      ( "images/must-gather/***".pathChanged() || ".tekton/*-must-gather-release-*.yaml".pathChanged() ||
+      "images/must-gather/Containerfile".pathChanged() || "utils/***".pathChanged() || "LICENSE".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-release-1-7

--- a/.tekton/compliance-operator-openscap-release-1-7-pull-request.yaml
+++ b/.tekton/compliance-operator-openscap-release-1-7-pull-request.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.7" && ( "images/openscap/***".pathChanged() || ".tekton/compliance-operator-openscap-release-1-7-pull-request.yaml".pathChanged() || "images/openscap/Containerfile".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.7" &&
+      ( "images/openscap/***".pathChanged() || ".tekton/*-openscap-release-*.yaml".pathChanged() ||
+      "images/openscap/Containerfile".pathChanged() || "LICENSE".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-release-1-7

--- a/.tekton/compliance-operator-openscap-release-1-7-push.yaml
+++ b/.tekton/compliance-operator-openscap-release-1-7-push.yaml
@@ -9,6 +9,8 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.7"
+      ( "images/openscap/***".pathChanged() || ".tekton/*-openscap-release-*.yaml".pathChanged() ||
+      "images/openscap/Containerfile".pathChanged() || "LICENSE".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-release-1-7

--- a/.tekton/compliance-operator-release-1-7-pull-request.yaml
+++ b/.tekton/compliance-operator-release-1-7-pull-request.yaml
@@ -8,7 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.7"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-1.7" &&
+      ( ".tekton/compliance-operator-release-1-7-pull-request*.yaml".pathChanged() ||
+      "*.go".pathChanged() || "pkg/**/*.go".pathChanged() || "cmd/**/*.go".pathChanged() || "version/***".pathChaned() ||
+      "config/***".pathChanged() || "*Makefile*".pathChanged() || "vendor/***".pathChanged() ||
+      "tests/***".pathChanged() || "LICENSE".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-release-1-7

--- a/.tekton/compliance-operator-release-1-7-push.yaml
+++ b/.tekton/compliance-operator-release-1-7-push.yaml
@@ -8,7 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.7"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-1.7" &&
+      ( ".tekton/compliance-operator-release-1-7-push.yaml".pathChanged() ||
+      "*.go".pathChanged() || "pkg/**/*.go".pathChanged() || "cmd/**/*.go".pathChanged() || "version/***".pathChaned() ||
+      "config/***".pathChanged() || "*Makefile*".pathChanged() || "vendor/***".pathChanged() ||
+      "tests/***".pathChanged() || "LICENSE".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-release-1-7


### PR DESCRIPTION
Restrict build images to when relevant files are changed.

This should make it easier to manage nudges to the bundle.