### PR TITLE
CNF-22657: Replace deprecated io/ioutil with io package

### DIFF
--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"strconv"
 	"strings"
@@ -553,7 +553,7 @@ func (r *ReconcileComplianceScan) getRuntimeKubeletConfig(nodeName string) (stri
 		return "", fmt.Errorf("cannot get the runtime kubelet config for node %s: %v", nodeName, err)
 	}
 	defer kubeletConfigIO.Close()
-	kubeletConfig, err := ioutil.ReadAll(kubeletConfigIO)
+	kubeletConfig, err := io.ReadAll(kubeletConfigIO)
 	if err != nil {
 		return "", fmt.Errorf("cannot read the runtime kubelet config for node %s: %v", nodeName, err)
 	}

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"strconv"
 	"strings"
@@ -561,7 +561,7 @@ func (r *ReconcileComplianceScan) getRuntimeKubeletConfig(nodeName string) (stri
 		return "", fmt.Errorf("cannot get the runtime kubelet config for node %s: %v", nodeName, err)
 	}
 	defer kubeletConfigIO.Close()
-	kubeletConfig, err := ioutil.ReadAll(kubeletConfigIO)
+	kubeletConfig, err := io.ReadAll(kubeletConfigIO)
 	if err != nil {
 		return "", fmt.Errorf("cannot read the runtime kubelet config for node %s: %v", nodeName, err)
 	}

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -187,18 +187,18 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 				if req.URL.Path == "/api/v1/nodes/"+nodeinstance1.Name+"/proxy/configz" {
 					return &http.Response{
 						StatusCode: 200,
-						Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`{"kubeletconfig": {"kind": "KubeletConfiguration", "apiVersion": "kubelet.config.k8s.io/v1beta1", "authentication": {"x509": {"clientCAFile": "/etc/kubernetes/ca.crt"}}}}`))),
+						Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"kubeletconfig": {"kind": "KubeletConfiguration", "apiVersion": "kubelet.config.k8s.io/v1beta1", "authentication": {"x509": {"clientCAFile": "/etc/kubernetes/ca.crt"}}}}`))),
 					}, nil
 				}
 				if req.URL.Path == "/api/v1/nodes/"+nodeinstance2.Name+"/proxy/configz" {
 					return &http.Response{
 						StatusCode: 200,
-						Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`{"kubeletconfig": {"kind": "KubeletConfiguration", "apiVersion": "kubelet.config.k8s.io/v1beta1"}}`))),
+						Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"kubeletconfig": {"kind": "KubeletConfiguration", "apiVersion": "kubelet.config.k8s.io/v1beta1"}}`))),
 					}, nil
 				}
 				return &http.Response{
 					StatusCode: 404,
-					Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`{"error": "not found"}`))),
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"error": "not found"}`))),
 				}, nil
 			}),
 		}


### PR DESCRIPTION
## Summary
- Replace `ioutil.ReadAll` with `io.ReadAll` and `ioutil.NopCloser` with `io.NopCloser`
- `io/ioutil` has been deprecated since Go 1.16; no behavioral changes

## Related PRs
| PR | Title | Status |
|----|-------|--------|
| [#1116](https://github.com/ComplianceAsCode/compliance-operator/pull/1116) | CNF-22644: Remove unused functions, variables, and struct fields | Open |
| [#1117](https://github.com/ComplianceAsCode/compliance-operator/pull/1117) | CNF-22645: Use strings.EqualFold for case-insensitive comparisons | Open |
| [#1118](https://github.com/ComplianceAsCode/compliance-operator/pull/1118) | CNF-22646: Fix typos in error variable names | Open |
| [#1119](https://github.com/ComplianceAsCode/compliance-operator/pull/1119) | CNF-22647: Rename KubeDepsNotFound to ErrKubeDepsNotFound | Open |
| [#1121](https://github.com/ComplianceAsCode/compliance-operator/pull/1121) | CNF-22658: Remove deprecated GO111MODULE=auto from Makefile | Open |
| [#1122](https://github.com/ComplianceAsCode/compliance-operator/pull/1122) | CNF-22659: Fix typo in error message: retriving -> retrieving | Open |
| [#1123](https://github.com/ComplianceAsCode/compliance-operator/pull/1123) | CNF-22660: Lowercase error strings per Go conventions | Open |
| [#721](https://github.com/ComplianceAsCode/compliance-operator/pull/721) | CNF-22754: Update repository references from openshift to ComplianceAsCode org | Open |
| [#1187](https://github.com/ComplianceAsCode/compliance-operator/pull/1187) | CNF-23094: Propagate context through pkg/utils public API | Open |

## Jira
- [CNF-22657](https://issues.redhat.com/browse/CNF-22657) -- Replace deprecated io/ioutil with io package (Code Review)
- Epic: [CNF-23313](https://issues.redhat.com/browse/CNF-23313) -- Compliance Operator Tuning

## Test Plan
- [ ] CI passes
- [ ] Existing tests pass without modification

[CNF-22657]: https://redhat.atlassian.net/browse/CNF-22657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ