### PR TITLE
CMP-3781: Add testing for CIS profile version consistency between base and vers…

### DIFF
--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -3143,7 +3143,7 @@ func (f *Framework) waitForNamespaceDeletion(namespace string, retryInterval, ti
 	return nil
 }
 
-// check if node names appear in <target> & fact:identifier elements of complianceScan XCCDF format result 
+// check if node names appear in <target> & fact:identifier elements of complianceScan XCCDF format result
 func (f *Framework) AssertNodeNameIsInTargetAndFactIdentifierInCM(nodes []core.Node, configMaps []core.ConfigMap) error {
 	for _, node := range nodes {
 		nodeName := node.Name
@@ -3178,4 +3178,112 @@ func (f *Framework) AssertNodeNameIsInTargetAndFactIdentifierInCM(nodes []core.N
 		}
 	}
 	return nil
-}	
+}
+
+// GetScanCheckCount returns the check count from a scan's annotation
+func (f *Framework) GetScanCheckCount(namespace, scanName string) (int, error) {
+	scan := &compv1alpha1.ComplianceScan{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{
+		Namespace: namespace,
+		Name:      scanName,
+	}, scan); err != nil {
+		return 0, err
+	}
+	checkCount, ok := scan.Annotations[compv1alpha1.ComplianceCheckCountAnnotation]
+	if !ok {
+		return 0, fmt.Errorf("scan %s missing check count annotation", scanName)
+	}
+	return strconv.Atoi(checkCount)
+}
+
+// CollectScanCounts collects check counts for all scans in a ComplianceSuite
+func (f *Framework) CollectScanCounts(t *testing.T, suite *compv1alpha1.ComplianceSuite, description string) (map[string]int, error) {
+	counts := make(map[string]int)
+	for _, scanStatus := range suite.Status.ScanStatuses {
+		// Verify scan has valid check counts
+		if err := f.AssertScanHasTotalCheckCounts(f.OperatorNamespace, scanStatus.Name); err != nil {
+			return nil, fmt.Errorf("failed check count validation for %s scan %s: %s", description, scanStatus.Name, err)
+		}
+		count, err := f.GetScanCheckCount(f.OperatorNamespace, scanStatus.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get check count for %s scan %s: %s", description, scanStatus.Name, err)
+		}
+		counts[scanStatus.Name] = count
+		t.Logf("%s scan %s: %d rules", description, scanStatus.Name, count)
+	}
+	return counts, nil
+}
+
+// GetCheckResultsForScan retrieves all ComplianceCheckResults for a specific scan
+func (f *Framework) GetCheckResultsForScan(namespace, scanName string) (map[string]compv1alpha1.ComplianceCheckStatus, error) {
+	var checkList compv1alpha1.ComplianceCheckResultList
+	checkListOpts := client.MatchingLabels{
+		compv1alpha1.ComplianceScanLabel: scanName,
+	}
+	if err := f.Client.List(context.TODO(), &checkList, checkListOpts); err != nil {
+		return nil, err
+	}
+
+	results := make(map[string]compv1alpha1.ComplianceCheckStatus)
+	for _, check := range checkList.Items {
+		// Use the check ID as the key - it's consistent across scans
+		ruleID := check.ID
+		if ruleID == "" {
+			// Fallback to check name if ID is not set
+			ruleID = check.Name
+		}
+		results[ruleID] = check.Status
+	}
+	return results, nil
+}
+
+// CompareCheckResults compares ComplianceCheckResults between two scans
+func (f *Framework) CompareCheckResults(t *testing.T, namespace string, scan1Name, scan2Name string) error {
+	results1, err := f.GetCheckResultsForScan(namespace, scan1Name)
+	if err != nil {
+		return fmt.Errorf("failed to get check results for scan %s: %w", scan1Name, err)
+	}
+
+	results2, err := f.GetCheckResultsForScan(namespace, scan2Name)
+	if err != nil {
+		return fmt.Errorf("failed to get check results for scan %s: %w", scan2Name, err)
+	}
+
+	// Check if the number of results matches
+	if len(results1) != len(results2) {
+		return fmt.Errorf("check result count mismatch: %s has %d checks, %s has %d checks",
+			scan1Name, len(results1), scan2Name, len(results2))
+	}
+
+	// Compare each rule's status
+	var mismatches []string
+	for ruleName, status1 := range results1 {
+		status2, exists := results2[ruleName]
+		if !exists {
+			mismatches = append(mismatches, fmt.Sprintf("rule %s exists in %s but not in %s", ruleName, scan1Name, scan2Name))
+			continue
+		}
+		if status1 != status2 {
+			mismatches = append(mismatches, fmt.Sprintf("rule %s: %s=%s, %s=%s",
+				ruleName, scan1Name, status1, scan2Name, status2))
+		}
+	}
+
+	// Check for rules that exist in results2 but not in results1
+	for ruleName := range results2 {
+		if _, exists := results1[ruleName]; !exists {
+			mismatches = append(mismatches, fmt.Sprintf("rule %s exists in %s but not in %s", ruleName, scan2Name, scan1Name))
+		}
+	}
+
+	if len(mismatches) > 0 {
+		t.Logf("Found %d check result mismatches between %s and %s:", len(mismatches), scan1Name, scan2Name)
+		for _, mismatch := range mismatches {
+			t.Logf("  - %s", mismatch)
+		}
+		return fmt.Errorf("found %d check result mismatches", len(mismatches))
+	}
+
+	t.Logf("All %d check results match between %s and %s", len(results1), scan1Name, scan2Name)
+	return nil
+}

--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -5523,3 +5523,186 @@ func TestScanWithCustomStorageClass(t *testing.T) {
 
 	t.Logf("Successfully verified scan %s has custom storage configuration", scanName)
 }
+
+// TestCISProfileVersionConsistency verifies that versioned (e.g., ocp4-cis-1-7) and
+// non-versioned (e.g., ocp4-cis) CIS profiles produce identical compliance scan results.
+func TestCISProfileVersionConsistency(t *testing.T) {
+	t.Parallel()
+	f := framework.Global
+
+	t.Log("Testing CIS profile version consistency between ocp4-cis and ocp4-cis-1-7")
+
+	// Profile configurations for the test
+	type profileSet struct {
+		name            string
+		platformProfile string
+		nodeProfile     string
+	}
+
+	baseProfiles := profileSet{
+		name:            "base",
+		platformProfile: "ocp4-cis",
+		nodeProfile:     "ocp4-cis-node",
+	}
+
+	versionedProfiles := profileSet{
+		name:            "versioned",
+		platformProfile: "ocp4-cis-1-7",
+		nodeProfile:     "ocp4-cis-node-1-7",
+	}
+
+	// Helper to create ScanSettingBinding
+	createBinding := func(profiles profileSet) (*compv1alpha1.ScanSettingBinding, error) {
+		bindingName := framework.GetObjNameFromTest(t) + "-" + profiles.name
+		binding := &compv1alpha1.ScanSettingBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      bindingName,
+				Namespace: f.OperatorNamespace,
+			},
+			Profiles: []compv1alpha1.NamedObjectReference{
+				{
+					Name:     profiles.platformProfile,
+					Kind:     "Profile",
+					APIGroup: "compliance.openshift.io/v1alpha1",
+				},
+				{
+					Name:     profiles.nodeProfile,
+					Kind:     "Profile",
+					APIGroup: "compliance.openshift.io/v1alpha1",
+				},
+			},
+		}
+
+		if err := f.Client.Create(context.TODO(), binding, nil); err != nil {
+			return nil, fmt.Errorf("failed to create %s ScanSettingBinding: %w", profiles.name, err)
+		}
+		t.Logf("Created ScanSettingBinding %s with profiles: %s, %s",
+			bindingName, profiles.platformProfile, profiles.nodeProfile)
+		return binding, nil
+	}
+
+	// Helper to wait for suite completion with DONE phase
+	waitForSuiteCompletion := func(suiteName, description string) error {
+		t.Logf("Waiting for %s ComplianceSuite to complete...", description)
+
+		// Try NON-COMPLIANT first
+		err := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant)
+		if err != nil {
+			// If not NON-COMPLIANT, try INCONSISTENT
+			errInconsistent := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultInconsistent)
+			if errInconsistent != nil {
+				return fmt.Errorf("%s suite not in expected state (tried NON-COMPLIANT and INCONSISTENT): %w", description, err)
+			}
+		}
+		t.Logf("%s ComplianceSuite completed", description)
+		return nil
+	}
+
+	// Helper to match scans by node role (master/worker) or platform type
+	findMatchingScan := func(scanName string, scanCounts map[string]int) (string, int, bool) {
+		isMaster := strings.Contains(scanName, "master")
+		isWorker := strings.Contains(scanName, "worker")
+		isPlatform := !isMaster && !isWorker
+
+		for candidateName, count := range scanCounts {
+			candidateIsMaster := strings.Contains(candidateName, "master")
+			candidateIsWorker := strings.Contains(candidateName, "worker")
+			candidateIsPlatform := !candidateIsMaster && !candidateIsWorker
+
+			// Match by role: master with master, worker with worker, platform with platform
+			if (isMaster && candidateIsMaster) ||
+				(isWorker && candidateIsWorker) ||
+				(isPlatform && candidateIsPlatform) {
+				return candidateName, count, true
+			}
+		}
+		return "", 0, false
+	}
+
+	// Create bindings for both profile sets
+	baseBinding, err := createBinding(baseProfiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Client.Delete(context.TODO(), baseBinding)
+
+	versionedBinding, err := createBinding(versionedProfiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Client.Delete(context.TODO(), versionedBinding)
+
+	// Wait for both suites to complete
+	if err := waitForSuiteCompletion(baseBinding.Name, "base"); err != nil {
+		t.Fatal(err)
+	}
+	if err := waitForSuiteCompletion(versionedBinding.Name, "versioned"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fetch completed suites
+	baseSuite := &compv1alpha1.ComplianceSuite{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{
+		Namespace: f.OperatorNamespace,
+		Name:      baseBinding.Name,
+	}, baseSuite); err != nil {
+		t.Fatalf("failed to retrieve base ComplianceSuite: %s", err)
+	}
+
+	versionedSuite := &compv1alpha1.ComplianceSuite{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{
+		Namespace: f.OperatorNamespace,
+		Name:      versionedBinding.Name,
+	}, versionedSuite); err != nil {
+		t.Fatalf("failed to retrieve versioned ComplianceSuite: %s", err)
+	}
+
+	t.Logf("Base suite status: phase=%s, result=%s", baseSuite.Status.Phase, baseSuite.Status.Result)
+	t.Logf("Versioned suite status: phase=%s, result=%s", versionedSuite.Status.Phase, versionedSuite.Status.Result)
+
+	// Collect and compare scan counts
+	t.Log("Collecting check counts from all scans...")
+	baseCounts, err := f.CollectScanCounts(t, baseSuite, "base")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	versionedCounts, err := f.CollectScanCounts(t, versionedSuite, "versioned")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compare scans and their results
+	t.Log("Comparing scan results between base and versioned profiles...")
+	matchedPairs := 0
+
+	for versionedScanName, versionedCount := range versionedCounts {
+		baseScanName, baseCount, found := findMatchingScan(versionedScanName, baseCounts)
+
+		if !found {
+			t.Errorf("No matching base scan found for versioned scan: %s", versionedScanName)
+			continue
+		}
+
+		// Verify rule counts match
+		if versionedCount != baseCount {
+			t.Fatalf("Rule count mismatch: %s has %d rules, %s has %d rules",
+				versionedScanName, versionedCount, baseScanName, baseCount)
+		}
+		t.Logf("✓ Rule counts match for %s ↔ %s: %d rules",
+			versionedScanName, baseScanName, versionedCount)
+
+		// Verify check results match
+		if err := f.CompareCheckResults(t, f.OperatorNamespace, versionedScanName, baseScanName); err != nil {
+			t.Fatalf("Check results differ between %s and %s: %s",
+				versionedScanName, baseScanName, err)
+		}
+		t.Logf("✓ All check results match for %s ↔ %s", versionedScanName, baseScanName)
+
+		matchedPairs++
+	}
+
+	// Summary
+	t.Logf("Successfully verified %d scan pairs between base and versioned CIS profiles", matchedPairs)
+	t.Log("✓ CIS profile versions produce consistent results")
+}

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -2431,9 +2431,9 @@ func TestStrictNodeScanConfiguration(t *testing.T) {
 	defer f.Client.Delete(context.TODO(), &scanSettingBinding)
 
 	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, bindingName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant); err != nil {
-		t.Fatal(err) 
+		t.Fatal(err)
 	}
-    
+
 	if err := f.Client.Delete(context.TODO(), &scanSettingBinding); err != nil {
 		t.Fatal(err)
 	}
@@ -2451,7 +2451,7 @@ func TestStrictNodeScanConfiguration(t *testing.T) {
 	if err := f.Client.Update(context.TODO(), scanSettingUpdate); err != nil {
 		t.Fatalf("failed to update ScanSetting: %s", err)
 	}
-	
+
 	// Clear metadata to ensure clean recreation of the ssb
 	scanSettingBinding.ObjectMeta = metav1.ObjectMeta{
 		Name:      bindingName,
@@ -2487,5 +2487,5 @@ func TestStrictNodeScanConfiguration(t *testing.T) {
 			t.Fatalf("suite left PENDING state (expected to remain PENDING for 30s): phase=%s", suite.Status.Phase)
 		}
 		time.Sleep(framework.RetryInterval)
-}
+	}
 }


### PR DESCRIPTION
…ioned profiles

1. Add testing for CIS profile version consistency between base and versioned profiles.
2. Check the rule annoations in the scan, add check the numbers match between base and versions profiles.
3. Check the test result is the same for base and versioned profiles.

```
=== NAME  TestCISProfileVersionConsistency
    main_test.go:5375: versioned ComplianceSuite completed
    main_test.go:5438: Base suite status: phase=DONE, result=NON-COMPLIANT
    main_test.go:5439: Versioned suite status: phase=DONE, result=NON-COMPLIANT
    main_test.go:5442: Collecting check counts from all scans...
    common.go:2978: base scan ocp4-cis: 91 rules
    common.go:2978: base scan ocp4-cis-node-master: 94 rules
    common.go:2978: base scan ocp4-cis-node-worker: 57 rules
    common.go:2978: versioned scan ocp4-cis-1-7: 91 rules
    common.go:2978: versioned scan ocp4-cis-node-1-7-master: 94 rules
    common.go:2978: versioned scan ocp4-cis-node-1-7-worker: 57 rules
    main_test.go:5454: Comparing scan results between base and versioned profiles...
    main_test.go:5470: ✓ Rule counts match for ocp4-cis-node-1-7-master ↔ ocp4-cis-node-master: 94 rules
    common.go:3053: All 94 check results match between ocp4-cis-node-1-7-master and ocp4-cis-node-master
    main_test.go:5478: ✓ All check results match for ocp4-cis-node-1-7-master ↔ ocp4-cis-node-master
    main_test.go:5470: ✓ Rule counts match for ocp4-cis-node-1-7-worker ↔ ocp4-cis-node-worker: 57 rules
    common.go:3053: All 57 check results match between ocp4-cis-node-1-7-worker and ocp4-cis-node-worker
    main_test.go:5478: ✓ All check results match for ocp4-cis-node-1-7-worker ↔ ocp4-cis-node-worker
    main_test.go:5470: ✓ Rule counts match for ocp4-cis-1-7 ↔ ocp4-cis: 91 rules
2026/01/21 09:57:07 re-scan hasn't taken place. CurrentIndex 0. Waiting for re-scan
    common.go:3053: All 91 check results match between ocp4-cis-1-7 and ocp4-cis
    main_test.go:5478: ✓ All check results match for ocp4-cis-1-7 ↔ ocp4-cis
    main_test.go:5484: Successfully verified 3 scan pairs between base and versioned CIS profiles
    main_test.go:5485: ✓ CIS profile versions produce consistent results
--- PASS: TestCISProfileVersionConsistency (116.77s)
```