### PR TITLE
CMP-3864: Add test for remediation with variables (ocp4_kubelet_confi…

### DIFF
--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -4078,3 +4078,208 @@ curl -k -s -G "https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query
 	}
 	return fmt.Errorf("%s still present in ALERTS query output", alertName)
 }
+
+// WaitForMachineConfigPoolUpdated waits until the pool reports Updated=True and all machines
+// are updated and ready. If the pool is already settled, returns immediately.
+func (f *Framework) WaitForMachineConfigPoolUpdated(poolName string) error {
+	if f.Platform == "rosa" {
+		log.Printf("Bypassing MachineConfigPool update check on %s", f.Platform)
+		return nil
+	}
+
+	return wait.PollImmediate(machineOperationRetryInterval, machineOperationTimeout, func() (bool, error) {
+		pool := mcfgv1.MachineConfigPool{}
+		if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: poolName}, &pool); err != nil {
+			return false, err
+		}
+		for _, c := range pool.Status.Conditions {
+			if c.Type == mcfgv1.MachineConfigPoolUpdated {
+				if c.Status == core.ConditionTrue &&
+					pool.Status.MachineCount == pool.Status.UpdatedMachineCount &&
+					pool.Status.MachineCount == pool.Status.ReadyMachineCount {
+					log.Printf("Machine Config Pool %s is updated (%d/%d machines)\n",
+						poolName, pool.Status.UpdatedMachineCount, pool.Status.MachineCount)
+					return true, nil
+				}
+				log.Printf("Machine Config Pool %s not fully updated yet (Updated=%s, %d/%d updated, %d/%d ready)\n",
+					poolName, c.Status,
+					pool.Status.UpdatedMachineCount, pool.Status.MachineCount,
+					pool.Status.ReadyMachineCount, pool.Status.MachineCount)
+				return false, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+// WaitForNodeToMatchMachineConfigPool waits until the node's machine-config annotations show
+// desiredConfig matching the pool's rendered configuration (status.configuration.name, else
+// spec.configuration.name), currentConfig == desiredConfig, and state Done. Use this after
+// moving a node into a pool (e.g. removing a custom role label so it rejoins worker) and
+// before deleting that custom MachineConfigPool.
+func (f *Framework) WaitForNodeToMatchMachineConfigPool(poolName, nodeName string) error {
+	if f.Platform == "rosa" {
+		return nil
+	}
+	return wait.PollImmediate(machineOperationRetryInterval, machineOperationTimeout, func() (bool, error) {
+		pool := &mcfgv1.MachineConfigPool{}
+		if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: poolName}, pool); err != nil {
+			return false, err
+		}
+		target := pool.Status.Configuration.Name
+		if target == "" {
+			target = pool.Spec.Configuration.Name
+		}
+		if target == "" {
+			log.Printf("MachineConfigPool %s has no configuration name yet; retrying\n", poolName)
+			return false, nil
+		}
+		node := &core.Node{}
+		if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: nodeName}, node); err != nil {
+			return false, err
+		}
+		cur := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
+		des := node.Annotations["machineconfiguration.openshift.io/desiredConfig"]
+		st := node.Annotations["machineconfiguration.openshift.io/state"]
+		if des != target || cur != des || st != "Done" {
+			log.Printf("waiting for node %s to match pool %s: desired=%s want=%s current=%s state=%s\n",
+				nodeName, poolName, des, target, cur, st)
+			return false, nil
+		}
+		log.Printf("node %s matches MachineConfigPool %s (%s)\n", nodeName, poolName, target)
+		return true, nil
+	})
+}
+
+// GetOneRhcosWorkerNodeForCustomMCP returns an RHCOS/RHEL worker that does not have the
+// framework e2e MachineConfigPool role (see SetUp createMachineConfigPool). That node is
+// reserved for the shared e2e pool; labeling it again for another custom MCP (e.g. wrscan)
+// makes it match multiple pools and commonly leaves machineconfiguration.openshift.io/state
+// Degraded, which breaks WaitForNodesToBeReady after remediation.
+func (f *Framework) GetOneRhcosWorkerNodeForCustomMCP() (string, error) {
+	e2eRoleLabel := fmt.Sprintf("node-role.kubernetes.io/%s", TestPoolName)
+
+	tryList := func(labelSelector string) ([]corev1.Node, error) {
+		nodes, err := f.KubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return nil, err
+		}
+		return nodes.Items, nil
+	}
+
+	selectNode := func(nodes []corev1.Node) (string, bool) {
+		for i := range nodes {
+			if _, hasE2E := nodes[i].Labels[e2eRoleLabel]; hasE2E {
+				continue
+			}
+			return nodes[i].Name, true
+		}
+		return "", false
+	}
+
+	rhcosNodes, err := tryList("node-role.kubernetes.io/edge!=,node-role.kubernetes.io/worker=,node.openshift.io/os_id=rhcos")
+	if err != nil {
+		return "", err
+	}
+	if name, ok := selectNode(rhcosNodes); ok {
+		return name, nil
+	}
+
+	rhelNodes, err := tryList("node-role.kubernetes.io/edge!=,node-role.kubernetes.io/worker=,node.openshift.io/os_id=rhel")
+	if err != nil {
+		return "", err
+	}
+	if name, ok := selectNode(rhelNodes); ok {
+		return name, nil
+	}
+
+	if len(rhcosNodes)+len(rhelNodes) > 0 {
+		return "", fmt.Errorf("no worker found outside framework %s MachineConfigPool (need a worker not labeled %s)", TestPoolName, e2eRoleLabel)
+	}
+	return "", fmt.Errorf("no rhcos/rhel worker node found")
+}
+
+// SetNodeRoleLabel sets node-role.kubernetes.io/<role>="" on a node.
+func (f *Framework) SetNodeRoleLabel(nodeName, role string) error {
+	node := &corev1.Node{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: nodeName}, node); err != nil {
+		return err
+	}
+	nodeCopy := node.DeepCopy()
+	if nodeCopy.Labels == nil {
+		nodeCopy.Labels = map[string]string{}
+	}
+	nodeCopy.Labels[fmt.Sprintf("node-role.kubernetes.io/%s", role)] = ""
+	return f.Client.Update(context.TODO(), nodeCopy)
+}
+
+// RemoveNodeRoleLabel removes node-role.kubernetes.io/<role> from a node.
+func (f *Framework) RemoveNodeRoleLabel(nodeName, role string) error {
+	node := &corev1.Node{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: nodeName}, node); err != nil {
+		return err
+	}
+	nodeCopy := node.DeepCopy()
+	delete(nodeCopy.Labels, fmt.Sprintf("node-role.kubernetes.io/%s", role))
+	return f.Client.Update(context.TODO(), nodeCopy)
+}
+
+// EnsureMachineConfigPoolForRole creates a MachineConfigPool if it doesn't exist.
+func (f *Framework) EnsureMachineConfigPoolForRole(poolName, role string) error {
+	pool := &mcfgv1.MachineConfigPool{}
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: poolName}, pool)
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	poolLabels := map[string]string{
+		fmt.Sprintf("pools.operator.machineconfiguration.openshift.io/%s", role): "",
+	}
+	nodeLabel := map[string]string{
+		fmt.Sprintf("node-role.kubernetes.io/%s", role): "",
+	}
+	newPool := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{Name: poolName, Labels: poolLabels},
+		Spec: mcfgv1.MachineConfigPoolSpec{
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: nodeLabel,
+			},
+			MachineConfigSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      mcfgv1.MachineConfigRoleLabelKey,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"worker", role},
+					},
+				},
+			},
+		},
+	}
+	return f.Client.Create(context.TODO(), newPool, nil)
+}
+
+// SetSuiteRemediationsApply updates spec.apply for all remediations belonging to a suite.
+func (f *Framework) SetSuiteRemediationsApply(namespace, suiteName string, apply bool) error {
+	list := &compv1alpha1.ComplianceRemediationList{}
+	if err := f.Client.List(
+		context.TODO(),
+		list,
+		client.InNamespace(namespace),
+		client.MatchingLabels{compv1alpha1.SuiteLabel: suiteName},
+	); err != nil {
+		return err
+	}
+
+	for i := range list.Items {
+		rem := &list.Items[i]
+		remCopy := rem.DeepCopy()
+		remCopy.Spec.Apply = apply
+		if err := f.Client.Update(context.TODO(), remCopy); err != nil {
+			return fmt.Errorf("update remediation %s: %w", rem.Name, err)
+		}
+	}
+	return nil
+}

--- a/tests/e2e/framework/main_entry.go
+++ b/tests/e2e/framework/main_entry.go
@@ -186,6 +186,12 @@ func (f *Framework) TearDown() error {
 		if err != nil {
 			return err
 		}
+		// Wait for worker pool to be updated after nodes are unlabeled. This is best-effort:
+		// if it fails we still delete the e2e MCPs so cluster-scoped leftovers are not abandoned.
+		err = f.WaitForMachineConfigPoolUpdated(workerPoolName)
+		if err != nil {
+			log.Printf("waiting for worker MachineConfigPool to update after unlabeled e2e nodes: %v; continuing cleanup", err)
+		}
 		err = f.cleanUpMachineConfigPool("e2e")
 		if err != nil {
 			return err

--- a/tests/e2e/prerelease/main_test.go
+++ b/tests/e2e/prerelease/main_test.go
@@ -10,6 +10,7 @@ import (
 	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/ComplianceAsCode/compliance-operator/tests/e2e/framework"
 	corev1 "k8s.io/api/core/v1"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -203,5 +204,209 @@ func TestResourceRequestsQuotaVariable(t *testing.T) {
 	moderateCheckName := fmt.Sprintf("%s-resource-requests-quota", tpModerateName)
 	if err := f.WaitForCheckResultStatus(moderateCheckName, compv1alpha1.CheckResultPass); err != nil {
 		t.Fatalf("check %s did not become PASS: %v", moderateCheckName, err)
+	}
+}
+
+// TestKubeletTLSCipherSuitesVariable ports test case 50505.
+// It validates fail -> auto-remediation applied -> rescan -> pass flow for
+// ocp4-kubelet-configure-tls-cipher-suites using tailored profile variables.
+func TestKubeletTLSCipherSuitesVariable(t *testing.T) {
+	f := framework.Global
+	arch := f.ClusterArchitecture()
+	if arch == framework.ArchARM64 || arch == framework.ArchMULTI || arch == framework.ArchS390X {
+		t.Skipf("skipping on architecture %s (upstream parity)", arch)
+	}
+
+	const (
+		roleName          = "wrscan"
+		mcpName           = "wrscan"
+		kubeletConfigName = "compliance-operator-kubelet-wrscan"
+	)
+
+	// Avoid the worker reserved for framework SetUp's "e2e" MachineConfigPool; labeling
+	// that node for wrscan overlaps MCPs and often leaves MCO state Degraded.
+	nodeName, err := f.GetOneRhcosWorkerNodeForCustomMCP()
+	if err != nil {
+		t.Skipf("skipping test: %v", err)
+	}
+	if err := f.SetNodeRoleLabel(nodeName, roleName); err != nil {
+		t.Fatalf("failed to label node %s: %v", nodeName, err)
+	}
+
+	if err := f.EnsureMachineConfigPoolForRole(mcpName, roleName); err != nil {
+		t.Fatalf("failed ensuring MachineConfigPool %s: %v", mcpName, err)
+	}
+
+	base := framework.GetObjNameFromTest(t)
+	tpName := base + "-tp"
+	ssName := base + "-ss"
+	ssbName := base + "-ssb"
+	scanName := fmt.Sprintf("%s-%s", tpName, roleName)
+	checkName := fmt.Sprintf("%s-%s-kubelet-configure-tls-cipher-suites", tpName, roleName)
+	remName := checkName
+
+	// ssbCreated gates pause/remediation cleanup; must run before unlabel. Order below matches
+	// restoreNodeLabelsForPool / TearDown: unapply → unlabel → wait node on worker → delete custom MCP → wait worker.
+	var ssbCreated bool
+	defer func() {
+		if ssbCreated {
+			_ = f.PauseMachinePool(mcpName)
+			_ = f.SetSuiteRemediationsApply(f.OperatorNamespace, ssbName, false)
+			_ = f.ResumeMachinePool(mcpName)
+		}
+		kc := &mcfgv1.KubeletConfig{}
+		if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: kubeletConfigName}, kc); err == nil {
+			if err := f.Client.Delete(context.TODO(), kc); err != nil {
+				t.Logf("cleanup kubeletconfig %s: %v", kubeletConfigName, err)
+			}
+		}
+		if err := f.RemoveNodeRoleLabel(nodeName, roleName); err != nil {
+			t.Logf("cleanup: remove node label %s from %s: %v", roleName, nodeName, err)
+		}
+		if err := f.WaitForNodeToMatchMachineConfigPool("worker", nodeName); err != nil {
+			t.Logf("cleanup: wait for node %s to match worker pool before deleting %s MCP: %v", nodeName, mcpName, err)
+		}
+		pool := &mcfgv1.MachineConfigPool{ObjectMeta: metav1.ObjectMeta{Name: mcpName}}
+		if err := f.Client.Delete(context.TODO(), pool); err != nil {
+			t.Logf("cleanup: delete mcp %s: %v", mcpName, err)
+		}
+		if err := f.WaitForMachineConfigPoolUpdated("worker"); err != nil {
+			t.Logf("cleanup: wait for worker MachineConfigPool after wrscan cleanup: %v", err)
+		}
+	}()
+
+	tp := &compv1alpha1.TailoredProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tpName,
+			Namespace: f.OperatorNamespace,
+			Annotations: map[string]string{
+				compv1alpha1.ProductTypeAnnotation: "Node",
+			},
+		},
+		Spec: compv1alpha1.TailoredProfileSpec{
+			Title:       "kubelet tls cipher suites",
+			Description: "Ported from test case 50505",
+			EnableRules: []compv1alpha1.RuleReferenceSpec{
+				{
+					Name:      "ocp4-kubelet-configure-tls-cipher-suites",
+					Rationale: "Node",
+				},
+			},
+			SetValues: []compv1alpha1.VariableValueSpec{
+				{
+					Name:      "ocp4-var-kubelet-tls-cipher-suites-regex",
+					Rationale: "Node",
+					Value:     "^(TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256)$",
+				},
+				{
+					Name:      "ocp4-var-kubelet-tls-cipher-suites",
+					Rationale: "Node",
+					Value:     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+				},
+			},
+		},
+	}
+	if err := f.Client.Create(context.TODO(), tp, nil); err != nil {
+		t.Fatalf("failed to create tailored profile %s: %v", tpName, err)
+	}
+	defer f.Client.Delete(context.TODO(), tp)
+	if err := f.WaitForTailoredProfileStatus(f.OperatorNamespace, tpName, compv1alpha1.TailoredProfileStateReady); err != nil {
+		t.Fatalf("tailored profile %s not ready: %v", tpName, err)
+	}
+
+	ss := &compv1alpha1.ScanSetting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ssName,
+			Namespace: f.OperatorNamespace,
+		},
+		ComplianceSuiteSettings: compv1alpha1.ComplianceSuiteSettings{
+			AutoApplyRemediations:  true,
+			AutoUpdateRemediations: true,
+			Schedule:               "0 1 * * *",
+		},
+		ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+			StrictNodeScan: func() *bool { b := false; return &b }(),
+			RawResultStorage: compv1alpha1.RawResultStorageSettings{
+				Size:     "2Gi",
+				Rotation: 5,
+			},
+			Debug: true,
+		},
+		Roles: []string{roleName},
+	}
+	if err := f.Client.Create(context.TODO(), ss, nil); err != nil {
+		t.Fatalf("failed to create scansetting %s: %v", ssName, err)
+	}
+	defer f.Client.Delete(context.TODO(), ss)
+
+	ssb := &compv1alpha1.ScanSettingBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ssbName,
+			Namespace: f.OperatorNamespace,
+		},
+		Profiles: []compv1alpha1.NamedObjectReference{
+			{
+				APIGroup: "compliance.openshift.io/v1alpha1",
+				Kind:     "TailoredProfile",
+				Name:     tpName,
+			},
+		},
+		SettingsRef: &compv1alpha1.NamedObjectReference{
+			APIGroup: "compliance.openshift.io/v1alpha1",
+			Kind:     "ScanSetting",
+			Name:     ssName,
+		},
+	}
+	if err := f.Client.Create(context.TODO(), ssb, nil); err != nil {
+		t.Fatalf("failed to create scansettingbinding %s: %v", ssbName, err)
+	}
+	ssbCreated = true
+	defer func() {
+		if err := f.DeleteScanSettingBindingAndWaitForCleanup(ssb); err != nil {
+			t.Logf("cleanup scansettingbinding %s: %v", ssbName, err)
+		}
+	}()
+
+	// First run: suite should be done and non-compliant, check should fail, remediation should be applied.
+	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, ssbName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant); err != nil {
+		t.Fatalf("suite %s first run not done/non-compliant: %v", ssbName, err)
+	}
+
+	failCheck := compv1alpha1.ComplianceCheckResult{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      checkName,
+			Namespace: f.OperatorNamespace,
+		},
+		ID:       "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cipher_suites",
+		Status:   compv1alpha1.CheckResultFail,
+		Severity: compv1alpha1.CheckResultSeverityMedium,
+	}
+	if err := f.AssertHasCheck(ssbName, scanName, failCheck); err != nil {
+		t.Fatalf("expected FAIL check %s after first run: %v", checkName, err)
+	}
+
+	if err := f.WaitForGenericRemediationToBeAutoApplied(remName, f.OperatorNamespace); err != nil {
+		t.Fatalf("remediation %s was not auto-applied: %v", remName, err)
+	}
+
+	// Rescan and verify pass.
+	if err := f.ReRunScan(scanName, f.OperatorNamespace); err != nil {
+		t.Fatalf("failed to trigger rescan for %s: %v", scanName, err)
+	}
+	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, ssbName, compv1alpha1.PhaseDone, compv1alpha1.ResultCompliant); err != nil {
+		t.Fatalf("suite %s second run not done/compliant: %v", ssbName, err)
+	}
+
+	passCheck := compv1alpha1.ComplianceCheckResult{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      checkName,
+			Namespace: f.OperatorNamespace,
+		},
+		ID:       "xccdf_org.ssgproject.content_rule_kubelet_configure_tls_cipher_suites",
+		Status:   compv1alpha1.CheckResultPass,
+		Severity: compv1alpha1.CheckResultSeverityMedium,
+	}
+	if err := f.AssertHasCheck(ssbName, scanName, passCheck); err != nil {
+		t.Fatalf("expected PASS check %s after rescan: %v", checkName, err)
 	}
 }


### PR DESCRIPTION
…gure_tls_cipher_suites)

Test case is now passing on OCP 4.21, the only problem is that it takes ages:
```
=== RUN   TestKubeletTLSCipherSuitesVariable
2026/04/01 15:43:12 TailoredProfile ready (READY)
2026/04/01 15:43:18 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:43:23 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:43:28 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:43:33 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:43:38 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:43:43 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:43:48 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: AGGREGATING
2026/04/01 15:43:58 ComplianceScan ready (DONE)
2026/04/01 15:43:58 All scans in ComplianceSuite have finished (test-kubelet-t-l-s-cipher-suites-variable-ssb)
2026/04/01 15:44:03 found remediation: test-kubelet-t-l-s-cipher-suites-variable-tp-wrscan-kubelet-configure-tls-cipher-suites
2026/04/01 15:44:08 machines updated with remediation
2026/04/01 15:44:08 node ip-10-0-12-176.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:44:08 node ip-10-0-12-176.us-east-2.compute.internal was updated
2026/04/01 15:44:08 node ip-10-0-31-67.us-east-2.compute.internal has config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042 state Done
2026/04/01 15:44:08 node ip-10-0-31-67.us-east-2.compute.internal was updated
2026/04/01 15:44:08 node ip-10-0-36-216.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:44:08 node ip-10-0-36-216.us-east-2.compute.internal was updated
2026/04/01 15:44:08 node ip-10-0-50-66.us-east-2.compute.internal has config rendered-wrscan-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state Working
2026/04/01 15:44:08 node ip-10-0-50-66.us-east-2.compute.internal still updating
2026/04/01 15:44:19 node ip-10-0-12-176.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:44:19 node ip-10-0-12-176.us-east-2.compute.internal was updated
2026/04/01 15:44:19 node ip-10-0-31-67.us-east-2.compute.internal has config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042 state Done
2026/04/01 15:44:19 node ip-10-0-31-67.us-east-2.compute.internal was updated
2026/04/01 15:44:19 node ip-10-0-36-216.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:44:19 node ip-10-0-36-216.us-east-2.compute.internal was updated
2026/04/01 15:44:19 node ip-10-0-50-66.us-east-2.compute.internal has config rendered-wrscan-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state Working
2026/04/01 15:44:19 node ip-10-0-50-66.us-east-2.compute.internal still updating
2026/04/01 15:44:29 node ip-10-0-12-176.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:44:29 node ip-10-0-12-176.us-east-2.compute.internal was updated
2026/04/01 15:44:29 node ip-10-0-31-67.us-east-2.compute.internal has config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042 state Done
2026/04/01 15:44:29 node ip-10-0-31-67.us-east-2.compute.internal was updated
2026/04/01 15:44:29 node ip-10-0-36-216.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:44:29 node ip-10-0-36-216.us-east-2.compute.internal was updated
2026/04/01 15:44:29 node ip-10-0-50-66.us-east-2.compute.internal has config rendered-wrscan-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state Working
2026/04/01 15:44:29 node ip-10-0-50-66.us-east-2.compute.internal still updating
2026/04/01 15:44:39 node ip-10-0-12-176.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:44:39 node ip-10-0-12-176.us-east-2.compute.internal was updated
2026/04/01 15:44:39 node ip-10-0-31-67.us-east-2.compute.internal has config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042 state Done
2026/04/01 15:44:39 node ip-10-0-31-67.us-east-2.compute.internal was updated
2026/04/01 15:44:39 node ip-10-0-36-216.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:44:39 node ip-10-0-36-216.us-east-2.compute.internal was updated
2026/04/01 15:44:39 node ip-10-0-50-66.us-east-2.compute.internal has config rendered-wrscan-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state Working
2026/04/01 15:44:39 node ip-10-0-50-66.us-east-2.compute.internal still updating
2026/04/01 15:44:49 node ip-10-0-12-176.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:44:49 node ip-10-0-12-176.us-east-2.compute.internal was updated
2026/04/01 15:44:49 node ip-10-0-31-67.us-east-2.compute.internal has config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042 state Done
2026/04/01 15:44:49 node ip-10-0-31-67.us-east-2.compute.internal was updated
2026/04/01 15:44:49 node ip-10-0-36-216.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:44:49 node ip-10-0-36-216.us-east-2.compute.internal was updated
2026/04/01 15:44:49 node ip-10-0-50-66.us-east-2.compute.internal has config rendered-wrscan-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state Working
2026/04/01 15:44:49 node ip-10-0-50-66.us-east-2.compute.internal still updating
2026/04/01 15:44:59 node ip-10-0-12-176.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:44:59 node ip-10-0-12-176.us-east-2.compute.internal was updated
2026/04/01 15:44:59 node ip-10-0-31-67.us-east-2.compute.internal has config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042 state Done
2026/04/01 15:44:59 node ip-10-0-31-67.us-east-2.compute.internal was updated
2026/04/01 15:44:59 node ip-10-0-36-216.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:44:59 node ip-10-0-36-216.us-east-2.compute.internal was updated
2026/04/01 15:44:59 node ip-10-0-50-66.us-east-2.compute.internal has config rendered-wrscan-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state Working
2026/04/01 15:44:59 node ip-10-0-50-66.us-east-2.compute.internal still updating
2026/04/01 15:45:09 node ip-10-0-12-176.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:45:09 node ip-10-0-12-176.us-east-2.compute.internal was updated
2026/04/01 15:45:09 node ip-10-0-31-67.us-east-2.compute.internal has config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042 state Done
2026/04/01 15:45:09 node ip-10-0-31-67.us-east-2.compute.internal was updated
2026/04/01 15:45:09 node ip-10-0-36-216.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:45:09 node ip-10-0-36-216.us-east-2.compute.internal was updated
2026/04/01 15:45:09 node ip-10-0-50-66.us-east-2.compute.internal has config rendered-wrscan-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state Working
2026/04/01 15:45:09 node ip-10-0-50-66.us-east-2.compute.internal still updating
2026/04/01 15:45:19 node ip-10-0-12-176.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:45:19 node ip-10-0-12-176.us-east-2.compute.internal was updated
2026/04/01 15:45:19 node ip-10-0-31-67.us-east-2.compute.internal has config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042 state Done
2026/04/01 15:45:19 node ip-10-0-31-67.us-east-2.compute.internal was updated
2026/04/01 15:45:19 node ip-10-0-36-216.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:45:19 node ip-10-0-36-216.us-east-2.compute.internal was updated
2026/04/01 15:45:19 node ip-10-0-50-66.us-east-2.compute.internal has config rendered-wrscan-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state Working
2026/04/01 15:45:19 node ip-10-0-50-66.us-east-2.compute.internal still updating
2026/04/01 15:45:29 node ip-10-0-12-176.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:45:29 node ip-10-0-12-176.us-east-2.compute.internal was updated
2026/04/01 15:45:29 node ip-10-0-31-67.us-east-2.compute.internal has config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042 state Done
2026/04/01 15:45:29 node ip-10-0-31-67.us-east-2.compute.internal was updated
2026/04/01 15:45:29 node ip-10-0-36-216.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:45:29 node ip-10-0-36-216.us-east-2.compute.internal was updated
2026/04/01 15:45:29 node ip-10-0-50-66.us-east-2.compute.internal has config rendered-wrscan-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state Working
2026/04/01 15:45:29 node ip-10-0-50-66.us-east-2.compute.internal still updating
2026/04/01 15:45:39 node ip-10-0-12-176.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:45:39 node ip-10-0-12-176.us-east-2.compute.internal was updated
2026/04/01 15:45:39 node ip-10-0-31-67.us-east-2.compute.internal has config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042 state Done
2026/04/01 15:45:39 node ip-10-0-31-67.us-east-2.compute.internal was updated
2026/04/01 15:45:39 node ip-10-0-36-216.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:45:39 node ip-10-0-36-216.us-east-2.compute.internal was updated
2026/04/01 15:45:39 node ip-10-0-50-66.us-east-2.compute.internal has config rendered-wrscan-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state Working
2026/04/01 15:45:39 node ip-10-0-50-66.us-east-2.compute.internal still updating
2026/04/01 15:45:49 node ip-10-0-12-176.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:45:49 node ip-10-0-12-176.us-east-2.compute.internal was updated
2026/04/01 15:45:49 node ip-10-0-31-67.us-east-2.compute.internal has config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042 state Done
2026/04/01 15:45:49 node ip-10-0-31-67.us-east-2.compute.internal was updated
2026/04/01 15:45:49 node ip-10-0-36-216.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:45:49 node ip-10-0-36-216.us-east-2.compute.internal was updated
2026/04/01 15:45:49 node ip-10-0-50-66.us-east-2.compute.internal has config rendered-wrscan-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state Working
2026/04/01 15:45:49 node ip-10-0-50-66.us-east-2.compute.internal still updating
2026/04/01 15:45:59 node ip-10-0-12-176.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:45:59 node ip-10-0-12-176.us-east-2.compute.internal was updated
2026/04/01 15:45:59 node ip-10-0-31-67.us-east-2.compute.internal has config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-e2e-ea6f4d49acd2a7a27b1a423530a6b042 state Done
2026/04/01 15:45:59 node ip-10-0-31-67.us-east-2.compute.internal was updated
2026/04/01 15:45:59 node ip-10-0-36-216.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:45:59 node ip-10-0-36-216.us-east-2.compute.internal was updated
2026/04/01 15:45:59 node ip-10-0-50-66.us-east-2.compute.internal has config rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd, desired config rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state Done
2026/04/01 15:45:59 node ip-10-0-50-66.us-east-2.compute.internal was updated
2026/04/01 15:45:59 node ip-10-0-81-139.us-east-2.compute.internal has config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b, desired config rendered-master-351aa1fd1f0b7ad8b7890280abcadd6b state Done
2026/04/01 15:45:59 node ip-10-0-81-139.us-east-2.compute.internal was updated
2026/04/01 15:45:59 node ip-10-0-92-27.us-east-2.compute.internal has config rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042, desired config rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 state Done
2026/04/01 15:45:59 node ip-10-0-92-27.us-east-2.compute.internal was updated
2026/04/01 15:45:59 all machines updated
2026/04/01 15:45:59 rerunning scan test-kubelet-t-l-s-cipher-suites-variable-tp-wrscan
2026/04/01 15:46:05 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:46:10 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:46:15 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:46:20 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:46:25 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:46:30 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:46:35 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:46:40 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:46:45 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:46:50 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:46:55 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:47:00 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: RUNNING
2026/04/01 15:47:05 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: AGGREGATING
2026/04/01 15:47:10 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: AGGREGATING
2026/04/01 15:47:15 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: AGGREGATING
2026/04/01 15:47:20 waiting until suite test-kubelet-t-l-s-cipher-suites-variable-ssb reaches target status 'DONE'. Current status: AGGREGATING
2026/04/01 15:47:30 ComplianceScan ready (DONE)
2026/04/01 15:47:30 All scans in ComplianceSuite have finished (test-kubelet-t-l-s-cipher-suites-variable-ssb)
2026/04/01 15:47:38 waiting for node ip-10-0-50-66.us-east-2.compute.internal to match pool worker: desired=rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd want=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 current=rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state=Done
2026/04/01 15:47:48 waiting for node ip-10-0-50-66.us-east-2.compute.internal to match pool worker: desired=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 want=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 current=rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state=Working
2026/04/01 15:47:58 waiting for node ip-10-0-50-66.us-east-2.compute.internal to match pool worker: desired=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 want=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 current=rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state=Working
2026/04/01 15:48:08 waiting for node ip-10-0-50-66.us-east-2.compute.internal to match pool worker: desired=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 want=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 current=rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state=Working
2026/04/01 15:48:18 waiting for node ip-10-0-50-66.us-east-2.compute.internal to match pool worker: desired=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 want=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 current=rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state=Working
2026/04/01 15:48:28 waiting for node ip-10-0-50-66.us-east-2.compute.internal to match pool worker: desired=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 want=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 current=rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state=Working
2026/04/01 15:48:39 waiting for node ip-10-0-50-66.us-east-2.compute.internal to match pool worker: desired=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 want=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 current=rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state=Working
2026/04/01 15:48:48 waiting for node ip-10-0-50-66.us-east-2.compute.internal to match pool worker: desired=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 want=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 current=rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state=Working
2026/04/01 15:48:58 waiting for node ip-10-0-50-66.us-east-2.compute.internal to match pool worker: desired=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 want=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 current=rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state=Working
2026/04/01 15:49:09 waiting for node ip-10-0-50-66.us-east-2.compute.internal to match pool worker: desired=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 want=rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042 current=rendered-wrscan-8b02de5e0dcf6b73cf6c54e7023718dd state=Working
2026/04/01 15:49:18 node ip-10-0-50-66.us-east-2.compute.internal matches MachineConfigPool worker (rendered-worker-ea6f4d49acd2a7a27b1a423530a6b042)
2026/04/01 15:49:19 Machine Config Pool worker is currently updated. Waiting for update to start...
2026/04/01 15:49:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:49:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:49:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:49:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:49:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:50:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:50:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:50:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:50:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:50:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:50:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:51:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:51:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:51:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:51:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:51:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:51:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:52:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:52:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:52:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:52:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:52:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:52:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:53:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:53:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:53:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:53:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:53:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:54:06 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:54:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:54:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:54:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:54:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:54:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:54:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:55:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:55:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:55:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:55:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:55:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:55:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:56:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:56:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:56:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:56:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:56:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:56:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:57:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:57:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:57:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:57:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:57:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:57:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:58:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:58:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:58:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:58:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:58:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:58:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:59:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:59:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:59:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:59:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:59:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 15:59:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:00:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:00:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:00:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:00:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:00:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:00:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:01:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:01:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:01:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:01:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:01:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:01:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:02:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:02:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:02:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:02:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:02:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:02:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:03:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:03:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:03:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:03:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:03:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:03:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:04:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:04:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:04:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:04:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:04:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:04:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:05:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:05:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:05:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:05:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:05:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:05:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:06:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:06:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:06:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:06:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:06:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:06:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:07:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:07:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:07:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:07:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:07:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:07:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:08:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:08:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:08:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:08:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:08:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:08:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:09:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:09:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:09:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:09:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:09:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:09:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:10:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:10:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:10:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:10:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:10:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:10:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:11:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:11:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:11:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:11:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:11:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:11:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:12:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:12:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:12:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:12:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:12:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:12:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:13:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:13:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:13:29 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:13:39 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:13:49 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:13:59 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:14:09 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:14:19 Machine Config Pool worker still updated, waiting for update to start...
2026/04/01 16:14:19 Machine Config Pool worker still updated, waiting for update to start...
    main_test.go:94: cleanup: wait for worker MachineConfigPool after wrscan cleanup: failed waiting for Machine Config Pool worker to start updating: timed out waiting for the condition
--- PASS: TestKubeletTLSCipherSuitesVariable (1874.30s)
PASS
...
ok  	github.com/ComplianceAsCode/compliance-operator/tests/e2e/prerelease	2126.057s
