### PR TITLE
CNF-22647: Rename KubeDepsNotFound to ErrKubeDepsNotFound

### DIFF
--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types.go
@@ -93,7 +93,7 @@ const (
 )
 
 var (
-	KubeDepsNotFound = errors.New("kubernetes dependency annotation not found")
+	ErrKubeDepsNotFound = errors.New("kubernetes dependency annotation not found")
 )
 
 type RemediationObjectDependencyReference struct {
@@ -283,7 +283,7 @@ func (r *ComplianceRemediation) ParseRemediationDependencyRefs() ([]RemediationO
 	annotations := r.GetAnnotations()
 	rawdeps, hasDeps := annotations[RemediationObjectDependencyAnnotation]
 	if !hasDeps {
-		return nil, KubeDepsNotFound
+		return nil, ErrKubeDepsNotFound
 	}
 
 	deps := []RemediationObjectDependencyReference{}

--- a/pkg/apis/compliance/v1alpha1/complianceremediation_types_test.go
+++ b/pkg/apis/compliance/v1alpha1/complianceremediation_types_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Testing ComplianceRemediation API", func() {
 		It("returns an error if no annotation is set", func() {
 			_, err := rem.ParseRemediationDependencyRefs()
 			Expect(err).ToNot(BeNil())
-			Expect(err).To(MatchError(KubeDepsNotFound))
+			Expect(err).To(MatchError(ErrKubeDepsNotFound))
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Rename `KubeDepsNotFound` -> `ErrKubeDepsNotFound` to follow Go convention of prefixing sentinel error variables with `Err`
- No behavioral changes

## Related PRs
| PR | Title | Status |
|----|-------|--------|
| [#1116](https://github.com/ComplianceAsCode/compliance-operator/pull/1116) | CNF-22644: Remove unused functions, variables, and struct fields | Open |
| [#1117](https://github.com/ComplianceAsCode/compliance-operator/pull/1117) | CNF-22645: Use strings.EqualFold for case-insensitive comparisons | Open |
| [#1118](https://github.com/ComplianceAsCode/compliance-operator/pull/1118) | CNF-22646: Fix typos in error variable names | Open |
| [#1120](https://github.com/ComplianceAsCode/compliance-operator/pull/1120) | CNF-22657: Replace deprecated io/ioutil with io package | Open |
| [#1121](https://github.com/ComplianceAsCode/compliance-operator/pull/1121) | CNF-22658: Remove deprecated GO111MODULE=auto from Makefile | Open |
| [#1122](https://github.com/ComplianceAsCode/compliance-operator/pull/1122) | CNF-22659: Fix typo in error message: retriving -> retrieving | Open |
| [#1123](https://github.com/ComplianceAsCode/compliance-operator/pull/1123) | CNF-22660: Lowercase error strings per Go conventions | Open |
| [#721](https://github.com/ComplianceAsCode/compliance-operator/pull/721) | CNF-22754: Update repository references from openshift to ComplianceAsCode org | Open |
| [#1187](https://github.com/ComplianceAsCode/compliance-operator/pull/1187) | CNF-23094: Propagate context through pkg/utils public API | Open |

## Jira
- [CNF-22647](https://issues.redhat.com/browse/CNF-22647) -- Rename KubeDepsNotFound to ErrKubeDepsNotFound (Code Review)
- Epic: [CNF-23313](https://issues.redhat.com/browse/CNF-23313) -- Compliance Operator Tuning

## Test Plan
- [ ] CI passes
- [ ] Existing tests pass without modification

[CNF-22647]: https://redhat.atlassian.net/browse/CNF-22647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ