### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for compliance-operator-bundle-release-1-7

### DIFF
--- a/bundle.openshift.Dockerfile
+++ b/bundle.openshift.Dockerfile
@@ -17,7 +17,7 @@ FROM scratch
 
 ARG CO_NEW_VERSION
 
-LABEL name=openshift-compliance-operator-bundle
+LABEL name=compliance/openshift-compliance-operator-bundle
 LABEL version=${CO_NEW_VERSION}
 LABEL summary='OpenShift Compliance Operator'
 LABEL maintainer='Infrastructure Security and Compliance Team <isc-team@redhat.com>'
@@ -31,6 +31,7 @@ LABEL url="https://github.com/ComplianceAsCode/compliance-operator"
 LABEL distribution-scope=public
 
 LABEL com.redhat.component=openshift-compliance-operator-bundle-container
+LABEL cpe=cpe:/a:redhat:openshift_file_integrity_operator:1::el9
 LABEL com.redhat.delivery.appregistry=false
 LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.openshift.versions="v4.10"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
