### PR TITLE
Only build when relevant files changed

### DIFF
--- a/.tekton/compliance-operator-bundle-dev-pull-request.yaml
+++ b/.tekton/compliance-operator-bundle-dev-pull-request.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master" &&
+      ( ".tekton/compliance-operator-bundle-dev-*.yaml".pathChanged() ||
+      "bundle-hack/***".pathChanged() || "bundle/***".pathChanged() || "bundle.openshift.Dockerfile".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-dev

--- a/.tekton/compliance-operator-bundle-dev-push.yaml
+++ b/.tekton/compliance-operator-bundle-dev-push.yaml
@@ -7,7 +7,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master" &&
+      ( ".tekton/compliance-operator-bundle-dev-*.yaml".pathChanged() ||
+      "bundle-hack/***".pathChanged() || "bundle/***".pathChanged() || "bundle.openshift.Dockerfile".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-dev

--- a/.tekton/compliance-operator-dev-pull-request.yaml
+++ b/.tekton/compliance-operator-dev-pull-request.yaml
@@ -8,7 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master" &&
+      ( ".tekton/compliance-operator-dev-*.yaml".pathChanged() ||
+      "*.go".pathChanged() || "pkg/**/*.go".pathChanged() || "cmd/**/*.go".pathChanged() || "version/***".pathChaned() ||
+      "config/***".pathChanged() || "*Makefile*".pathChanged() || "vendor/***".pathChanged() ||
+      "tests/***".pathChanged() || "LICENSE".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-dev

--- a/.tekton/compliance-operator-dev-push.yaml
+++ b/.tekton/compliance-operator-dev-push.yaml
@@ -8,7 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master" &&
+      ( ".tekton/compliance-operator-dev-*.yaml".pathChanged() ||
+      "*.go".pathChanged() || "pkg/**/*.go".pathChanged() || "cmd/**/*.go".pathChanged() || "version/***".pathChaned() ||
+      "config/***".pathChanged() || "*Makefile*".pathChanged() || "vendor/***".pathChanged() ||
+      "tests/***".pathChanged() || "LICENSE".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-dev

--- a/.tekton/compliance-operator-must-gather-dev-pull-request.yaml
+++ b/.tekton/compliance-operator-must-gather-dev-pull-request.yaml
@@ -8,7 +8,10 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master" && ( "images/must-gather/***".pathChanged() || ".tekton/compliance-operator-must-gather-dev-pull-request.yaml".pathChanged() || "images/must-gather/Containerfile".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master" &&
+      ( ".tekton/compliance-operator-must-gather-dev-*.yaml".pathChanged() ||
+      "images/must-gather/***".pathChanged() || "images/must-gather/Containerfile".pathChanged() ||
+      "utils/***".pathChanged() || "LICENSE".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-dev

--- a/.tekton/compliance-operator-must-gather-dev-push.yaml
+++ b/.tekton/compliance-operator-must-gather-dev-push.yaml
@@ -8,7 +8,10 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master" &&
+      ( ".tekton/compliance-operator-must-gather-dev-*.yaml".pathChanged() ||
+      "images/must-gather/***".pathChanged() || "images/must-gather/Containerfile".pathChanged() ||
+      "utils/***".pathChanged() || "LICENSE".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-dev

--- a/.tekton/compliance-operator-openscap-dev-pull-request.yaml
+++ b/.tekton/compliance-operator-openscap-dev-pull-request.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master" && ( "images/openscap/***".pathChanged() || ".tekton/compliance-operator-openscap-dev-pull-request.yaml".pathChanged() || "images/openscap/Containerfile".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master" &&
+      ( ".tekton/compliance-operator-openscap-dev-*.yaml".pathChanged() ||
+      "images/openscap/***".pathChanged() || "images/openscap/Containerfile".pathChanged() || "LICENSE".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-dev

--- a/.tekton/compliance-operator-openscap-dev-push.yaml
+++ b/.tekton/compliance-operator-openscap-dev-push.yaml
@@ -8,7 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master" &&
+      ( ".tekton/compliance-operator-openscap-dev-*.yaml".pathChanged() ||
+      "images/openscap/***".pathChanged() || "images/openscap/Containerfile".pathChanged() || "LICENSE".pathChanged() )
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: compliance-operator-dev


### PR DESCRIPTION
Restrict build images to when relevant files are changed. This should make it easier to manage nudges to the bundle.

Similar to #755.