### PR TITLE
CMP-3515: Use Konflux builds for content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,10 +137,10 @@ E2E_USE_DEFAULT_IMAGES?=false
 E2E_SKIP_CONTAINER_BUILD?=false
 
 # Used for substitutions
-DEFAULT_CONTENT_IMAGE=ghcr.io/complianceascode/k8scontent:latest
+DEFAULT_CONTENT_IMAGE=quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master
 CONTENT_IMAGE?=$(DEFAULT_CONTENT_IMAGE)
 # Specifies the image path to use for the content in the tests
-E2E_CONTENT_IMAGE_PATH?=ghcr.io/complianceascode/k8scontent:latest
+E2E_CONTENT_IMAGE_PATH?=quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master
 # We specifically omit the tag here since we use this for testing
 # different images referenced by different tags.
 E2E_BROKEN_CONTENT_IMAGE_PATH?=ghcr.io/complianceascode/test-broken-content-ocp

--- a/images/testcontent/Dockerfile.ci
+++ b/images/testcontent/Dockerfile.ci
@@ -1,1 +1,0 @@
-FROM ghcr.io/complianceascode/k8scontent:latest

--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	DefaultContentContainerImage = "ghcr.io/complianceascode/k8scontent:latest"
+	DefaultContentContainerImage = "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master"
 	CACertDataKey                = "ca.crt"
 	CAKeyDataKey                 = "ca.key"
 	ServerCertInstanceSuffix     = "-rs"

--- a/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 				Namespace: common.GetComplianceOperatorNamespace(),
 			},
 			Spec: compv1alpha1.ProfileBundleSpec{
-				ContentImage: "ghcr.io/complianceascode/k8scontent:latest",
+				ContentImage: "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master",
 				ContentFile:  "ssg-rhcos4-ds.xml",
 			},
 			Status: compv1alpha1.ProfileBundleStatus{

--- a/pkg/utils/images.go
+++ b/pkg/utils/images.go
@@ -16,7 +16,7 @@ var componentDefaults = []struct {
 }{
 	{"ghcr.io/complianceascode/openscap-ocp:latest", "RELATED_IMAGE_OPENSCAP"},
 	{"ghcr.io/complianceascode/compliance-operator:latest", "RELATED_IMAGE_OPERATOR"},
-	{"ghcr.io/complianceascode/k8scontent:latest", "RELATED_IMAGE_PROFILE"},
+	{"quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master", "RELATED_IMAGE_PROFILE"},
 }
 
 // GetComponentImage returns a full image pull spec for a given component


### PR DESCRIPTION
Konflux already builds the compliance operator content and pushes it to
Quay. This means we don't need to setup duplicate Github Actions to
maintain the content and push it to k8scontent:latest.

This commit updates the project by replacing references to
k8scontent:latest with the corresponding references in Konflux.
