### PR TITLE
CMP-3765: ocp-virt: add rule to enforce MAC spoof filtering

### DIFF
--- a/config/samples/custom-rules/openshift-virtualization/kubevirt-macspoof-nad.yaml
+++ b/config/samples/custom-rules/openshift-virtualization/kubevirt-macspoof-nad.yaml
@@ -1,0 +1,30 @@
+apiVersion: compliance.openshift.io/v1alpha1
+kind: CustomRule
+metadata:
+  name: kubevirt-macspoof-enabled-for-nad
+  namespace: openshift-compliance
+spec:
+  title: "Macspoof Filtering Must Be Enabled for all Network Attachment Definitions"
+  id: macspoof_filtering_enabled_nad
+  description: |-
+    Mac spoof filtering is a feature that helps prevent man-in-the-middle
+    attacks by verifying the authenticity of MAC addresses in network packets.
+    By checking the MAC address of incoming packets, mac-spoof filtering can
+    help ensure that only authorized devices are able to communicate with a
+    particular device or network.
+  failureReason: |-
+    The '.spec.config.macspoofchk' field is missing or not set to true in the
+    'NetworkAttachmentDefinition' resource.
+  severity: Medium
+  checkType: Platform
+  scannerType: CEL
+  inputs:
+    - name: nadList
+      kubernetesInputSpec:
+        apiVersion: k8s.cni.cncf.io/v1
+        resource: NetworkAttachmentDefinition
+  expression: |
+    nadList.all(s,
+        has(s.spec.config.macspoofchk) &&
+        s.spec.config.macspoofchk == true
+    )

--- a/config/samples/custom-rules/openshift-virtualization/kubevirt-macspoof-sriov.yaml
+++ b/config/samples/custom-rules/openshift-virtualization/kubevirt-macspoof-sriov.yaml
@@ -1,0 +1,30 @@
+apiVersion: compliance.openshift.io/v1alpha1
+kind: CustomRule
+metadata:
+  name: kubevirt-macspoof-enabled-for-sriov
+  namespace: openshift-compliance
+spec:
+  title: "Macspoof Filtering Must Be Enabled for all SRIOV devices"
+  id: macspoof_filtering_enabled_sriov
+  description: |-
+    Mac spoof filtering is a feature that helps prevent man-in-the-middle
+    attacks by verifying the authenticity of MAC addresses in network packets.
+    By checking the MAC address of incoming packets, mac-spoof filtering can
+    help ensure that only authorized devices are able to communicate with a
+    particular device or network.
+  failureReason: |-
+    The '.spec.spoofChk' field is missing or not set to 'on' in the
+    'sriovnetwork' resource.
+  severity: Medium
+  checkType: Platform
+  scannerType: CEL
+  inputs:
+    - name: sriovList
+      kubernetesInputSpec:
+        apiVersion: sriovnetwork.openshift.io/v1
+        resource: sriovnetwork
+  expression: |
+    sriovList.all(s,
+        has(s.spec.spoofChk) &&
+        s.spec.spoofChk == 'on'
+    )

--- a/config/samples/custom-rules/openshift-virtualization/kustomization.yaml
+++ b/config/samples/custom-rules/openshift-virtualization/kustomization.yaml
@@ -1,6 +1,8 @@
 resources:
   - ocp-virt-permissions.yaml
   - ocp-virt-rbac-binding.yaml
+  - kubevirt-macspoof-nad.yaml
+  - kubevirt-macspoof-sriov.yaml
   - kubevirt-nonroot-feature-gate-is-enabled.yaml
   - kubevirt-no-permitted-host-devices.yaml
   - kubevirt-persistent-reservation-disabled.yaml

--- a/config/samples/custom-rules/openshift-virtualization/tailored-profile.yaml
+++ b/config/samples/custom-rules/openshift-virtualization/tailored-profile.yaml
@@ -7,6 +7,22 @@ spec:
   description: Custom security checks for OpenShift Virtualization
   enableRules:
     - kind: CustomRule
+      name: kubevirt-macspoof-enabled-for-nad
+      rationale: |-
+        Mac spoof filtering is a feature that helps prevent man-in-the-middle
+        attacks by verifying the authenticity of MAC addresses in network packets.
+        By checking the MAC address of incoming packets, mac-spoof filtering can
+        help ensure that only authorized devices are able to communicate with a
+        particular device or network.
+    - kind: CustomRule
+      name: kubevirt-macspoof-enabled-for-sriov
+      rationale: |-
+        Mac spoof filtering is a feature that helps prevent man-in-the-middle
+        attacks by verifying the authenticity of MAC addresses in network packets.
+        By checking the MAC address of incoming packets, mac-spoof filtering can
+        help ensure that only authorized devices are able to communicate with a
+        particular device or network.
+    - kind: CustomRule
       name: kubevirt-nonroot-feature-gate-is-enabled
       rationale: |-
         Unauthorized access to a root account without restrictions implemented


### PR DESCRIPTION
Add rules to enforce the usage of MAC spoof filtering. This covers SRIOV devices and Network Attachment Definitions in two separate rules.