### PR TITLE
CNF-22659: Fix typo in error message: retriving → retrieving

### DIFF
--- a/pkg/controller/complianceremediation/complianceremediation_controller.go
+++ b/pkg/controller/complianceremediation/complianceremediation_controller.go
@@ -527,7 +527,7 @@ func (r *ReconcileComplianceRemediation) isRequiredValueSet(rem *compv1alpha1.Co
 		}
 		tpContent, ok := tpcm.Data["tailoring.xml"]
 		if !ok {
-			return false, fmt.Errorf("Error retriving Tailor Profile CM")
+			return false, fmt.Errorf("error retrieving tailored profile configmap")
 		}
 		if strings.Contains(tpContent, strings.ReplaceAll(requiredValue, "-", "_")) {
 			return true, nil


### PR DESCRIPTION
## Summary
- Fix spelling error "retriving" -> "retrieving" in complianceremediation controller error message
- Also lowercased the error string per Go conventions; no behavioral changes

## Related PRs
| PR | Title | Status |
|----|-------|--------|
| [#1116](https://github.com/ComplianceAsCode/compliance-operator/pull/1116) | CNF-22644: Remove unused functions, variables, and struct fields | Open |
| [#1117](https://github.com/ComplianceAsCode/compliance-operator/pull/1117) | CNF-22645: Use strings.EqualFold for case-insensitive comparisons | Open |
| [#1118](https://github.com/ComplianceAsCode/compliance-operator/pull/1118) | CNF-22646: Fix typos in error variable names | Open |
| [#1119](https://github.com/ComplianceAsCode/compliance-operator/pull/1119) | CNF-22647: Rename KubeDepsNotFound to ErrKubeDepsNotFound | Open |
| [#1120](https://github.com/ComplianceAsCode/compliance-operator/pull/1120) | CNF-22657: Replace deprecated io/ioutil with io package | Open |
| [#1121](https://github.com/ComplianceAsCode/compliance-operator/pull/1121) | CNF-22658: Remove deprecated GO111MODULE=auto from Makefile | Open |
| [#1123](https://github.com/ComplianceAsCode/compliance-operator/pull/1123) | CNF-22660: Lowercase error strings per Go conventions | Open |
| [#721](https://github.com/ComplianceAsCode/compliance-operator/pull/721) | CNF-22754: Update repository references from openshift to ComplianceAsCode org | Open |
| [#1187](https://github.com/ComplianceAsCode/compliance-operator/pull/1187) | CNF-23094: Propagate context through pkg/utils public API | Open |

## Jira
- [CNF-22659](https://issues.redhat.com/browse/CNF-22659) -- Fix typo in error message: retriving -> retrieving (Code Review)
- Epic: [CNF-23313](https://issues.redhat.com/browse/CNF-23313) -- Compliance Operator Tuning

## Test Plan
- [ ] CI passes
- [ ] Existing tests pass without modification

[CNF-22659]: https://redhat.atlassian.net/browse/CNF-22659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ