### PR TITLE
CMP-3765: Add a rule to restrict patching annotations

### DIFF
--- a/config/samples/custom-rules/openshift-virtualization/kustomization.yaml
+++ b/config/samples/custom-rules/openshift-virtualization/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - kubevirt-no-vms-overcommiting-guest-memory
   - tailored-profile.yaml
   - scan-setting-binding.yaml
+  - ocp-virt-restrict-patching-annotations.yaml

--- a/config/samples/custom-rules/openshift-virtualization/ocp-virt-restrict-patching-annotations.yaml
+++ b/config/samples/custom-rules/openshift-virtualization/ocp-virt-restrict-patching-annotations.yaml
@@ -1,0 +1,40 @@
+apiVersion: compliance.openshift.io/v1alpha1
+kind: CustomRule
+metadata:
+  name: ocp-virt-restrict-patching-annotations
+  namespace: openshift-compliance
+spec:
+  title: "OCP Virt restrict patching annotations"
+  id: ocp_virt_restrict_patching_annotations
+  description: |-
+    The kubevirt-hyperconverged (HCO) object provides a mechanism to customize
+    OpenShift Virtualization components through the control of patching operations.
+    Although this approach itself does not inherently introduce security risks,
+    enabling experimental features may have unintended consequences and might not
+    be officially supported. It is essential to weigh the benefits of using these
+    options against any potential security implications before proceeding.
+  failureReason: |-
+    The '.metadata.annotations' field contains sub-component json patches in
+    the 'kubevirt-hyperconverged' resource.
+  severity: Medium
+  checkType: Platform
+  scannerType: CEL
+  inputs:
+    - name: hcoList
+      kubernetesInputSpec:
+        apiVersion: hco.kubevirt.io/v1beta1
+        resource: hyperconvergeds
+  expression: |
+    hcoList.items.all(h,
+      !(h.metadata.name == 'kubevirt-hyperconverged' &&
+        h.metadata.namespace == 'openshift-cnv') ||
+      (
+        !has(h.metadata.annotations) ||
+        !(
+          "kubevirt.kubevirt.io/jsonpatch" in h.metadata.annotations ||
+          "containerizeddataimporter.kubevirt.io/jsonpatch" in h.metadata.annotations ||
+          "networkaddonsconfigs.kubevirt.io/jsonpatch" in h.metadata.annotations ||
+          "ssp.kubevirt.io/jsonpatch" in h.metadata.annotations
+        )
+      )
+    )

--- a/config/samples/custom-rules/openshift-virtualization/tailored-profile.yaml
+++ b/config/samples/custom-rules/openshift-virtualization/tailored-profile.yaml
@@ -36,4 +36,9 @@ spec:
         scheduling algorithms. If the VM consumes the entire memory might
         cause the guest to crash with workload interruptions and guest
         malfunctioning.
+    - kind: CustomRule
+      name: ocp-virt-restrict-patching-annotations
+      rationale: |-
+        Cloud administrators should not patch OpenShift Virtualization objects,
+        but rather configure the OpenShift Virtualization options available in HCO.
   title: Platform checks for OpenShift Virtualization


### PR DESCRIPTION
Restrictions to patching operations may prevent the use of experimental features not yet supported or considered insecure.