### PR TITLE
 CMP-3847: Added TestOperatorResourceLimitsConfigurable tests operator's resource limits and requests can be configured via patching the deployment

### DIFF
--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -2765,126 +2765,6 @@ func TestOperatorResourceLimitsConfigurable(t *testing.T) {
 	t.Log("Successfully verified operator resource limits are configurable")
 }
 
-func TestRuntimeSSHConfigWithRemediation(t *testing.T) {
-	f := framework.Global
-
-	baselineImage := fmt.Sprintf("%s:%s", brokenContentImagePath, "runtime_sshd")
-	pbName := framework.GetObjNameFromTest(t)
-
-	rhcos4Pb, err := f.CreateProfileBundle(pbName, baselineImage, framework.RhcosContentFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer f.Client.Delete(context.TODO(), rhcos4Pb)
-	if err := f.WaitForProfileBundleStatus(pbName, compv1alpha1.DataStreamValid); err != nil {
-		t.Fatal(err)
-	}
-
-	// This test applies an SSH remediation and verifies runtime checks still work
-	suiteName := "test-runtime-ssh-remediation"
-	scanName := fmt.Sprintf("%s-scan", suiteName)
-
-	suite := &compv1alpha1.ComplianceSuite{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      suiteName,
-			Namespace: f.OperatorNamespace,
-		},
-		Spec: compv1alpha1.ComplianceSuiteSpec{
-			ComplianceSuiteSettings: compv1alpha1.ComplianceSuiteSettings{
-				AutoApplyRemediations: true,
-			},
-			Scans: []compv1alpha1.ComplianceScanSpecWrapper{
-				{
-					ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
-						ContentImage: baselineImage,
-						Profile:      "xccdf_org.ssgproject.content_profile_e8",
-						Rule:         "xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth",
-						Content:      framework.RhcosContentFile,
-						NodeSelector: framework.GetPoolNodeRoleSelector(),
-						ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
-							Debug: true,
-						},
-					},
-					Name: scanName,
-				},
-			},
-		},
-	}
-
-	if err := f.Client.Create(context.TODO(), suite, nil); err != nil {
-		t.Fatalf("failed to create ComplianceSuite: %s", err)
-	}
-	defer f.Client.Delete(context.TODO(), suite)
-
-	// Get the MachineConfigPool before remediation
-	poolBeforeRemediation := &mcfgv1.MachineConfigPool{}
-	if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: framework.TestPoolName}, poolBeforeRemediation); err != nil {
-		t.Fatal(err)
-	}
-
-	// Wait for initial scan to complete - it should be non-compliant
-	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant); err != nil {
-		// Might already be compliant if previously remediated
-		if err2 := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultCompliant); err2 != nil {
-			t.Fatalf("initial scan did not complete: %v", err)
-		}
-		t.Log("System already compliant, skipping remediation test")
-		return
-	}
-
-	// Check that remediation was auto-applied
-	remName := fmt.Sprintf("%s-sshd-disable-gssapi-auth", scanName)
-	if err := f.WaitForRemediationToBeAutoApplied(remName, f.OperatorNamespace, poolBeforeRemediation); err != nil {
-		t.Logf("Remediation might not be needed or already applied: %v", err)
-	}
-
-	// Re-run the scan to verify compliance with runtime checking
-	if err := f.ReRunScan(scanName, f.OperatorNamespace); err != nil {
-		t.Fatal(err)
-	}
-
-	// Wait for re-scan to complete - should be compliant now
-	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultCompliant); err != nil {
-		t.Logf("WARNING: Re-scan was not compliant after remediation: %v", err)
-	}
-
-	// Verify the runtime config was still created and used in the re-scan
-	t.Log("Verifying runtime SSH config was used in re-scan after remediation")
-
-	// Get the check result for the SSH rule
-	checkName := fmt.Sprintf("%s-sshd-disable-gssapi-auth", scanName)
-	check := &compv1alpha1.ComplianceCheckResult{}
-	if err := f.Client.Get(context.TODO(), types.NamespacedName{
-		Name:      checkName,
-		Namespace: f.OperatorNamespace,
-	}, check); err != nil {
-		t.Logf("Could not get check result %s: %v", checkName, err)
-	} else {
-		t.Logf("SSH check after remediation - Status: %s", check.Status)
-		if check.Status == compv1alpha1.CheckResultPass {
-			t.Log("SUCCESS: SSH configuration check passed after remediation (runtime config verified)")
-		}
-	}
-
-	// Clean up the remediation if it was applied
-	rem := &compv1alpha1.ComplianceRemediation{}
-	if err := f.Client.Get(context.TODO(), types.NamespacedName{
-		Name:      remName,
-		Namespace: f.OperatorNamespace,
-	}, rem); err == nil {
-		// Unapply the remediation
-		if err := f.UnApplyRemediationAndCheck(f.OperatorNamespace, remName, framework.TestPoolName); err != nil {
-			t.Logf("Could not unapply remediation: %v", err)
-		}
-
-		// Wait for nodes to be ready again
-		if err := f.WaitForNodesToBeReady(); err != nil {
-			t.Logf("Nodes did not become ready after remediation removal: %v", err)
-		}
-	}
-
-	t.Log("Runtime SSH configuration with remediation test completed")
-}
 func TestMustGatherImageWorksAsExpected(t *testing.T) {
 	f := framework.Global
 
@@ -3348,7 +3228,7 @@ func searchCRDDirectories(crdNames []string, complianceNamespaceDir, timestampDi
 //							NodeSelector: workerNodesLabel,
 //							ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 //								Debug: true,
-//							},
+//			},
 //						},
 //						Name: scanName,
 //					},

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -2490,6 +2490,19 @@ func TestOperatorResourceLimitsConfigurable(t *testing.T) {
 		}
 	}`)
 
+	// Get the current pod UID before patching to detect when a new pod is created
+	podList := &corev1.PodList{}
+	err = f.Client.List(context.TODO(), podList,
+		client.InNamespace(f.OperatorNamespace),
+		client.MatchingLabels(map[string]string{"name": "compliance-operator"}))
+	if err != nil {
+		t.Fatalf("failed to list operator pods before patch: %s", err)
+	}
+	if len(podList.Items) == 0 {
+		t.Fatal("no compliance-operator pods found before patch")
+	}
+	oldPodUID := podList.Items[0].UID
+
 	// Apply the patch
 	err = f.Client.Patch(context.TODO(), deployment, client.RawPatch(types.StrategicMergePatchType, patchData))
 	if err != nil {
@@ -2541,32 +2554,55 @@ func TestOperatorResourceLimitsConfigurable(t *testing.T) {
 		}
 	}()
 
-	// Wait for the deployment to rollout with new pod
-	err = f.WaitForDeployment(deploymentName, 1, framework.RetryInterval, framework.Timeout)
+	// Wait for a new pod to be created with the updated resource limits
+	// We poll until we find a pod with a different UID (new pod) that has the expected resources
+	t.Log("Waiting for new pod with updated resource limits")
+	var newPod *corev1.Pod
+	err = wait.Poll(framework.RetryInterval, framework.Timeout, func() (bool, error) {
+		podList := &corev1.PodList{}
+		listErr := f.Client.List(context.TODO(), podList,
+			client.InNamespace(f.OperatorNamespace),
+			client.MatchingLabels(map[string]string{"name": "compliance-operator"}))
+		if listErr != nil {
+			log.Printf("failed to list operator pods: %s, retrying...", listErr)
+			return false, nil
+		}
+
+		if len(podList.Items) == 0 {
+			log.Printf("no compliance-operator pods found yet, waiting...")
+			return false, nil
+		}
+
+		pod := &podList.Items[0]
+
+		// Check if this is a new pod (different UID)
+		if pod.UID == oldPodUID {
+			log.Printf("old pod still exists (UID: %s), waiting for new pod...", oldPodUID)
+			return false, nil
+		}
+
+		// Check if the new pod is running
+		if pod.Status.Phase != corev1.PodRunning {
+			log.Printf("new pod exists but not running yet (phase: %s), waiting...", pod.Status.Phase)
+			return false, nil
+		}
+
+		// Found a new running pod
+		newPod = pod
+		log.Printf("new pod found with UID: %s, phase: %s", pod.UID, pod.Status.Phase)
+		return true, nil
+	})
 	if err != nil {
-		t.Fatalf("deployment did not become ready after patch: %s", err)
+		t.Fatalf("timed out waiting for new pod with updated resources: %s", err)
 	}
 
-	// Get the new pod and verify it has the updated resource limits
+	// Verify the new pod has the updated resource limits
 	t.Log("Verifying new resource limits on operator pod")
-	podList := &corev1.PodList{}
-	err = f.Client.List(context.TODO(), podList,
-		client.InNamespace(f.OperatorNamespace),
-		client.MatchingLabels(map[string]string{"name": "compliance-operator"}))
-	if err != nil {
-		t.Fatalf("failed to list operator pods: %s", err)
+	if len(newPod.Spec.Containers) == 0 {
+		t.Fatal("no containers found in new pod")
 	}
 
-	if len(podList.Items) == 0 {
-		t.Fatal("no compliance-operator pods found")
-	}
-
-	pod := podList.Items[0]
-	if len(pod.Spec.Containers) == 0 {
-		t.Fatal("no containers found in pod")
-	}
-
-	podContainer := pod.Spec.Containers[0]
+	podContainer := newPod.Spec.Containers[0]
 	newCPULimit := podContainer.Resources.Limits.Cpu().String()
 	newMemLimit := podContainer.Resources.Limits.Memory().String()
 	newCPURequest := podContainer.Resources.Requests.Cpu().String()

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -2418,6 +2418,134 @@ func TestScanTailoredProfileExtendsDeprecated(t *testing.T) {
 	}
 }
 
+func TestRuntimeSSHConfigWithRemediation(t *testing.T) {
+	f := framework.Global
+
+	baselineImage := fmt.Sprintf("%s:%s", brokenContentImagePath, "runtime_sshd")
+	pbName := framework.GetObjNameFromTest(t)
+
+	rhcos4Pb, err := f.CreateProfileBundle(pbName, baselineImage, framework.RhcosContentFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Client.Delete(context.TODO(), rhcos4Pb)
+	if err := f.WaitForProfileBundleStatus(pbName, compv1alpha1.DataStreamValid); err != nil {
+		t.Fatal(err)
+	}
+
+	// This test applies an SSH remediation and verifies runtime checks still work
+	suiteName := "test-runtime-ssh-remediation"
+	scanName := fmt.Sprintf("%s-scan", suiteName)
+
+	suite := &compv1alpha1.ComplianceSuite{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      suiteName,
+			Namespace: f.OperatorNamespace,
+		},
+		Spec: compv1alpha1.ComplianceSuiteSpec{
+			ComplianceSuiteSettings: compv1alpha1.ComplianceSuiteSettings{
+				AutoApplyRemediations: true,
+			},
+			Scans: []compv1alpha1.ComplianceScanSpecWrapper{
+				{
+					ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
+						ContentImage: baselineImage,
+						Profile:      "xccdf_org.ssgproject.content_profile_e8",
+						Rule:         "xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth",
+						Content:      framework.RhcosContentFile,
+						NodeSelector: framework.GetPoolNodeRoleSelector(),
+						ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+							Debug: true,
+						},
+					},
+					Name: scanName,
+				},
+			},
+		},
+	}
+
+	if err := f.Client.Create(context.TODO(), suite, nil); err != nil {
+		t.Fatalf("failed to create ComplianceSuite: %s", err)
+	}
+	defer f.Client.Delete(context.TODO(), suite)
+
+	// Get the MachineConfigPool before remediation
+	poolBeforeRemediation := &mcfgv1.MachineConfigPool{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: framework.TestPoolName}, poolBeforeRemediation); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for initial scan to complete - it should be non-compliant
+	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant); err != nil {
+		// Might already be compliant if previously remediated
+		if err2 := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultCompliant); err2 != nil {
+			t.Fatalf("initial scan did not complete: %v", err)
+		}
+		t.Log("System already compliant, skipping remediation test")
+		return
+	}
+
+	// Check that remediation was auto-applied
+	remName := fmt.Sprintf("%s-sshd-disable-gssapi-auth", scanName)
+	if err := f.WaitForRemediationToBeAutoApplied(remName, f.OperatorNamespace, poolBeforeRemediation); err != nil {
+		t.Logf("Remediation might not be needed or already applied: %v", err)
+	}
+
+	// Re-run the scan to verify compliance with runtime checking
+	if err := f.ReRunScan(scanName, f.OperatorNamespace); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for re-scan to complete - should be compliant now
+	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultCompliant); err != nil {
+		t.Logf("WARNING: Re-scan was not compliant after remediation: %v", err)
+	}
+
+	// Verify the runtime config was still created and used in the re-scan
+	t.Log("Verifying runtime SSH config was used in re-scan after remediation")
+
+	// Get the check result for the SSH rule
+	checkName := fmt.Sprintf("%s-sshd-disable-gssapi-auth", scanName)
+	check := &compv1alpha1.ComplianceCheckResult{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      checkName,
+		Namespace: f.OperatorNamespace,
+	}, check); err != nil {
+		t.Logf("Could not get check result %s: %v", checkName, err)
+	} else {
+		t.Logf("SSH check after remediation - Status: %s", check.Status)
+		if check.Status == compv1alpha1.CheckResultPass {
+			t.Log("SUCCESS: SSH configuration check passed after remediation (runtime config verified)")
+		}
+	}
+
+	// Clean up the remediation if it was applied
+	rem := &compv1alpha1.ComplianceRemediation{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      remName,
+		Namespace: f.OperatorNamespace,
+	}, rem); err == nil {
+		// Unapply the remediation
+		if err := f.UnApplyRemediationAndCheck(f.OperatorNamespace, remName, framework.TestPoolName); err != nil {
+			t.Logf("Could not unapply remediation: %v", err)
+		}
+
+		// Wait for nodes to be ready again
+		if err := f.WaitForNodesToBeReady(); err != nil {
+			t.Logf("Nodes did not become ready after remediation removal: %v", err)
+		}
+	}
+
+	t.Log("Runtime SSH configuration with remediation test completed")
+}
+
+const (
+	defaultOperatorCPULimit   = "200m"
+	defaultOperatorMemLimit   = "500Mi"
+	defaultOperatorCPURequest = "10m"
+	defaultOperatorMemRequest = "20Mi"
+)
+
 // TestOperatorResourceLimitsConfigurable tests that the compliance operator's
 // resource limits and requests can be configured via patching the deployment.
 func TestOperatorResourceLimitsConfigurable(t *testing.T) {
@@ -2451,17 +2579,17 @@ func TestOperatorResourceLimitsConfigurable(t *testing.T) {
 	defaultCPURequest := container.Resources.Requests.Cpu().String()
 	defaultMemRequest := container.Resources.Requests.Memory().String()
 
-	if defaultCPULimit != "200m" {
-		t.Errorf("expected default CPU limit 200m, got %s", defaultCPULimit)
+	if defaultCPULimit != defaultOperatorCPULimit {
+		t.Errorf("expected default CPU limit %s, got %s", defaultOperatorCPULimit, defaultCPULimit)
 	}
-	if defaultMemLimit != "500Mi" {
-		t.Errorf("expected default memory limit 500Mi, got %s", defaultMemLimit)
+	if defaultMemLimit != defaultOperatorMemLimit {
+		t.Errorf("expected default memory limit %s, got %s", defaultOperatorMemLimit, defaultMemLimit)
 	}
-	if defaultCPURequest != "10m" {
-		t.Errorf("expected default CPU request 10m, got %s", defaultCPURequest)
+	if defaultCPURequest != defaultOperatorCPURequest {
+		t.Errorf("expected default CPU request %s, got %s", defaultOperatorCPURequest, defaultCPURequest)
 	}
-	if defaultMemRequest != "20Mi" {
-		t.Errorf("expected default memory request 20Mi, got %s", defaultMemRequest)
+	if defaultMemRequest != defaultOperatorMemRequest {
+		t.Errorf("expected default memory request %s, got %s", defaultOperatorMemRequest, defaultMemRequest)
 	}
 
 	// Patch the deployment with new resource limits

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -2501,18 +2501,33 @@ func TestOperatorResourceLimitsConfigurable(t *testing.T) {
 	if len(podList.Items) == 0 {
 		t.Fatal("no compliance-operator pods found before patch")
 	}
-	oldPodUID := podList.Items[0].UID
 
-	// Apply the patch
+	var oldPodUID types.UID
+	foundRunning := false
+	for i := range podList.Items {
+		if podList.Items[i].Status.Phase == corev1.PodRunning {
+			oldPodUID = podList.Items[i].UID
+			foundRunning = true
+			break
+		}
+	}
+	if !foundRunning {
+		t.Fatal("no Running compliance-operator pod found before patch")
+	}
+
+	// Patch the Deployment directly. OLM does not continuously reconcile
+	// Deployment specs back to the CSV; it only does so on CSV updates or
+	// operator upgrades, so the patch persists for the duration of this test.
 	err = f.Client.Patch(context.TODO(), deployment, client.RawPatch(types.StrategicMergePatchType, patchData))
 	if err != nil {
 		t.Fatalf("failed to patch deployment: %s", err)
 	}
 
-	// Defer cleanup: restore original resource limits
+	// Defer cleanup: restore original resource limits using the values captured
+	// from the deployment before patching
 	defer func() {
 		t.Log("Restoring original resource limits")
-		restorePatch := []byte(`{
+		restorePatch := []byte(fmt.Sprintf(`{
 			"spec": {
 				"template": {
 					"spec": {
@@ -2520,19 +2535,19 @@ func TestOperatorResourceLimitsConfigurable(t *testing.T) {
 							"name": "compliance-operator",
 							"resources": {
 								"limits": {
-									"cpu": "200m",
-									"memory": "500Mi"
+									"cpu": "%s",
+									"memory": "%s"
 								},
 								"requests": {
-									"cpu": "10m",
-									"memory": "20Mi"
+									"cpu": "%s",
+									"memory": "%s"
 								}
 							}
 						}]
 					}
 				}
 			}
-		}`)
+		}`, defaultCPULimit, defaultMemLimit, defaultCPURequest, defaultMemRequest))
 
 		// Get fresh deployment object for restore
 		freshDeployment := &appsv1.Deployment{}
@@ -2573,24 +2588,22 @@ func TestOperatorResourceLimitsConfigurable(t *testing.T) {
 			return false, nil
 		}
 
-		pod := &podList.Items[0]
-
-		// Check if this is a new pod (different UID)
-		if pod.UID == oldPodUID {
-			log.Printf("old pod still exists (UID: %s), waiting for new pod...", oldPodUID)
-			return false, nil
+		for i := range podList.Items {
+			pod := &podList.Items[i]
+			if pod.UID == oldPodUID {
+				continue
+			}
+			if pod.Status.Phase != corev1.PodRunning {
+				log.Printf("new pod exists but not running yet (phase: %s), waiting...", pod.Status.Phase)
+				return false, nil
+			}
+			newPod = pod
+			log.Printf("new pod found with UID: %s, phase: %s", pod.UID, pod.Status.Phase)
+			return true, nil
 		}
 
-		// Check if the new pod is running
-		if pod.Status.Phase != corev1.PodRunning {
-			log.Printf("new pod exists but not running yet (phase: %s), waiting...", pod.Status.Phase)
-			return false, nil
-		}
-
-		// Found a new running pod
-		newPod = pod
-		log.Printf("new pod found with UID: %s, phase: %s", pod.UID, pod.Status.Phase)
-		return true, nil
+		log.Printf("no new pod found yet (old UID: %s), waiting...", oldPodUID)
+		return false, nil
 	})
 	if err != nil {
 		t.Fatalf("timed out waiting for new pod with updated resources: %s", err)
@@ -3207,7 +3220,7 @@ func searchCRDDirectories(crdNames []string, complianceNamespaceDir, timestampDi
 //							NodeSelector: workerNodesLabel,
 //							ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 //								Debug: true,
-//			},
+//							},
 //						},
 //						Name: scanName,
 //					},

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -14,6 +14,7 @@ import (
 	compsuitectrl "github.com/ComplianceAsCode/compliance-operator/pkg/controller/compliancesuite"
 	configv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -2417,6 +2418,176 @@ func TestScanTailoredProfileExtendsDeprecated(t *testing.T) {
 	}
 }
 
+// TestOperatorResourceLimitsConfigurable tests that the compliance operator's
+// resource limits and requests can be configured via patching the deployment.
+func TestOperatorResourceLimitsConfigurable(t *testing.T) {
+	f := framework.Global
+	deploymentName := "compliance-operator"
+
+	// Get the compliance-operator deployment
+	deployment := &appsv1.Deployment{}
+	err := f.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      deploymentName,
+		Namespace: f.OperatorNamespace,
+	}, deployment)
+	if err != nil {
+		t.Fatalf("failed to get compliance-operator deployment: %s", err)
+	}
+
+	// Verify default resource limits
+	t.Log("Verifying default resource limits for compliance-operator")
+	if len(deployment.Spec.Template.Spec.Containers) == 0 {
+		t.Fatal("no containers found in deployment")
+	}
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+	if container.Name != "compliance-operator" {
+		t.Fatalf("expected container name 'compliance-operator', got %s", container.Name)
+	}
+
+	// Check default limits
+	defaultCPULimit := container.Resources.Limits.Cpu().String()
+	defaultMemLimit := container.Resources.Limits.Memory().String()
+	defaultCPURequest := container.Resources.Requests.Cpu().String()
+	defaultMemRequest := container.Resources.Requests.Memory().String()
+
+	if defaultCPULimit != "200m" {
+		t.Errorf("expected default CPU limit 200m, got %s", defaultCPULimit)
+	}
+	if defaultMemLimit != "500Mi" {
+		t.Errorf("expected default memory limit 500Mi, got %s", defaultMemLimit)
+	}
+	if defaultCPURequest != "10m" {
+		t.Errorf("expected default CPU request 10m, got %s", defaultCPURequest)
+	}
+	if defaultMemRequest != "20Mi" {
+		t.Errorf("expected default memory request 20Mi, got %s", defaultMemRequest)
+	}
+
+	// Patch the deployment with new resource limits
+	t.Log("Patching deployment with new resource limits")
+
+	// Create a patch to update resource requirements
+	patchData := []byte(`{
+		"spec": {
+			"template": {
+				"spec": {
+					"containers": [{
+						"name": "compliance-operator",
+						"resources": {
+							"limits": {
+								"cpu": "256m",
+								"memory": "512Mi"
+							},
+							"requests": {
+								"cpu": "25m",
+								"memory": "52Mi"
+							}
+						}
+					}]
+				}
+			}
+		}
+	}`)
+
+	// Apply the patch
+	err = f.Client.Patch(context.TODO(), deployment, client.RawPatch(types.StrategicMergePatchType, patchData))
+	if err != nil {
+		t.Fatalf("failed to patch deployment: %s", err)
+	}
+
+	// Defer cleanup: restore original resource limits
+	defer func() {
+		t.Log("Restoring original resource limits")
+		restorePatch := []byte(`{
+			"spec": {
+				"template": {
+					"spec": {
+						"containers": [{
+							"name": "compliance-operator",
+							"resources": {
+								"limits": {
+									"cpu": "200m",
+									"memory": "500Mi"
+								},
+								"requests": {
+									"cpu": "10m",
+									"memory": "20Mi"
+								}
+							}
+						}]
+					}
+				}
+			}
+		}`)
+
+		// Get fresh deployment object for restore
+		freshDeployment := &appsv1.Deployment{}
+		if err := f.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      deploymentName,
+			Namespace: f.OperatorNamespace,
+		}, freshDeployment); err != nil {
+			t.Logf("failed to get deployment for restore: %s", err)
+			return
+		}
+
+		if err := f.Client.Patch(context.TODO(), freshDeployment, client.RawPatch(types.StrategicMergePatchType, restorePatch)); err != nil {
+			t.Logf("failed to restore original resource limits: %s", err)
+		}
+
+		// Wait for deployment to be ready with original limits
+		if err := f.WaitForDeployment(deploymentName, 1, framework.RetryInterval, framework.Timeout); err != nil {
+			t.Logf("deployment did not become ready after restore: %s", err)
+		}
+	}()
+
+	// Wait for the deployment to rollout with new pod
+	err = f.WaitForDeployment(deploymentName, 1, framework.RetryInterval, framework.Timeout)
+	if err != nil {
+		t.Fatalf("deployment did not become ready after patch: %s", err)
+	}
+
+	// Get the new pod and verify it has the updated resource limits
+	t.Log("Verifying new resource limits on operator pod")
+	podList := &corev1.PodList{}
+	err = f.Client.List(context.TODO(), podList,
+		client.InNamespace(f.OperatorNamespace),
+		client.MatchingLabels(map[string]string{"name": "compliance-operator"}))
+	if err != nil {
+		t.Fatalf("failed to list operator pods: %s", err)
+	}
+
+	if len(podList.Items) == 0 {
+		t.Fatal("no compliance-operator pods found")
+	}
+
+	pod := podList.Items[0]
+	if len(pod.Spec.Containers) == 0 {
+		t.Fatal("no containers found in pod")
+	}
+
+	podContainer := pod.Spec.Containers[0]
+	newCPULimit := podContainer.Resources.Limits.Cpu().String()
+	newMemLimit := podContainer.Resources.Limits.Memory().String()
+	newCPURequest := podContainer.Resources.Requests.Cpu().String()
+	newMemRequest := podContainer.Resources.Requests.Memory().String()
+
+	if newCPULimit != "256m" {
+		t.Errorf("expected new CPU limit 256m, got %s", newCPULimit)
+	}
+	if newMemLimit != "512Mi" {
+		t.Errorf("expected new memory limit 512Mi, got %s", newMemLimit)
+	}
+	if newCPURequest != "25m" {
+		t.Errorf("expected new CPU request 25m, got %s", newCPURequest)
+	}
+	if newMemRequest != "52Mi" {
+		t.Errorf("expected new memory request 52Mi, got %s", newMemRequest)
+	}
+
+	t.Log("Successfully verified operator resource limits are configurable")
+}
+
 func TestRuntimeSSHConfigWithRemediation(t *testing.T) {
 	f := framework.Global
 
@@ -3000,7 +3171,7 @@ func searchCRDDirectories(crdNames []string, complianceNamespaceDir, timestampDi
 //							NodeSelector: workerNodesLabel,
 //							ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 //								Debug: true,
-//							},
+//			},
 //						},
 //						Name: scanName,
 //					},


### PR DESCRIPTION
TestOperatorResourceLimitsConfigurable verifies that the Compliance Operator's CPU and memory resource limits can be dynamically configured by patching its Deployment object. This ensures that cluster administrators can tune the operator's resource consumption to meet their cluster's needs.

Can be executed: 
`make e2e-serial E2E_GO_TEST_FLAGS="-v -run TestOperatorResourceLimitsConfigurable"`

Expected Output:
```
=== RUN   TestOperatorResourceLimitsConfigurable
    main_test.go:2438: Verifying default resource limits for compliance-operator
    main_test.go:2468: Patching deployment with new resource limits
2026/06/23 12:25:03 Deployment available (1/1)
    main_test.go:2551: Verifying new resource limits on operator pod
    main_test.go:2588: Successfully verified operator resource limits are configurable
    main_test.go:2501: Restoring original resource limits
2026/06/23 12:25:08 Deployment available (1/1)
--- PASS: TestOperatorResourceLimitsConfigurable (10.79s)
PASS



```

Assisted by Claude.
