### PR TITLE
CMP-3969, CMP-4121: Fix panic issue when deleting a scan with invalid storage size

### DIFF
--- a/bundle/manifests/compliance.openshift.io_compliancescans.yaml
+++ b/bundle/manifests/compliance.openshift.io_compliancescans.yaml
@@ -143,7 +143,12 @@ spec:
                     description: |-
                       Specifies the amount of storage to ask for storing the raw results. Note that
                       if re-scans happen, the new results will also need to be stored. Defaults to 1Gi.
+                    maxLength: 16
                     type: string
+                    x-kubernetes-validations:
+                    - message: size must be a valid Kubernetes quantity (e.g., 1Gi,
+                        500Mi)
+                      rule: self == '' || isQuantity(self)
                   storageClassName:
                     description: |-
                       Specifies the StorageClassName to use when creating the PersistentVolumeClaim

--- a/bundle/manifests/compliance.openshift.io_compliancesuites.yaml
+++ b/bundle/manifests/compliance.openshift.io_compliancesuites.yaml
@@ -162,7 +162,12 @@ spec:
                           description: |-
                             Specifies the amount of storage to ask for storing the raw results. Note that
                             if re-scans happen, the new results will also need to be stored. Defaults to 1Gi.
+                          maxLength: 16
                           type: string
+                          x-kubernetes-validations:
+                          - message: size must be a valid Kubernetes quantity (e.g.,
+                              1Gi, 500Mi)
+                            rule: self == '' || isQuantity(self)
                         storageClassName:
                           description: |-
                             Specifies the StorageClassName to use when creating the PersistentVolumeClaim

--- a/bundle/manifests/compliance.openshift.io_scansettings.yaml
+++ b/bundle/manifests/compliance.openshift.io_scansettings.yaml
@@ -113,7 +113,11 @@ spec:
                 description: |-
                   Specifies the amount of storage to ask for storing the raw results. Note that
                   if re-scans happen, the new results will also need to be stored. Defaults to 1Gi.
+                maxLength: 16
                 type: string
+                x-kubernetes-validations:
+                - message: size must be a valid Kubernetes quantity (e.g., 1Gi, 500Mi)
+                  rule: self == '' || isQuantity(self)
               storageClassName:
                 description: |-
                   Specifies the StorageClassName to use when creating the PersistentVolumeClaim

--- a/config/crd/bases/compliance.openshift.io_compliancescans.yaml
+++ b/config/crd/bases/compliance.openshift.io_compliancescans.yaml
@@ -143,7 +143,12 @@ spec:
                     description: |-
                       Specifies the amount of storage to ask for storing the raw results. Note that
                       if re-scans happen, the new results will also need to be stored. Defaults to 1Gi.
+                    maxLength: 16
                     type: string
+                    x-kubernetes-validations:
+                    - message: size must be a valid Kubernetes quantity (e.g., 1Gi,
+                        500Mi)
+                      rule: self == '' || isQuantity(self)
                   storageClassName:
                     description: |-
                       Specifies the StorageClassName to use when creating the PersistentVolumeClaim

--- a/config/crd/bases/compliance.openshift.io_compliancesuites.yaml
+++ b/config/crd/bases/compliance.openshift.io_compliancesuites.yaml
@@ -162,7 +162,12 @@ spec:
                           description: |-
                             Specifies the amount of storage to ask for storing the raw results. Note that
                             if re-scans happen, the new results will also need to be stored. Defaults to 1Gi.
+                          maxLength: 16
                           type: string
+                          x-kubernetes-validations:
+                          - message: size must be a valid Kubernetes quantity (e.g.,
+                              1Gi, 500Mi)
+                            rule: self == '' || isQuantity(self)
                         storageClassName:
                           description: |-
                             Specifies the StorageClassName to use when creating the PersistentVolumeClaim

--- a/config/crd/bases/compliance.openshift.io_scansettings.yaml
+++ b/config/crd/bases/compliance.openshift.io_scansettings.yaml
@@ -113,7 +113,11 @@ spec:
                 description: |-
                   Specifies the amount of storage to ask for storing the raw results. Note that
                   if re-scans happen, the new results will also need to be stored. Defaults to 1Gi.
+                maxLength: 16
                 type: string
+                x-kubernetes-validations:
+                - message: size must be a valid Kubernetes quantity (e.g., 1Gi, 500Mi)
+                  rule: self == '' || isQuantity(self)
               storageClassName:
                 description: |-
                   Specifies the StorageClassName to use when creating the PersistentVolumeClaim

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -148,6 +148,8 @@ type RawResultStorageSettings struct {
 	// if re-scans happen, the new results will also need to be stored. Defaults to 1Gi.
 	// +kubebuilder:validation:Default=1Gi
 	// +kubebuilder:default="1Gi"
+	// +kubebuilder:validation:MaxLength=16
+	// +kubebuilder:validation:XValidation:rule="self == '' || isQuantity(self)",message="size must be a valid Kubernetes quantity (e.g., 1Gi, 500Mi)"
 	Size string `json:"size,omitempty"`
 	// Specifies the amount of scans for which the raw results will be stored.
 	// Older results will get rotated, and it's the responsibility of administrators

--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -58,6 +58,105 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
+// TestScanWithInvalidStorageSizeRejected tests that scans with invalid storage size are rejected at API level
+func TestScanWithInvalidStorageSizeRejected(t *testing.T) {
+	t.Parallel()
+	f := framework.Global
+
+	// Test cases with different invalid storage size formats
+	testCases := []struct {
+		name        string
+		size        string
+		description string
+	}{
+		{
+			name:        "invalid-text",
+			size:        "invalid-size",
+			description: "Plain text that is not a valid quantity",
+		},
+		{
+			name:        "invalid-unit",
+			size:        "1GB",
+			description: "Using GB instead of Gi (decimal vs binary)",
+		},
+		{
+			name:        "invalid-suffix",
+			size:        "1B",
+			description: "Using B suffix which is not valid in Kubernetes quantities",
+		},
+		{
+			name:        "random-string",
+			size:        "abc123",
+			description: "Random string that cannot be parsed",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			suiteName := framework.GetObjNameFromTest(t)
+			scanName := fmt.Sprintf("%s-worker-scan", suiteName)
+
+			// Create a ComplianceSuite with invalid storage size
+			testSuite := &compv1alpha1.ComplianceSuite{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      suiteName,
+					Namespace: f.OperatorNamespace,
+				},
+				Spec: compv1alpha1.ComplianceSuiteSpec{
+					ComplianceSuiteSettings: compv1alpha1.ComplianceSuiteSettings{
+						AutoApplyRemediations: false,
+					},
+					Scans: []compv1alpha1.ComplianceScanSpecWrapper{
+						{
+							Name: scanName,
+							ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
+								ContentImage: contentImagePath,
+								Profile:      "xccdf_org.ssgproject.content_profile_coreos-ncp",
+								Content:      "ssg-rhcos4-ds.xml",
+								ScanType:     compv1alpha1.ScanTypeNode,
+								NodeSelector: map[string]string{
+									"node-role.kubernetes.io/worker": "",
+								},
+								ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+									RawResultStorage: compv1alpha1.RawResultStorageSettings{
+										Size: tc.size, // Invalid size format
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			// Attempt to create the suite - this should fail with validation error
+			err := f.Client.Create(context.TODO(), testSuite, nil)
+			if err == nil {
+				// If creation succeeded, clean up and fail the test
+				f.Client.Delete(context.TODO(), testSuite)
+				t.Fatalf("expected ComplianceSuite creation to fail with invalid size %q (%s), but it succeeded", tc.size, tc.description)
+			}
+
+			// Verify the error message contains expected validation failure text
+			expectedErrorSubstrings := []string{
+				"Invalid value",
+				"size must be a valid Kubernetes quantity",
+			}
+
+			errorMsg := err.Error()
+			for _, expectedSubstr := range expectedErrorSubstrings {
+				if !strings.Contains(errorMsg, expectedSubstr) {
+					t.Errorf("expected error message to contain %q, but got: %s", expectedSubstr, errorMsg)
+				}
+			}
+
+			t.Logf("Successfully rejected invalid storage size %q with error: %s", tc.size, errorMsg)
+		})
+	}
+}
+
 func TestProfileVersion(t *testing.T) {
 	t.Parallel()
 	f := framework.Global


### PR DESCRIPTION
Description of the PR:
1. Fix panic issue when storage size is invalid
2. Add CEL validation to RawResultStorageSettings.Size field to validate quantity format at API creation time using isQuantity() function
3. Add e2e test to verify invalid storage sizes are rejected at API level