### PR TITLE
Don't update golang dependencies in release branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,12 @@
   ],
   "schedule": [
     "every weekend"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchBaseBranches": ["/^release-.*/"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
The tekton pipeline updates are actually done with MintMaker and Renovate.

This tries to disable management of gomod packages in release branches.