### PR TITLE
CNF-22646: Fix typos in error variable names

### DIFF
--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -48,9 +48,9 @@ const ScanFinalizer = "scan.finalizers.compliance.openshift.io"
 const DefaultRawStorageSize = "1Gi"
 const DefaultStorageRotation = 3
 
-var ErrUnkownScanType = errors.New("Unknown scan type")
+var ErrUnknownScanType = errors.New("Unknown scan type")
 
-var ErrUnkownScanerType = errors.New("Unknown scanner type")
+var ErrUnknownScannerType = errors.New("Unknown scanner type")
 
 // Represents the status of the compliance scan run.
 type ComplianceScanStatusPhase string
@@ -376,7 +376,7 @@ func (cs *ComplianceScan) GetScanTypeIfValid() (ComplianceScanType, error) {
 	if strings.ToLower(string(cs.Spec.ScanType)) == strings.ToLower(string(ScanTypeNode)) {
 		return ScanTypeNode, nil
 	}
-	return "", ErrUnkownScanType
+	return "", ErrUnknownScanType
 }
 
 // GetScannerTypeIfValid returns scaner type we will be using if the scan has a valid one, else it returns
@@ -389,7 +389,7 @@ func (cs *ComplianceScan) GetScannerTypeIfValid() (ScannerType, error) {
 	if strings.ToLower(string(cs.Spec.ScannerType)) == strings.ToLower(string(ScannerTypeCEL)) {
 		return ScannerTypeCEL, nil
 	}
-	return "", ErrUnkownScanerType
+	return "", ErrUnknownScannerType
 }
 
 // GetScanType get's the scan type for a scan

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -55,9 +55,9 @@ const ScanFinalizer = "scan.finalizers.compliance.openshift.io"
 const DefaultRawStorageSize = "1Gi"
 const DefaultStorageRotation = 3
 
-var ErrUnkownScanType = errors.New("Unknown scan type")
+var ErrUnknownScanType = errors.New("Unknown scan type")
 
-var ErrUnkownScanerType = errors.New("Unknown scanner type")
+var ErrUnknownScannerType = errors.New("Unknown scanner type")
 
 // Represents the status of the compliance scan run.
 type ComplianceScanStatusPhase string
@@ -383,7 +383,7 @@ func (cs *ComplianceScan) GetScanTypeIfValid() (ComplianceScanType, error) {
 	if strings.ToLower(string(cs.Spec.ScanType)) == strings.ToLower(string(ScanTypeNode)) {
 		return ScanTypeNode, nil
 	}
-	return "", ErrUnkownScanType
+	return "", ErrUnknownScanType
 }
 
 // GetScannerTypeIfValid returns scaner type we will be using if the scan has a valid one, else it returns
@@ -396,7 +396,7 @@ func (cs *ComplianceScan) GetScannerTypeIfValid() (ScannerType, error) {
 	if strings.ToLower(string(cs.Spec.ScannerType)) == strings.ToLower(string(ScannerTypeCEL)) {
 		return ScannerTypeCEL, nil
 	}
-	return "", ErrUnkownScanerType
+	return "", ErrUnknownScannerType
 }
 
 // GetScanType get's the scan type for a scan

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -957,7 +957,7 @@ func (r *ReconcileComplianceScan) scanDeleteHandler(instance *compv1alpha1.Compl
 		scanToBeDeleted := instance.DeepCopy()
 
 		scanTypeHandler, err := getScanTypeHandler(r, scanToBeDeleted, logger)
-		if err != nil && !goerrors.Is(err, compv1alpha1.ErrUnkownScanType) {
+		if err != nil && !goerrors.Is(err, compv1alpha1.ErrUnknownScanType) {
 			return reconcile.Result{}, err
 		}
 

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -965,7 +965,7 @@ func (r *ReconcileComplianceScan) scanDeleteHandler(instance *compv1alpha1.Compl
 		scanToBeDeleted := instance.DeepCopy()
 
 		scanTypeHandler, err := getScanTypeHandler(r, scanToBeDeleted, logger)
-		if err != nil && !goerrors.Is(err, compv1alpha1.ErrUnkownScanType) {
+		if err != nil && !goerrors.Is(err, compv1alpha1.ErrUnknownScanType) {
 			return reconcile.Result{}, err
 		}
 


### PR DESCRIPTION
## Summary
- Fix typos in error variable names: `ErrUnkownScanType` -> `ErrUnknownScanType`, `ErrUnkownScanerType` -> `ErrUnknownScannerType`
- No behavioral changes

## Related PRs
| PR | Title | Status |
|----|-------|--------|
| [#1116](https://github.com/ComplianceAsCode/compliance-operator/pull/1116) | CNF-22644: Remove unused functions, variables, and struct fields | Open |
| [#1117](https://github.com/ComplianceAsCode/compliance-operator/pull/1117) | CNF-22645: Use strings.EqualFold for case-insensitive comparisons | Open |
| [#1119](https://github.com/ComplianceAsCode/compliance-operator/pull/1119) | CNF-22647: Rename KubeDepsNotFound to ErrKubeDepsNotFound | Open |
| [#1120](https://github.com/ComplianceAsCode/compliance-operator/pull/1120) | CNF-22657: Replace deprecated io/ioutil with io package | Open |
| [#1121](https://github.com/ComplianceAsCode/compliance-operator/pull/1121) | CNF-22658: Remove deprecated GO111MODULE=auto from Makefile | Open |
| [#1122](https://github.com/ComplianceAsCode/compliance-operator/pull/1122) | CNF-22659: Fix typo in error message: retriving -> retrieving | Open |
| [#1123](https://github.com/ComplianceAsCode/compliance-operator/pull/1123) | CNF-22660: Lowercase error strings per Go conventions | Open |
| [#721](https://github.com/ComplianceAsCode/compliance-operator/pull/721) | CNF-22754: Update repository references from openshift to ComplianceAsCode org | Open |
| [#1187](https://github.com/ComplianceAsCode/compliance-operator/pull/1187) | CNF-23094: Propagate context through pkg/utils public API | Open |

## Jira
- [CNF-22646](https://issues.redhat.com/browse/CNF-22646) -- Fix typos in error variable names (Code Review)
- Epic: [CNF-23313](https://issues.redhat.com/browse/CNF-23313) -- Compliance Operator Tuning

## Test Plan
- [ ] CI passes
- [ ] Existing tests pass without modification

[CNF-22646]: https://redhat.atlassian.net/browse/CNF-22646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ