### PR TITLE
CMP-3765: Add kubevirt-no-shareable-disks to OpenShift virtualization samples

### DIFF
--- a/config/samples/custom-rules/openshift-virtualization/kubevirt-no-shareable-disks.yaml
+++ b/config/samples/custom-rules/openshift-virtualization/kubevirt-no-shareable-disks.yaml
@@ -1,0 +1,35 @@
+apiVersion: compliance.openshift.io/v1alpha1
+kind: CustomRule
+metadata:
+  name: kubevirt-no-shareable-disks
+  namespace: openshift-compliance
+spec:
+  title: "KubeVirt Must Not Use Shareable Disks"
+  id: kubevirt_no_shareable_disks
+  description: |-
+    Sharable disks are shared between VMs, and they can be used only if a filesystem
+    installed on top of it is a cluster-file system or the application using the
+    device is distributed and cloud aware. Their wrong usage might cause data corruption.
+
+    Sharing system resources increases the risk of unauthorized access to data,
+    manipulation of data flow restrictions, and could lead to corruption and data loss.
+  failureReason: |-
+    One or more virtual machines have disks with the 'shareable' flag set to 'true'.
+    This configuration allows disks to be shared between VMs, which can lead to data
+    corruption and security risks.
+  severity: Medium
+  checkType: Platform
+  scannerType: CEL
+  inputs:
+    - name: vmList
+      kubernetesInputSpec:
+        apiVersion: kubevirt.io/v1
+        resource: virtualmachines
+  expression: |
+    vmList.items.all(vm,
+        !has(vm.spec.template.spec.domain.devices.disks) ||
+        vm.spec.template.spec.domain.devices.disks.all(disk,
+            !has(disk.shareable) ||
+            disk.shareable != true
+        )
+    )

--- a/config/samples/custom-rules/openshift-virtualization/kustomization.yaml
+++ b/config/samples/custom-rules/openshift-virtualization/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - kubevirt-no-permitted-host-devices.yaml
   - kubevirt-persistent-reservation-disabled.yaml
   - kubevirt-no-vms-overcommiting-guest-memory
+  - kubevirt-no-shareable-disks.yaml
   - tailored-profile.yaml
   - scan-setting-binding.yaml

--- a/config/samples/custom-rules/openshift-virtualization/ocp-virt-permissions.yaml
+++ b/config/samples/custom-rules/openshift-virtualization/ocp-virt-permissions.yaml
@@ -11,3 +11,11 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/samples/custom-rules/openshift-virtualization/tailored-profile.yaml
+++ b/config/samples/custom-rules/openshift-virtualization/tailored-profile.yaml
@@ -36,4 +36,11 @@ spec:
         scheduling algorithms. If the VM consumes the entire memory might
         cause the guest to crash with workload interruptions and guest
         malfunctioning.
+    - kind: CustomRule
+      name: kubevirt-no-shareable-disks
+      rationale: |-
+        Shareable disks are shared between VMs and can only be used safely with
+        cluster filesystems or distributed applications. Their incorrect usage
+        might cause data corruption and introduces security risks including
+        unauthorized access to data and potential data loss.
   title: Platform checks for OpenShift Virtualization


### PR DESCRIPTION
We are adding rules for checking Disable Shareable disks

The original control is 
```
Disable Shareable disks
Profile Applicability: Level 1

Description: Sharable disks are shared between VMs, and they can be used only if a filesystem installed on top of it is a cluster-file system or the application using the device is distributed and cloud aware. Their wrong usage might cause data corruption.

Rationale: Sharing system resources increases the risk of unauthorized access to data, manipulation of data flow restrictions, and could lead to corruption and data loss.

Impact: Sharable disks are one means of sharing data between workloads, which cannot be used if this feature is avoided.

Audit: Inspect virtual machine volumes and ensure the shareable flag is not set to true:

$ oc get vm -ojson -A | jq '.items[] | select(.spec.template.spec.domain.devices.disks[].shareable == true)| .metadata.namespace + "/" + .metadata.name'


Remediation: Remove the shareable flag from any disk where it is found.
For example, to remove the shareable flag on the first disk (index 0) of a given VM, this command can be used:

$ oc patch vm <vm-name> --type='json' -p='[
    {"op": "remove", "path": "/spec/template/spec/domain/devices/disks/0/shareable"},
]'


To set a shareable flag to false on every disk, this (experimental) command can be used:

$ oc get vm <vm-name> -o json | jq '.spec.template.spec.domain.devices.disks[] += {"shareable":false}' | oc apply -f -


Default Value: Shareable disks are not enabled by default. The command should return an empty list.
```