### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for compliance-operator-release-1-7

### DIFF
--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -22,7 +22,8 @@ LABEL \
         description="An operator that performs compliance scanning and remediation on a cluster" \
         maintainer="Red Hat ISC <isc-team@redhat.com>" \
         License="GPLv2+" \
-        name="openshift-compliance-operator" \
+        name="compliance/openshift-compliance-rhel8-operator" \
+        cpe="cpe:/a:redhat:openshift_file_integrity_operator:1::el9" \
         com.redhat.component="openshift-compliance-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Compliance Operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
