### PR TITLE
CMP-4068: Fix TestKubeletConfigRemediation unstable issue

### DIFF
--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -968,6 +968,90 @@ func (f *Framework) restoreNodeLabelsForPool(n string) error {
 	return nil
 }
 
+// WaitForMachineConfigPoolUpdated waits for a MachineConfigPool to complete an update cycle.
+// It first waits for the Updated condition to become False (indicating update/reboot started),
+// then waits for it to become True again (indicating update/reboot completed).
+func (f *Framework) WaitForMachineConfigPoolUpdated(poolName string) error {
+	if f.Platform == "rosa" {
+		log.Printf("Bypassing MachineConfigPool update check on %s", f.Platform)
+		return nil
+	}
+
+	// First, get the initial state
+	pool := mcfgv1.MachineConfigPool{}
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: poolName}, &pool)
+	if err != nil {
+		return fmt.Errorf("failed to find Machine Config Pool %s: %w", poolName, err)
+	}
+
+	// Check initial state of MachineConfigPoolUpdated condition
+	initialUpdated := false
+	for _, c := range pool.Status.Conditions {
+		if c.Type == mcfgv1.MachineConfigPoolUpdated {
+			initialUpdated = (c.Status == core.ConditionTrue)
+			break
+		}
+	}
+
+	// If the pool is already updated (True), wait for it to start updating (False)
+	if initialUpdated {
+		log.Printf("Machine Config Pool %s is currently updated. Waiting for update to start...\n", poolName)
+		err = wait.PollImmediate(machineOperationRetryInterval, machineOperationTimeout, func() (bool, error) {
+			pool := mcfgv1.MachineConfigPool{}
+			err := f.Client.Get(context.TODO(), types.NamespacedName{Name: poolName}, &pool)
+			if err != nil {
+				log.Printf("failed to find Machine Config Pool %s\n", poolName)
+				return false, err
+			}
+
+			for _, c := range pool.Status.Conditions {
+				if c.Type == mcfgv1.MachineConfigPoolUpdated {
+					if c.Status == core.ConditionFalse {
+						log.Printf("Machine Config Pool %s update started (Updated=False)\n", poolName)
+						return true, nil
+					}
+					break
+				}
+			}
+
+			log.Printf("Machine Config Pool %s still updated, waiting for update to start...\n", poolName)
+			return false, nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed waiting for Machine Config Pool %s to start updating: %w", poolName, err)
+		}
+	} else {
+		log.Printf("Machine Config Pool %s is already updating (Updated=False). Waiting for update to complete...\n", poolName)
+	}
+
+	// Now wait for the update to complete (Updated=True)
+	err = wait.PollImmediate(machineOperationRetryInterval, machineOperationTimeout, func() (bool, error) {
+		pool := mcfgv1.MachineConfigPool{}
+		err := f.Client.Get(context.TODO(), types.NamespacedName{Name: poolName}, &pool)
+		if err != nil {
+			log.Printf("failed to find Machine Config Pool %s\n", poolName)
+			return false, err
+		}
+
+		for _, c := range pool.Status.Conditions {
+			if c.Type == mcfgv1.MachineConfigPoolUpdated {
+				if c.Status == core.ConditionTrue {
+					return true, nil
+				}
+				log.Printf("Machine Config Pool %s has not finished updating yet (Updated=%s)... retrying\n", poolName, c.Status)
+				return false, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed waiting for Machine Config Pool %s to be updated: %w", poolName, err)
+	}
+
+	log.Printf("Machine Config Pool %s is updated\n", poolName)
+	return nil
+}
+
 func (f *Framework) getNodesForPool(p *mcfgv1.MachineConfigPool) (core.NodeList, error) {
 	var nodeList core.NodeList
 	opts := &dynclient.ListOptions{

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -973,6 +973,90 @@ func (f *Framework) restoreNodeLabelsForPool(n string) error {
 	return nil
 }
 
+// WaitForMachineConfigPoolUpdated waits for a MachineConfigPool to complete an update cycle.
+// It first waits for the Updated condition to become False (indicating update/reboot started),
+// then waits for it to become True again (indicating update/reboot completed).
+func (f *Framework) WaitForMachineConfigPoolUpdated(poolName string) error {
+	if f.Platform == "rosa" {
+		log.Printf("Bypassing MachineConfigPool update check on %s", f.Platform)
+		return nil
+	}
+
+	// First, get the initial state
+	pool := mcfgv1.MachineConfigPool{}
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: poolName}, &pool)
+	if err != nil {
+		return fmt.Errorf("failed to find Machine Config Pool %s: %w", poolName, err)
+	}
+
+	// Check initial state of MachineConfigPoolUpdated condition
+	initialUpdated := false
+	for _, c := range pool.Status.Conditions {
+		if c.Type == mcfgv1.MachineConfigPoolUpdated {
+			initialUpdated = (c.Status == core.ConditionTrue)
+			break
+		}
+	}
+
+	// If the pool is already updated (True), wait for it to start updating (False)
+	if initialUpdated {
+		log.Printf("Machine Config Pool %s is currently updated. Waiting for update to start...\n", poolName)
+		err = wait.PollImmediate(machineOperationRetryInterval, machineOperationTimeout, func() (bool, error) {
+			pool := mcfgv1.MachineConfigPool{}
+			err := f.Client.Get(context.TODO(), types.NamespacedName{Name: poolName}, &pool)
+			if err != nil {
+				log.Printf("failed to find Machine Config Pool %s\n", poolName)
+				return false, err
+			}
+
+			for _, c := range pool.Status.Conditions {
+				if c.Type == mcfgv1.MachineConfigPoolUpdated {
+					if c.Status == core.ConditionFalse {
+						log.Printf("Machine Config Pool %s update started (Updated=False)\n", poolName)
+						return true, nil
+					}
+					break
+				}
+			}
+
+			log.Printf("Machine Config Pool %s still updated, waiting for update to start...\n", poolName)
+			return false, nil
+		})
+		if err != nil {
+			return fmt.Errorf("failed waiting for Machine Config Pool %s to start updating: %w", poolName, err)
+		}
+	} else {
+		log.Printf("Machine Config Pool %s is already updating (Updated=False). Waiting for update to complete...\n", poolName)
+	}
+
+	// Now wait for the update to complete (Updated=True)
+	err = wait.PollImmediate(machineOperationRetryInterval, machineOperationTimeout, func() (bool, error) {
+		pool := mcfgv1.MachineConfigPool{}
+		err := f.Client.Get(context.TODO(), types.NamespacedName{Name: poolName}, &pool)
+		if err != nil {
+			log.Printf("failed to find Machine Config Pool %s\n", poolName)
+			return false, err
+		}
+
+		for _, c := range pool.Status.Conditions {
+			if c.Type == mcfgv1.MachineConfigPoolUpdated {
+				if c.Status == core.ConditionTrue {
+					return true, nil
+				}
+				log.Printf("Machine Config Pool %s has not finished updating yet (Updated=%s)... retrying\n", poolName, c.Status)
+				return false, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed waiting for Machine Config Pool %s to be updated: %w", poolName, err)
+	}
+
+	log.Printf("Machine Config Pool %s is updated\n", poolName)
+	return nil
+}
+
 func (f *Framework) getNodesForPool(p *mcfgv1.MachineConfigPool) (core.NodeList, error) {
 	var nodeList core.NodeList
 	opts := &dynclient.ListOptions{

--- a/tests/e2e/framework/main_entry.go
+++ b/tests/e2e/framework/main_entry.go
@@ -175,6 +175,11 @@ func (f *Framework) TearDown() error {
 		if err != nil {
 			return err
 		}
+		// Wait for worker pool to be updated after nodes are unlabeled
+		err = f.WaitForMachineConfigPoolUpdated(workerPoolName)
+		if err != nil {
+			return err
+		}
 		err = f.cleanUpMachineConfigPool("e2e")
 		if err != nil {
 			return err

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -1656,6 +1656,9 @@ func TestKubeletConfigRemediation(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      suiteName,
 			Namespace: f.OperatorNamespace,
+			Annotations: map[string]string{
+				compv1alpha1.ProductTypeAnnotation: "Node",
+			},
 		},
 		Spec: compv1alpha1.TailoredProfileSpec{
 			Title:       "kubelet-remediation-test-node",
@@ -1708,7 +1711,17 @@ func TestKubeletConfigRemediation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Client.Delete(context.TODO(), ssb)
+	// Cleanup: Delete ScanSettingBinding first, then wait for ComplianceSuite to be cascade-deleted
+	// This ensures proper cleanup before the next test runs
+	defer func() {
+		if err := f.Client.Delete(context.TODO(), ssb); err != nil {
+			t.Fatal(err)
+			return
+		}
+		if err := f.WaitForComplianceSuiteDeletion(suiteName, f.OperatorNamespace); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	// Ensure that all the scans in the suite have finished and are marked as Done
 	err = f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant)
@@ -1726,6 +1739,21 @@ func TestKubeletConfigRemediation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Cleanup: Unapply the remediation before test ends to prevent leaving nodes in a modified state
+	// This ensures the cluster is reset after the test completes
+	defer func() {
+		// Finally clean up by removing the remediation and waiting for the nodes to reboot one more time
+		err = f.UnApplyRemediationAndCheck(f.OperatorNamespace, remName, "worker")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = f.WaitForNodesToBeReady()
+		if err != nil {
+			t.Fatalf("failed waiting for nodes to reboot after unapplying MachineConfig: %s", err)
+		}
+	}()
 
 	err = f.ReRunScan(scanName, f.OperatorNamespace)
 	if err != nil {

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -1660,6 +1660,9 @@ func TestKubeletConfigRemediation(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      suiteName,
 			Namespace: f.OperatorNamespace,
+			Annotations: map[string]string{
+				compv1alpha1.ProductTypeAnnotation: "Node",
+			},
 		},
 		Spec: compv1alpha1.TailoredProfileSpec{
 			Title:       "kubelet-remediation-test-node",
@@ -1712,7 +1715,17 @@ func TestKubeletConfigRemediation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Client.Delete(context.TODO(), ssb)
+	// Cleanup: Delete ScanSettingBinding first, then wait for ComplianceSuite to be cascade-deleted
+	// This ensures proper cleanup before the next test runs
+	defer func() {
+		if err := f.Client.Delete(context.TODO(), ssb); err != nil {
+			t.Fatal(err)
+			return
+		}
+		if err := f.WaitForComplianceSuiteDeletion(suiteName, f.OperatorNamespace); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	// Ensure that all the scans in the suite have finished and are marked as Done
 	err = f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant)
@@ -1730,6 +1743,21 @@ func TestKubeletConfigRemediation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Cleanup: Unapply the remediation before test ends to prevent leaving nodes in a modified state
+	// This ensures the cluster is reset after the test completes
+	defer func() {
+		// Finally clean up by removing the remediation and waiting for the nodes to reboot one more time
+		err = f.UnApplyRemediationAndCheck(f.OperatorNamespace, remName, "worker")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = f.WaitForNodesToBeReady()
+		if err != nil {
+			t.Fatalf("failed waiting for nodes to reboot after unapplying MachineConfig: %s", err)
+		}
+	}()
 
 	err = f.ReRunScan(scanName, f.OperatorNamespace)
 	if err != nil {


### PR DESCRIPTION
Note: 
As disscussed on Friday with the dev team and today with Xiaojie, we do not need the specific image the test case was using because we now ship these rules as part of the ocp4 profile bundle. Also, based on Xiaojie's suggestion I have replaced the overly complicated defer logic for unapplying the remediation with an implementation of already existing functions. Thanks for the feedback!

Changes in this PR: 

1. Add cleanup to test case TestKubeletConfigRemediation - the test case itself is not failing much in our serial job run, but the subsequent test, TestSuspendScanSetting, is failing quite often. I think the root cause lies in TestKubeletConfigRemediation, that applied remediation and did not unapply it as well as it did not wait for the scan and suite to be deleted. 

To fix that, I have added func WaitForComplianceSuiteDeletion() to common.go and make minor modification in the test itself. 

I hope this works, TestKubeletConfigRemediation is problematic, Xiaojie is trying a different approach in PR #1055  and in some of the PRs any few of my local tries, the test case fails on the result of the suite being NOT-APPLICABLE, which is a whole different story. 

2. When running test case in my local cluster, often after PASSing runs my environment ended up with one worker node degraded. This is apparently caused by removing the `e2e` label from the worker node and immediately deleting the `e2e` machineconfigpool before the node fully reboots as part of worker node pool. I have added a func WaitForMachineConfigPoolUpdated() into common.go and call for this function into the main_entry.go file to the teardown phase. 
This is not important for our CI runs, but it greatly improves quality of my experience when I run these tests locally and saves my sanity. 

At least I did not harm to the TestKubeletConfigRemediation: 
```
2026/02/06 15:55:25 All scans in ComplianceSuite have finished (kubelet-remediation-test-suite-node)
2026/02/06 15:55:25 scan re-run has finished
--- PASS: TestKubeletConfigRemediation (373.79s)
PASS
...
ok  	github.com/ComplianceAsCode/compliance-operator/tests/e2e/serial	658.249s
```