### PR TITLE
CMP-3799: Add e2e suite for odd tests for pre-release testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -616,6 +616,10 @@ e2e-parallel: e2e-set-image prep-e2e ## Run non-destructive end-to-end tests con
 e2e-serial: e2e-set-image prep-e2e ## Run destructive end-to-end tests serially.
 	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/serial $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
 
+.PHONY: e2e-prerelease
+e2e-prerelease: e2e-set-image prep-e2e ## Run prerelease e2e tests (e.g. default ProfileBundles and Profiles per architecture).
+	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/prerelease $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
+
 ## Convert --platform to using $PLATFORM if we make this target more generic
 ## for other offerings.
 .PHONY: e2e-rosa

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -629,6 +629,21 @@ func (f *Framework) GetReadyProfileBundle(name, namespace string) (*compv1alpha1
 	return pb, nil
 }
 
+// WaitForProfileExists polls until a Profile with the given name exists in the operator namespace.
+func (f *Framework) WaitForProfileExists(profileName string, timeout, interval time.Duration) error {
+	return wait.Poll(interval, timeout, func() (bool, error) {
+		profile := &compv1alpha1.Profile{}
+		err := f.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      profileName,
+			Namespace: f.OperatorNamespace,
+		}, profile)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
 func (f *Framework) updateScanSettingsForDebug() error {
 	if f.Platform == "rosa" {
 		fmt.Printf("bypassing ScanSettings test setup because it's not supported on %s\n", f.Platform)

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -232,6 +232,9 @@ func (f *Framework) cleanUpProfileBundle(p string) error {
 	}
 	err := f.Client.Delete(context.TODO(), pb)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		return fmt.Errorf("failed to delete ProfileBundle%s: %w", p, err)
 	}
 	return nil
@@ -632,6 +635,21 @@ func (f *Framework) GetReadyProfileBundle(name, namespace string) (*compv1alpha1
 	}
 
 	return pb, nil
+}
+
+// WaitForProfileExists polls until a Profile with the given name exists in the operator namespace.
+func (f *Framework) WaitForProfileExists(profileName string, timeout, interval time.Duration) error {
+	return wait.Poll(interval, timeout, func() (bool, error) {
+		profile := &compv1alpha1.Profile{}
+		err := f.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      profileName,
+			Namespace: f.OperatorNamespace,
+		}, profile)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
 }
 
 func (f *Framework) updateScanSettingsForDebug() error {

--- a/tests/e2e/framework/main_entry.go
+++ b/tests/e2e/framework/main_entry.go
@@ -97,9 +97,15 @@ func (f *Framework) SetUp() error {
 		return fmt.Errorf("timed out waiting for deployment to become available: %w", err)
 	}
 
-	err = f.WaitForProfileBundleStatus("rhcos4", compv1alpha1.DataStreamValid)
-	if err != nil {
-		return err
+	arch := f.ClusterArchitecture()
+
+	if ExpectsRhcos4ProfileBundle(arch) {
+		err = f.WaitForProfileBundleStatus("rhcos4", compv1alpha1.DataStreamValid)
+		if err != nil {
+			return err
+		}
+	} else {
+		log.Printf("skipping rhcos4 ProfileBundle wait for architecture %s", arch.String())
 	}
 	err = f.WaitForProfileBundleStatus("ocp4", compv1alpha1.DataStreamValid)
 	if err != nil {
@@ -150,9 +156,14 @@ func (f *Framework) TearDown() error {
 	}
 
 	log.Printf("cleaning up Profile Bundles")
-	err = f.cleanUpProfileBundle("rhcos4")
-	if err != nil {
-		return fmt.Errorf("failed to cleanup rhcos4 profile bundle: %w", err)
+	arch := f.ClusterArchitecture()
+	if ExpectsRhcos4ProfileBundle(arch) {
+		err = f.cleanUpProfileBundle("rhcos4")
+		if err != nil {
+			return fmt.Errorf("failed to cleanup rhcos4 profile bundle: %w", err)
+		}
+	} else {
+		log.Printf("skipping rhcos4 ProfileBundle cleanup for architecture %s", arch.String())
 	}
 	err = f.cleanUpProfileBundle("ocp4")
 	if err != nil {

--- a/tests/e2e/framework/profiles_arch.go
+++ b/tests/e2e/framework/profiles_arch.go
@@ -1,0 +1,144 @@
+package framework
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Architecture represents the cluster's node architecture for profile expectations.
+type Architecture int
+
+const (
+	ArchAMD64 Architecture = iota
+	ArchARM64
+	ArchPPC64LE
+	ArchS390X
+	ArchMULTI
+	ArchUNKNOWN
+)
+
+func (a Architecture) String() string {
+	switch a {
+	case ArchAMD64:
+		return "amd64"
+	case ArchARM64:
+		return "arm64"
+	case ArchPPC64LE:
+		return "ppc64le"
+	case ArchS390X:
+		return "s390x"
+	case ArchMULTI:
+		return "multi"
+	default:
+		return "unknown"
+	}
+}
+
+// ClusterArchitecture returns the cluster architecture from node status.
+// If nodes report different architectures, returns ArchMULTI.
+func (f *Framework) ClusterArchitecture() Architecture {
+	nodeList := &corev1.NodeList{}
+	if err := f.Client.List(context.TODO(), nodeList); err != nil {
+		log.Printf("failed to list nodes: %v", err)
+		return ArchUNKNOWN
+	}
+	archSet := make(map[string]struct{})
+	for i := range nodeList.Items {
+		arch := strings.ToLower(nodeList.Items[i].Status.NodeInfo.Architecture)
+		if arch != "" {
+			archSet[arch] = struct{}{}
+		}
+	}
+	if len(archSet) == 0 {
+		return ArchUNKNOWN
+	}
+	if len(archSet) > 1 {
+		return ArchMULTI
+	}
+	var single string
+	for a := range archSet {
+		single = a
+		break
+	}
+	switch single {
+	case "amd64":
+		return ArchAMD64
+	case "arm64":
+		return ArchARM64
+	case "ppc64le":
+		return ArchPPC64LE
+	case "s390x":
+		return ArchS390X
+	default:
+		return ArchUNKNOWN
+	}
+}
+
+// Expected profiles per architecture (from compliance-operator-supported-profiles).
+// MULTI and UNKNOWN have no single-arch list.
+var (
+	profilesS390X = []string{
+		"ocp4-cis", "ocp4-cis-1-9", "ocp4-cis-node", "ocp4-cis-node-1-9",
+		"ocp4-moderate", "ocp4-moderate-node", "ocp4-moderate-node-rev-4", "ocp4-moderate-rev-4",
+		"ocp4-pci-dss", "ocp4-pci-dss-3-2", "ocp4-pci-dss-4-0", "ocp4-pci-dss-node",
+		"ocp4-pci-dss-node-3-2", "ocp4-pci-dss-node-4-0",
+	}
+	profilesPPC64LE = []string{
+		"ocp4-cis", "ocp4-cis-1-9", "ocp4-cis-node", "ocp4-cis-node-1-9",
+		"ocp4-moderate", "ocp4-moderate-node", "ocp4-moderate-node-rev-4", "ocp4-moderate-rev-4",
+		"ocp4-pci-dss", "ocp4-pci-dss-3-2", "ocp4-pci-dss-4-0", "ocp4-pci-dss-node",
+		"ocp4-pci-dss-node-3-2", "ocp4-pci-dss-node-4-0",
+		"rhcos4-moderate", "rhcos4-moderate-rev-4",
+	}
+
+	profilesAMD64 = []string{
+		"ocp4-cis", "ocp4-cis-1-9", "ocp4-cis-node", "ocp4-cis-node-1-9",
+		"ocp4-e8", "ocp4-high", "ocp4-high-node", "ocp4-high-node-rev-4", "ocp4-high-rev-4",
+		"ocp4-moderate", "ocp4-moderate-node", "ocp4-moderate-node-rev-4", "ocp4-moderate-rev-4",
+		"ocp4-nerc-cip", "ocp4-nerc-cip-node",
+		"ocp4-pci-dss", "ocp4-pci-dss-3-2", "ocp4-pci-dss-4-0", "ocp4-pci-dss-node",
+		"ocp4-pci-dss-node-3-2", "ocp4-pci-dss-node-4-0",
+		"ocp4-stig", "ocp4-stig-node", "ocp4-stig-node-v2r2", "ocp4-stig-node-v2r3", "ocp4-stig-v2r2", "ocp4-stig-v2r3",
+		"rhcos4-e8", "rhcos4-high", "rhcos4-high-rev-4", "rhcos4-moderate", "rhcos4-moderate-rev-4",
+		"rhcos4-nerc-cip", "rhcos4-stig", "rhcos4-stig-v2r2", "rhcos4-stig-v2r3",
+		"ocp4-bsi", "ocp4-bsi-2022", "ocp4-bsi-node", "ocp4-bsi-node-2022",
+	}
+
+	profilesARM64 = []string{
+		"ocp4-cis", "ocp4-cis-1-9", "ocp4-cis-node", "ocp4-cis-node-1-9",
+		"ocp4-moderate", "ocp4-moderate-node", "ocp4-moderate-node-rev-4", "ocp4-moderate-rev-4",
+		"ocp4-pci-dss", "ocp4-pci-dss-3-2", "ocp4-pci-dss-4-0", "ocp4-pci-dss-node",
+		"ocp4-pci-dss-node-3-2", "ocp4-pci-dss-node-4-0",
+		"rhcos4-moderate", "rhcos4-moderate-rev-4",
+	}
+
+	profilesMULTI = []string{
+		"ocp4-cis", "ocp4-cis-1-9", "ocp4-cis-node", "ocp4-cis-node-1-9",
+		"ocp4-moderate", "ocp4-moderate-node", "ocp4-moderate-node-rev-4", "ocp4-moderate-rev-4",
+		"ocp4-pci-dss", "ocp4-pci-dss-3-2", "ocp4-pci-dss-4-0", "ocp4-pci-dss-node",
+		"ocp4-pci-dss-node-3-2", "ocp4-pci-dss-node-4-0",
+		"rhcos4-moderate", "rhcos4-moderate-rev-4",
+	}
+)
+
+// GetExpectedProfilesForArch returns the list of default profile names expected for the given
+// architecture. Returns nil for ArchMULTI and ArchUNKNOWN (no single-arch list).
+func GetExpectedProfilesForArch(arch Architecture) []string {
+	switch arch {
+	case ArchS390X:
+		return profilesS390X
+	case ArchPPC64LE:
+		return profilesPPC64LE
+	case ArchAMD64:
+		return profilesAMD64
+	case ArchARM64:
+		return profilesARM64
+	case ArchMULTI:
+		return profilesMULTI
+	default:
+		return nil
+	}
+}

--- a/tests/e2e/framework/profiles_arch.go
+++ b/tests/e2e/framework/profiles_arch.go
@@ -1,0 +1,76 @@
+package framework
+
+// ExpectsRhcos4ProfileBundle reports whether the cluster architecture should have a rhcos4 ProfileBundle.
+func ExpectsRhcos4ProfileBundle(arch Architecture) bool {
+	switch arch {
+	case ArchAMD64, ArchARM64, ArchPPC64LE, ArchMULTI:
+		return true
+	default:
+		return false
+	}
+}
+
+// Expected profiles per architecture (from compliance-operator-supported-profiles).
+var (
+	profilesS390X = []string{
+		"ocp4-cis", "ocp4-cis-1-9", "ocp4-cis-node", "ocp4-cis-node-1-9",
+		"ocp4-moderate", "ocp4-moderate-node", "ocp4-moderate-node-rev-4", "ocp4-moderate-rev-4",
+		"ocp4-pci-dss", "ocp4-pci-dss-3-2", "ocp4-pci-dss-4-0", "ocp4-pci-dss-node",
+		"ocp4-pci-dss-node-3-2", "ocp4-pci-dss-node-4-0",
+	}
+	profilesPPC64LE = []string{
+		"ocp4-cis", "ocp4-cis-1-9", "ocp4-cis-node", "ocp4-cis-node-1-9",
+		"ocp4-moderate", "ocp4-moderate-node", "ocp4-moderate-node-rev-4", "ocp4-moderate-rev-4",
+		"ocp4-pci-dss", "ocp4-pci-dss-3-2", "ocp4-pci-dss-4-0", "ocp4-pci-dss-node",
+		"ocp4-pci-dss-node-3-2", "ocp4-pci-dss-node-4-0",
+		"rhcos4-moderate", "rhcos4-moderate-rev-4",
+	}
+
+	profilesAMD64 = []string{
+		"ocp4-cis", "ocp4-cis-1-9", "ocp4-cis-node", "ocp4-cis-node-1-9",
+		"ocp4-e8", "ocp4-high", "ocp4-high-node", "ocp4-high-node-rev-4", "ocp4-high-rev-4",
+		"ocp4-moderate", "ocp4-moderate-node", "ocp4-moderate-node-rev-4", "ocp4-moderate-rev-4",
+		"ocp4-nerc-cip", "ocp4-nerc-cip-node",
+		"ocp4-pci-dss", "ocp4-pci-dss-3-2", "ocp4-pci-dss-4-0", "ocp4-pci-dss-node",
+		"ocp4-pci-dss-node-3-2", "ocp4-pci-dss-node-4-0",
+		"ocp4-stig", "ocp4-stig-node", "ocp4-stig-node-v2r2", "ocp4-stig-node-v2r3", "ocp4-stig-v2r2", "ocp4-stig-v2r3",
+		"rhcos4-e8", "rhcos4-high", "rhcos4-high-rev-4", "rhcos4-moderate", "rhcos4-moderate-rev-4",
+		"rhcos4-nerc-cip", "rhcos4-stig", "rhcos4-stig-v2r2", "rhcos4-stig-v2r3",
+		"ocp4-bsi", "ocp4-bsi-2022", "ocp4-bsi-node", "ocp4-bsi-node-2022",
+	}
+
+	profilesARM64 = []string{
+		"ocp4-cis", "ocp4-cis-1-9", "ocp4-cis-node", "ocp4-cis-node-1-9",
+		"ocp4-moderate", "ocp4-moderate-node", "ocp4-moderate-node-rev-4", "ocp4-moderate-rev-4",
+		"ocp4-pci-dss", "ocp4-pci-dss-3-2", "ocp4-pci-dss-4-0", "ocp4-pci-dss-node",
+		"ocp4-pci-dss-node-3-2", "ocp4-pci-dss-node-4-0",
+		"rhcos4-moderate", "rhcos4-moderate-rev-4",
+	}
+
+	profilesMULTI = []string{
+		"ocp4-cis", "ocp4-cis-1-9", "ocp4-cis-node", "ocp4-cis-node-1-9",
+		"ocp4-moderate", "ocp4-moderate-node", "ocp4-moderate-node-rev-4", "ocp4-moderate-rev-4",
+		"ocp4-pci-dss", "ocp4-pci-dss-3-2", "ocp4-pci-dss-4-0", "ocp4-pci-dss-node",
+		"ocp4-pci-dss-node-3-2", "ocp4-pci-dss-node-4-0",
+		"rhcos4-moderate", "rhcos4-moderate-rev-4",
+	}
+)
+
+// GetExpectedProfilesForArch returns the list of default profile names expected for the given
+// architecture. Returns nil for ArchUNKNOWN (unrecognized architecture).
+func GetExpectedProfilesForArch(arch Architecture) []string {
+	switch arch {
+	case ArchS390X:
+		return profilesS390X
+	case ArchPPC64LE:
+		return profilesPPC64LE
+	case ArchAMD64:
+		return profilesAMD64
+	case ArchARM64:
+		return profilesARM64
+	case ArchMULTI:
+		return profilesMULTI
+	default:
+		return nil
+	}
+}

--- a/tests/e2e/prerelease/main_test.go
+++ b/tests/e2e/prerelease/main_test.go
@@ -1,0 +1,71 @@
+package prerelease_e2e
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/ComplianceAsCode/compliance-operator/tests/e2e/framework"
+)
+
+func TestMain(m *testing.M) {
+	f := framework.NewFramework()
+	err := f.SetUp()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	exitCode := m.Run()
+	if exitCode == 0 || (exitCode > 0 && f.CleanUpOnError()) {
+		if err = f.TearDown(); err != nil {
+			log.Fatal(err)
+		}
+	}
+	os.Exit(exitCode)
+}
+
+// TestProfilesOnArch (test case 45729) verifies that after the Compliance Operator is installed,
+// it creates the expected default ProfileBundles (ocp4, and rhcos4 for amd64/arm64/ppc64le/multi) with status
+// VALID, and that the expected Profiles exist for the cluster's architecture.
+func TestProfilesOnArch(t *testing.T) {
+	f := framework.Global
+
+	arch := f.ClusterArchitecture()
+	t.Logf("Detected cluster architecture: %s", arch.String())
+
+	// 1. ocp4 ProfileBundle must always be VALID
+	if err := f.WaitForProfileBundleStatus("ocp4", compv1alpha1.DataStreamValid); err != nil {
+		t.Fatalf("ProfileBundle ocp4 did not reach VALID: %v", err)
+	}
+	t.Log("ProfileBundle ocp4 is VALID")
+
+	// 2. rhcos4 ProfileBundle only for AMD64, ARM64, ppc64le or MULTI (no rhcos4 on s390x in this test)
+	if arch == framework.ArchAMD64 || arch == framework.ArchARM64 || arch == framework.ArchPPC64LE || arch == framework.ArchMULTI {
+		if err := f.WaitForProfileBundleStatus("rhcos4", compv1alpha1.DataStreamValid); err != nil {
+			t.Fatalf("ProfileBundle rhcos4 did not reach VALID: %v", err)
+		}
+		t.Log("ProfileBundle rhcos4 is VALID")
+	} else {
+		t.Logf("Skipping rhcos4 ProfileBundle check for architecture %s", arch.String())
+	}
+
+	// 3. Verify expected Profiles exist (per-architecture list; skip for UNKNOWN)
+	expectedProfiles := framework.GetExpectedProfilesForArch(arch)
+	if len(expectedProfiles) == 0 {
+		if arch == framework.ArchUNKNOWN {
+			t.Logf("Architecture %s: skipping profile name assertions (no single-arch profile list)", arch.String())
+		}
+		return
+	}
+
+	for _, profileName := range expectedProfiles {
+		err := f.WaitForProfileExists(profileName, 10*time.Second, 2*time.Second)
+		if err != nil {
+			t.Fatalf("Profile %s not found in namespace %s: %v", profileName, f.OperatorNamespace, err)
+		}
+		t.Logf("Profile %s exists", profileName)
+	}
+	t.Logf("All %d expected profiles exist for architecture %s", len(expectedProfiles), arch.String())
+}

--- a/tests/e2e/prerelease/main_test.go
+++ b/tests/e2e/prerelease/main_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/ComplianceAsCode/compliance-operator/tests/e2e/framework"
@@ -204,4 +205,45 @@ func TestResourceRequestsQuotaVariable(t *testing.T) {
 	if err := f.WaitForCheckResultStatus(moderateCheckName, compv1alpha1.CheckResultPass); err != nil {
 		t.Fatalf("check %s did not become PASS: %v", moderateCheckName, err)
 	}
+}
+
+// TestProfilesOnArch (test case 45729) verifies that after the Compliance Operator is installed,
+// it creates the expected default ProfileBundles (ocp4, and rhcos4 for amd64/arm64/ppc64le/multi) with status
+// VALID, and that the expected Profiles exist for the cluster's architecture.
+func TestProfilesOnArch(t *testing.T) {
+	f := framework.Global
+
+	arch := f.ClusterArchitecture()
+	t.Logf("Detected cluster architecture: %s", arch.String())
+
+	// 1. ocp4 ProfileBundle must always be VALID
+	if err := f.WaitForProfileBundleStatus("ocp4", compv1alpha1.DataStreamValid); err != nil {
+		t.Fatalf("ProfileBundle ocp4 did not reach VALID: %v", err)
+	}
+	t.Log("ProfileBundle ocp4 is VALID")
+
+	// 2. rhcos4 ProfileBundle only on architectures that ship rhcos4 content (not s390x)
+	if framework.ExpectsRhcos4ProfileBundle(arch) {
+		if err := f.WaitForProfileBundleStatus("rhcos4", compv1alpha1.DataStreamValid); err != nil {
+			t.Fatalf("ProfileBundle rhcos4 did not reach VALID: %v", err)
+		}
+		t.Log("ProfileBundle rhcos4 is VALID")
+	} else {
+		t.Logf("Skipping rhcos4 ProfileBundle check for architecture %s", arch.String())
+	}
+
+	// 3. Verify expected Profiles exist for the detected architecture
+	expectedProfiles := framework.GetExpectedProfilesForArch(arch)
+	if len(expectedProfiles) == 0 {
+		t.Fatalf("no expected profiles defined for architecture %s", arch.String())
+	}
+
+	for _, profileName := range expectedProfiles {
+		err := f.WaitForProfileExists(profileName, 10*time.Second, 2*time.Second)
+		if err != nil {
+			t.Fatalf("Profile %s not found in namespace %s: %v", profileName, f.OperatorNamespace, err)
+		}
+		t.Logf("Profile %s exists", profileName)
+	}
+	t.Logf("All %d expected profiles exist for architecture %s", len(expectedProfiles), arch.String())
 }


### PR DESCRIPTION
Adding a `prerelease` testing suite (name is debatable, I was not able to come up with anything better, will taky any advice here) for the test cases that are not directly related to the CO code, but still need to be tested  before release, such as DAST tests, stability or profile support on different architectures. 

Added a testcase for the latest for start (OCP-45729 in the downstream suite). Test case is passing on OCP 4.21:
```
=== RUN   TestProfilesOnArch
    main_test.go:36: Detected cluster architecture: amd64
2026/03/23 13:22:48 ProfileBundle ready (VALID)
    main_test.go:42: ProfileBundle ocp4 is VALID
2026/03/23 13:22:53 ProfileBundle ready (VALID)
    main_test.go:49: ProfileBundle rhcos4 is VALID
    main_test.go:68: Profile ocp4-cis exists
    main_test.go:68: Profile ocp4-cis-1-7 exists
    main_test.go:68: Profile ocp4-cis-node exists
    main_test.go:68: Profile ocp4-cis-node-1-7 exists
    main_test.go:68: Profile ocp4-e8 exists
    main_test.go:68: Profile ocp4-high exists
    main_test.go:68: Profile ocp4-high-node exists
    main_test.go:68: Profile ocp4-high-node-rev-4 exists
    main_test.go:68: Profile ocp4-high-rev-4 exists
    main_test.go:68: Profile ocp4-moderate exists
    main_test.go:68: Profile ocp4-moderate-node exists
    main_test.go:68: Profile ocp4-moderate-node-rev-4 exists
    main_test.go:68: Profile ocp4-moderate-rev-4 exists
    main_test.go:68: Profile ocp4-nerc-cip exists
    main_test.go:68: Profile ocp4-nerc-cip-node exists
    main_test.go:68: Profile ocp4-pci-dss exists
    main_test.go:68: Profile ocp4-pci-dss-3-2 exists
    main_test.go:68: Profile ocp4-pci-dss-4-0 exists
    main_test.go:68: Profile ocp4-pci-dss-node exists
    main_test.go:68: Profile ocp4-pci-dss-node-3-2 exists
    main_test.go:68: Profile ocp4-pci-dss-node-4-0 exists
    main_test.go:68: Profile ocp4-stig exists
    main_test.go:68: Profile ocp4-stig-node exists
    main_test.go:68: Profile ocp4-stig-node-v2r2 exists
    main_test.go:68: Profile ocp4-stig-node-v2r3 exists
    main_test.go:68: Profile ocp4-stig-v2r2 exists
    main_test.go:68: Profile ocp4-stig-v2r3 exists
    main_test.go:68: Profile rhcos4-e8 exists
    main_test.go:68: Profile rhcos4-high exists
    main_test.go:68: Profile rhcos4-high-rev-4 exists
    main_test.go:68: Profile rhcos4-moderate exists
    main_test.go:68: Profile rhcos4-moderate-rev-4 exists
    main_test.go:68: Profile rhcos4-nerc-cip exists
    main_test.go:68: Profile rhcos4-stig exists
    main_test.go:68: Profile rhcos4-stig-v2r2 exists
    main_test.go:68: Profile rhcos4-stig-v2r3 exists
    main_test.go:68: Profile ocp4-bsi exists
    main_test.go:68: Profile ocp4-bsi-2022 exists
    main_test.go:68: Profile ocp4-bsi-node exists
    main_test.go:68: Profile ocp4-bsi-node-2022 exists
    main_test.go:70: All 40 expected profiles exist for architecture amd64
--- PASS: TestProfilesOnArch (103.29s)
PASS
...
ok  	github.com/ComplianceAsCode/compliance-operator/tests/e2e/prerelease	384.139s
```

The next logical step would be to set up a prow job with f999 frequency (that is what it was marked as in the downstream repo) so that the job never runs unless triggered and wire it up to be part of the integration tests.

Assisted-by: Cursor