### PR TITLE
CNF-22645: Use strings.EqualFold for case-insensitive comparisons

### DIFF
--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -369,11 +369,11 @@ func (cs *ComplianceScan) NeedsTimeoutRescan() bool {
 // GetScanTypeIfValid returns scan type if the scan has a valid one, else it returns
 // an error
 func (cs *ComplianceScan) GetScanTypeIfValid() (ComplianceScanType, error) {
-	if strings.ToLower(string(cs.Spec.ScanType)) == strings.ToLower(string(ScanTypePlatform)) {
+	if strings.EqualFold(string(cs.Spec.ScanType), string(ScanTypePlatform)) {
 		return ScanTypePlatform, nil
 	}
 
-	if strings.ToLower(string(cs.Spec.ScanType)) == strings.ToLower(string(ScanTypeNode)) {
+	if strings.EqualFold(string(cs.Spec.ScanType), string(ScanTypeNode)) {
 		return ScanTypeNode, nil
 	}
 	return "", ErrUnkownScanType
@@ -382,11 +382,11 @@ func (cs *ComplianceScan) GetScanTypeIfValid() (ComplianceScanType, error) {
 // GetScannerTypeIfValid returns scaner type we will be using if the scan has a valid one, else it returns
 // an error
 func (cs *ComplianceScan) GetScannerTypeIfValid() (ScannerType, error) {
-	if strings.ToLower(string(cs.Spec.ScannerType)) == strings.ToLower(string(ScannerTypeOpenSCAP)) {
+	if strings.EqualFold(string(cs.Spec.ScannerType), string(ScannerTypeOpenSCAP)) {
 		return ScannerTypeOpenSCAP, nil
 	}
 
-	if strings.ToLower(string(cs.Spec.ScannerType)) == strings.ToLower(string(ScannerTypeCEL)) {
+	if strings.EqualFold(string(cs.Spec.ScannerType), string(ScannerTypeCEL)) {
 		return ScannerTypeCEL, nil
 	}
 	return "", ErrUnkownScanerType

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -376,11 +376,11 @@ func (cs *ComplianceScan) NeedsTimeoutRescan() bool {
 // GetScanTypeIfValid returns scan type if the scan has a valid one, else it returns
 // an error
 func (cs *ComplianceScan) GetScanTypeIfValid() (ComplianceScanType, error) {
-	if strings.ToLower(string(cs.Spec.ScanType)) == strings.ToLower(string(ScanTypePlatform)) {
+	if strings.EqualFold(string(cs.Spec.ScanType), string(ScanTypePlatform)) {
 		return ScanTypePlatform, nil
 	}
 
-	if strings.ToLower(string(cs.Spec.ScanType)) == strings.ToLower(string(ScanTypeNode)) {
+	if strings.EqualFold(string(cs.Spec.ScanType), string(ScanTypeNode)) {
 		return ScanTypeNode, nil
 	}
 	return "", ErrUnkownScanType
@@ -389,11 +389,11 @@ func (cs *ComplianceScan) GetScanTypeIfValid() (ComplianceScanType, error) {
 // GetScannerTypeIfValid returns scaner type we will be using if the scan has a valid one, else it returns
 // an error
 func (cs *ComplianceScan) GetScannerTypeIfValid() (ScannerType, error) {
-	if strings.ToLower(string(cs.Spec.ScannerType)) == strings.ToLower(string(ScannerTypeOpenSCAP)) {
+	if strings.EqualFold(string(cs.Spec.ScannerType), string(ScannerTypeOpenSCAP)) {
 		return ScannerTypeOpenSCAP, nil
 	}
 
-	if strings.ToLower(string(cs.Spec.ScannerType)) == strings.ToLower(string(ScannerTypeCEL)) {
+	if strings.EqualFold(string(cs.Spec.ScannerType), string(ScannerTypeCEL)) {
 		return ScannerTypeCEL, nil
 	}
 	return "", ErrUnkownScanerType


### PR DESCRIPTION
## Summary
- Replace `strings.ToLower(a) == strings.ToLower(b)` with `strings.EqualFold(a, b)` in `GetScanTypeIfValid()` and `GetScannerTypeIfValid()`
- No behavioral changes

## Related PRs
| PR | Title | Status |
|----|-------|--------|
| [#1116](https://github.com/ComplianceAsCode/compliance-operator/pull/1116) | CNF-22644: Remove unused functions, variables, and struct fields | Open |
| [#1118](https://github.com/ComplianceAsCode/compliance-operator/pull/1118) | CNF-22646: Fix typos in error variable names | Open |
| [#1119](https://github.com/ComplianceAsCode/compliance-operator/pull/1119) | CNF-22647: Rename KubeDepsNotFound to ErrKubeDepsNotFound | Open |
| [#1120](https://github.com/ComplianceAsCode/compliance-operator/pull/1120) | CNF-22657: Replace deprecated io/ioutil with io package | Open |
| [#1121](https://github.com/ComplianceAsCode/compliance-operator/pull/1121) | CNF-22658: Remove deprecated GO111MODULE=auto from Makefile | Open |
| [#1122](https://github.com/ComplianceAsCode/compliance-operator/pull/1122) | CNF-22659: Fix typo in error message: retriving -> retrieving | Open |
| [#1123](https://github.com/ComplianceAsCode/compliance-operator/pull/1123) | CNF-22660: Lowercase error strings per Go conventions | Open |
| [#721](https://github.com/ComplianceAsCode/compliance-operator/pull/721) | CNF-22754: Update repository references from openshift to ComplianceAsCode org | Open |
| [#1187](https://github.com/ComplianceAsCode/compliance-operator/pull/1187) | CNF-23094: Propagate context through pkg/utils public API | Open |

## Jira
- [CNF-22645](https://issues.redhat.com/browse/CNF-22645) -- Use strings.EqualFold for case-insensitive comparisons (Code Review)
- Epic: [CNF-23313](https://issues.redhat.com/browse/CNF-23313) -- Compliance Operator Tuning

## Test Plan
- [ ] CI passes
- [ ] Existing tests pass without modification

[CNF-22645]: https://redhat.atlassian.net/browse/CNF-22645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ