### PR TITLE
fix: typo in update event

### DIFF
--- a/pkg/controller/scansettingbinding/scansettingbinding_controller.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller.go
@@ -279,7 +279,7 @@ func (r *ReconcileScanSettingBinding) Reconcile(ctx context.Context, request rec
 			reqLogger.Info("Suite updated", "suite.Name", suite.Name)
 			r.Eventf(
 				instance, corev1.EventTypeNormal, "SuiteUpdated",
-				"ComplianceSuite %s/%s updatd", suite.Namespace, suite.Name,
+				"ComplianceSuite %s/%s updated", suite.Namespace, suite.Name,
 			)
 		} else {
 			reqLogger.Error(err, "Suite failed to update", "suite.Name", suite.Name)


### PR DESCRIPTION
Fix typo `updatd` -> `updated`.