### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for compliance-operator-must-gather-release-1-7

### DIFF
--- a/images/must-gather/Containerfile
+++ b/images/must-gather/Containerfile
@@ -9,7 +9,8 @@ LABEL \
         description="An image to collect debug information from compliance-operator" \
         maintainer="Red Hat ISC <isc-team@redhat.com>" \
         License="GPLv2+" \
-        name="openshift-compliance-must-gather" \
+        name="compliance/openshift-compliance-must-gather-rhel8" \
+        cpe="cpe:/a:redhat:openshift_file_integrity_operator:1::el9" \
         com.redhat.component="openshift-compliance-must-gather-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Compliance Operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
