### PR TITLE
Update version to 1.8.0-dev in Makefile and manifests for development

### DIFF
--- a/bundle.openshift.Dockerfile
+++ b/bundle.openshift.Dockerfile
@@ -1,5 +1,5 @@
-ARG CO_OLD_VERSION="1.7.0"
-ARG CO_NEW_VERSION="1.7.1"
+ARG CO_OLD_VERSION="1.7.1"
+ARG CO_NEW_VERSION="1.8.0-dev"
 
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 as builder
 

--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -161,7 +161,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
     must-gather-image: ghcr.io/complianceascode/must-gather-ocp:latest
-    olm.skipRange: '>=0.1.17 <1.7.1'
+    olm.skipRange: '>=0.1.17 <1.8.0-dev'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
@@ -176,7 +176,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: compliance-operator.v1.7.1
+  name: compliance-operator.v1.8.0-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1695,5 +1695,5 @@ spec:
     name: operator
   - image: ghcr.io/complianceascode/k8scontent:latest
     name: profile
-  replaces: compliance-operator.v1.7.0
-  version: 1.7.1
+  replaces: compliance-operator.v1.7.1
+  version: 1.8.0-dev

--- a/catalog/preamble.json
+++ b/catalog/preamble.json
@@ -13,8 +13,8 @@
     "package": "compliance-operator",
     "entries": [
         {
-            "name": "compliance-operator.v1.7.1",
-            "skipRange": ">=0.1.17 <1.7.1"
+            "name": "compliance-operator.v1.8.0-dev",
+            "skipRange": ">=0.1.17 <1.8.0-dev"
         }
     ]
 }

--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -161,7 +161,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
     must-gather-image: ghcr.io/complianceascode/must-gather-ocp:latest
-    olm.skipRange: '>=0.1.17 <1.7.1'
+    olm.skipRange: '>=0.1.17 <1.8.0-dev'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
@@ -174,7 +174,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: compliance-operator.v1.7.1
+  name: compliance-operator.v1.8.0-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1574,5 +1574,5 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  replaces: compliance-operator.v1.7.0
-  version: 1.7.1
+  replaces: compliance-operator.v1.7.1
+  version: 1.8.0-dev

--- a/version.Makefile
+++ b/version.Makefile
@@ -3,4 +3,4 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 
 PREVIOUS_VERSION?=1.7.1
-VERSION?=1.7.1
+VERSION?=1.8.0-dev

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.7.1"
+	Version = "1.8.0-dev"
 )


### PR DESCRIPTION
Changed VERSION in version.Makefile to 1.8.0-dev.
This will help us to fix the bundle verify job.