### PR TITLE
Add variable tailoring based on variable selections

### DIFF
--- a/config/crd/bases/compliance.openshift.io_tailoredprofiles.yaml
+++ b/config/crd/bases/compliance.openshift.io_tailoredprofiles.yaml
@@ -139,14 +139,20 @@ spec:
                     rationale:
                       description: Rationale of why this value is being tailored
                       type: string
+                    selection:
+                      description: Selection to choose from predefined variable selections
+                        in the datastream
+                      type: string
                     value:
                       description: Value of the variable being set
                       type: string
                   required:
                   - name
                   - rationale
-                  - value
                   type: object
+                  x-kubernetes-validations:
+                  - message: exactly one of value or selection must be specified
+                    rule: has(self.value) != has(self.selection)
                 nullable: true
                 type: array
               title:

--- a/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
+++ b/pkg/apis/compliance/v1alpha1/tailoredprofile_types.go
@@ -36,13 +36,18 @@ type RuleReferenceSpec struct {
 }
 
 // ValueReferenceSpec specifies a value to be set for a variable with a reason why
+// +kubebuilder:validation:XValidation:rule="has(self.value) != has(self.selection)",message="exactly one of value or selection must be specified"
 type VariableValueSpec struct {
 	// Name of the variable that's being referenced
 	Name string `json:"name"`
 	// Rationale of why this value is being tailored
 	Rationale string `json:"rationale"`
-	// Value of the variable being set
-	Value string `json:"value"`
+	// Value to set the variable to
+	// +optional
+	Value string `json:"value,omitempty"`
+	// Value to choose from predefined variable selections
+	// +optional
+	Selection string `json:"selection,omitempty"`
 }
 
 // TailoredProfileSpec defines the desired state of TailoredProfile

--- a/pkg/controller/tailoredprofile/tailoredprofile_controller.go
+++ b/pkg/controller/tailoredprofile/tailoredprofile_controller.go
@@ -758,9 +758,44 @@ func (r *ReconcileTailoredProfile) getCustomVariablesFromSelections(tp *cmpv1alp
 	}
 	return variableList, nil
 }
+
+// getDisplayValue returns the display string for a VariableValueSpec (either Value or Selection)
+func getDisplayValue(spec cmpv1alpha1.VariableValueSpec) string {
+	if spec.Value != "" {
+		return spec.Value
+	}
+	return spec.Selection
+}
+
+// resolveVariableValue determines the actual value to set based on the VariableValueSpec
+func resolveVariableValue(setValues cmpv1alpha1.VariableValueSpec, variable *cmpv1alpha1.Variable) (string, error) {
+	// Validate that both fields are not set simultaneously
+	if setValues.Selection != "" && setValues.Value != "" {
+		return "", common.NewNonRetriableCtrlError("variable %s: cannot specify both 'value' and 'selection' fields", setValues.Name)
+	}
+
+	// Handle selection-based value
+	if setValues.Selection != "" {
+		for _, selection := range variable.Selections {
+			if selection.Description == setValues.Selection {
+				return selection.Value, nil
+			}
+		}
+		return "", common.NewNonRetriableCtrlError("variable %s: selection '%s' not found in available selections", setValues.Name, setValues.Selection)
+	}
+
+	// Handle direct value
+	if setValues.Value != "" {
+		return setValues.Value, nil
+	}
+
+	// Neither field is set
+	return "", common.NewNonRetriableCtrlError("variable %s: must specify either 'value' or 'selection' field", setValues.Name)
+}
+
 func (r *ReconcileTailoredProfile) getVariablesFromSelections(tp *cmpv1alpha1.TailoredProfile, pb *cmpv1alpha1.ProfileBundle) ([]*cmpv1alpha1.Variable, error) {
 	// First pass: Build de-duplicated map of variables, keeping last occurrence when duplicates exist.
-	variables := make(map[string]string)
+	variables := make(map[string]cmpv1alpha1.VariableValueSpec)
 
 	for i, setValue := range tp.Spec.SetValues {
 		if oldVal, seen := variables[setValue.Name]; seen {
@@ -768,16 +803,16 @@ func (r *ReconcileTailoredProfile) getVariablesFromSelections(tp *cmpv1alpha1.Ta
 			r.Eventf(tp, corev1.EventTypeWarning,
 				"DuplicatedSetValue",
 				"Variable '%s' appears multiple times in setValues. The operator will keep the last usage with value '%s' (position %d), ignoring the previous value '%s'. Specifying a variable multiple times using setValues will fail in a future release. Please remove duplicates from setValues as it introduces ambiguity.",
-				setValue.Name, setValue.Value, i, oldVal)
+				setValue.Name, getDisplayValue(setValue), i, getDisplayValue(oldVal))
 		}
-		// Always use the last occurrence's value
-		variables[setValue.Name] = setValue.Value
+		// Always use the last occurrence
+		variables[setValue.Name] = setValue
 	}
 
 	// Second pass: Retrieve Variables from cluster and set their values
 	// Variables are processed in random order (map iteration)
 	variableList := make([]*cmpv1alpha1.Variable, 0, len(variables))
-	for varName, value := range variables {
+	for varName, setValues := range variables {
 		// Grab the Variable from the cluster
 		variable := &cmpv1alpha1.Variable{}
 		varKey := types.NamespacedName{Name: varName, Namespace: tp.Namespace}
@@ -794,8 +829,14 @@ func (r *ReconcileTailoredProfile) getVariablesFromSelections(tp *cmpv1alpha1.Ta
 				variable.GetName(), pb.GetName())
 		}
 
-		// try setting the variable, this also validates the value
-		if err := variable.SetValue(value); err != nil {
+		// Resolve the value to set based on selection or direct value
+		valueToSet, err := resolveVariableValue(setValues, variable)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set the variable value (this also validates it)
+		if err := variable.SetValue(valueToSet); err != nil {
 			return nil, common.NewNonRetriableCtrlError("setting variable: %s", err)
 		}
 

--- a/pkg/controller/tailoredprofile/tailoredprofile_controller_test.go
+++ b/pkg/controller/tailoredprofile/tailoredprofile_controller_test.go
@@ -89,8 +89,23 @@ var _ = Describe("TailoredprofileController", func() {
 					Namespace: namespace,
 				},
 				VariablePayload: compv1alpha1.VariablePayload{
-					ID: fmt.Sprintf("var_%d", i),
+					ID:   fmt.Sprintf("var_%d", i),
+					Type: compv1alpha1.VarTypeString,
 				},
+			}
+
+			// Add selections for var-1 to test selection functionality
+			if i == 1 {
+				v.Selections = []compv1alpha1.ValueSelection{
+					{
+						Description: "default",
+						Value:       "default_value",
+					},
+					{
+						Description: "alternative",
+						Value:       "alt_value",
+					},
+				}
 			}
 
 			// Rules and Variables 1, 2, 3, 4 are owned by pb1
@@ -1335,6 +1350,146 @@ var _ = Describe("TailoredprofileController", func() {
 				By("Has the appropriate error status")
 				Expect(tp.Status.State).To(Equal(compv1alpha1.TailoredProfileStateError))
 				Expect(tp.Status.ErrorMessage).NotTo(BeEmpty())
+			})
+		})
+
+		Context("with variable selection", func() {
+			BeforeEach(func() {
+				tp := &compv1alpha1.TailoredProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tpName,
+						Namespace: namespace,
+					},
+					Spec: compv1alpha1.TailoredProfileSpec{
+						EnableRules: []compv1alpha1.RuleReferenceSpec{
+							{
+								Name:      "rule-1",
+								Rationale: "Enable rule for test",
+							},
+						},
+						SetValues: []compv1alpha1.VariableValueSpec{
+							{
+								Name:      "var-1",
+								Rationale: "Using selection for variable value",
+								Selection: "default",
+							},
+						},
+					},
+				}
+
+				createErr := r.Client.Create(ctx, tp)
+				Expect(createErr).To(BeNil())
+			})
+			It("sets the variable value using selection", func() {
+				tpKey := types.NamespacedName{
+					Name:      tpName,
+					Namespace: namespace,
+				}
+				tpReq := reconcile.Request{}
+				tpReq.Name = tpName
+				tpReq.Namespace = namespace
+
+				By("Reconciling the first time (setting ownership)")
+				_, err := r.Reconcile(context.TODO(), tpReq)
+				Expect(err).To(BeNil())
+
+				tp := &compv1alpha1.TailoredProfile{}
+				geterr := r.Client.Get(ctx, tpKey, tp)
+				Expect(geterr).To(BeNil())
+
+				By("Sets the profile bundle as the owner")
+				ownerRefs := tp.GetOwnerReferences()
+				Expect(ownerRefs).To(HaveLen(1))
+				Expect(ownerRefs[0].Kind).To(Equal("ProfileBundle"))
+
+				By("Reconciling a second time (setting status)")
+				_, err = r.Reconcile(context.TODO(), tpReq)
+
+				tp = &compv1alpha1.TailoredProfile{}
+				geterr = r.Client.Get(ctx, tpKey, tp)
+				Expect(geterr).To(BeNil())
+
+				By("Has the appropriate status")
+				Expect(tp.Status.State).To(Equal(compv1alpha1.TailoredProfileStateReady))
+				Expect(tp.Status.OutputRef.Name).To(Equal(tp.Name + "-tp"))
+				Expect(tp.Status.OutputRef.Namespace).To(Equal(tp.Namespace))
+
+				By("Generated an appropriate ConfigMap with selection-based value")
+				cm := &corev1.ConfigMap{}
+				cmKey := types.NamespacedName{
+					Name:      tp.Status.OutputRef.Name,
+					Namespace: tp.Status.OutputRef.Namespace,
+				}
+
+				geterr = r.Client.Get(ctx, cmKey, cm)
+				Expect(geterr).To(BeNil())
+				data := cm.Data["tailoring.xml"]
+				// Should set var-1 to "default_value" based on the "default" selection
+				Expect(data).To(ContainSubstring(`set-value idref="var_1">default_value<`))
+			})
+		})
+
+		Context("with both value and selection specified", func() {
+			BeforeEach(func() {
+				tp := &compv1alpha1.TailoredProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      tpName,
+						Namespace: namespace,
+					},
+					Spec: compv1alpha1.TailoredProfileSpec{
+						EnableRules: []compv1alpha1.RuleReferenceSpec{
+							{
+								Name:      "rule-1",
+								Rationale: "Enable rule for test",
+							},
+						},
+						SetValues: []compv1alpha1.VariableValueSpec{
+							{
+								Name:      "var-1",
+								Rationale: "Testing invalid configuration",
+								Value:     "direct_value",
+								Selection: "default",
+							},
+						},
+					},
+				}
+
+				createErr := r.Client.Create(ctx, tp)
+				Expect(createErr).To(BeNil())
+			})
+			It("reports an error for conflicting value and selection", func() {
+				tpKey := types.NamespacedName{
+					Name:      tpName,
+					Namespace: namespace,
+				}
+				tpReq := reconcile.Request{}
+				tpReq.Name = tpName
+				tpReq.Namespace = namespace
+
+				By("Reconciling the first time (setting ownership)")
+				_, err := r.Reconcile(context.TODO(), tpReq)
+				Expect(err).To(BeNil())
+
+				tp := &compv1alpha1.TailoredProfile{}
+				geterr := r.Client.Get(ctx, tpKey, tp)
+				Expect(geterr).To(BeNil())
+
+				By("Sets the profile bundle as the owner")
+				ownerRefs := tp.GetOwnerReferences()
+				Expect(ownerRefs).To(HaveLen(1))
+				Expect(ownerRefs[0].Kind).To(Equal("ProfileBundle"))
+
+				By("Reconciling a second time (should hit error)")
+				_, err = r.Reconcile(context.TODO(), tpReq)
+				Expect(err).To(BeNil())
+
+				tp = &compv1alpha1.TailoredProfile{}
+				geterr = r.Client.Get(ctx, tpKey, tp)
+				Expect(geterr).To(BeNil())
+
+				By("Has an error status")
+				Expect(tp.Status.State).To(Equal(compv1alpha1.TailoredProfileStateError))
+				Expect(tp.Status.ErrorMessage).To(ContainSubstring("cannot specify both 'value' and 'selection' fields"))
 			})
 		})
 	})


### PR DESCRIPTION
The Variables in CO have predefined selections that are parsed from the Data Stream.
These predefined selections are used to customize a rule to a specific policy or common use cases.

CO doesn't take advantage of these selector.
This patch allows the user to tailor a variable using the available selections in the variable.