### PR TITLE
CMP-3613: Gracefully handle profile deprecation checks

### DIFF
--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -337,9 +337,12 @@ func (r *ReconcileComplianceScan) notifyUseOfDeprecatedProfile(instance *compv1a
 			}
 		}
 		if pbName == "" {
-			err := goerrors.New("Could not find ProfileBundle used by scan")
-			logger.Error(err, "ComplianceScan uses non-existent ProfileBundle", "ComplianceScan", instance.Name, "Profile", instance.Spec.Profile)
-			return err
+			logger.Info("Could not find ProfileBundle used by scan to check if the Profile is deprecated",
+				"ComplianceScan", instance.Name,
+				"Profile", instance.Spec.Profile,
+				"ContentImage", instance.Spec.ContentImage,
+				"Content", instance.Spec.Content)
+			return nil
 		}
 
 		xccdfProfileName := xccdf.GetProfileNameFromID(instance.Spec.Profile)


### PR DESCRIPTION
Previously, when the operator checked if a profile was deprecated, it would
fail if it couldn't reliably detect the profile bundle used for the profile.
This is because the profile bundle contained the profiles, which carries the
deprecation flag. If the operator doesn't know which profile bundle a profile
came from, it can't guarantee it knows if the profile is supported or not.

This is mostly fine when users are scanning their environments using
ScanSettingBindings, which rely on existing Profile and ProfileBundle
resources. But, if a user is creating a ComplianceSuite or ComplianceScan
directly, they get to set the content and content image for the scan, which
usually comes from the profile and profile bundle. If a user specifies a
content image pointing to their own content (or even in our testing cases,
where we point to content images built for each pull request), that is going to
mismatch with the default profile bundles, meaning they can't create a
ComplianceScan directly to hook in their own content anymore because the
deprecation logic will always error out looking for a profile bundle that it
assumes must exist.

This commit relaxes that requirement, but maintains the default behavior so
that users relying on ScanSettingBindings still get deprecation notices when
they should, and allows power users the ability to set their own content images
directly without breaking the workflow on the deprecation check.

