### PR TITLE
CMP-4225: Check no TargetDown alert is raised after operator upgrade

### DIFF
--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"os"
 	"os/exec"
 	"regexp"
@@ -33,9 +34,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
-
-
-	"math"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	oauthclientset "github.com/openshift/client-go/oauth/clientset/versioned"
@@ -375,6 +373,12 @@ func (f *Framework) addFrameworks() error {
 	}
 
 	return nil
+}
+
+// EnsureE2ESchemes registers API schemes on the framework client when tests run against an
+// existing cluster install without SetUp (see E2E_SKIP_FRAMEWORK_SETUP in prerelease tests).
+func (f *Framework) EnsureE2ESchemes() error {
+	return f.addFrameworks()
 }
 
 func (f *Framework) initializeMetricsTestResources() error {
@@ -3797,4 +3801,261 @@ func (f *Framework) AssertSuiteScanExitCodesContainSubstring(suiteName, wantSubs
 		}
 	}
 	return nil
+}
+
+func compareVersion(v1, v2 string) int {
+	s1 := strings.Split(v1, ".")
+	s2 := strings.Split(v2, ".")
+	maxLen := len(s1)
+	if len(s2) > maxLen {
+		maxLen = len(s2)
+	}
+	for i := 0; i < maxLen; i++ {
+		a := 0
+		b := 0
+		if i < len(s1) {
+			part := regexp.MustCompile(`[^0-9]`).ReplaceAllString(s1[i], "")
+			if part != "" {
+				a, _ = strconv.Atoi(part)
+			}
+		}
+		if i < len(s2) {
+			part := regexp.MustCompile(`[^0-9]`).ReplaceAllString(s2[i], "")
+			if part != "" {
+				b, _ = strconv.Atoi(part)
+			}
+		}
+		if a > b {
+			return 1
+		}
+		if a < b {
+			return -1
+		}
+	}
+	return 0
+}
+
+func (f *Framework) GetInstalledComplianceOperatorCSV() (string, error) {
+	out, err := runOCandGetOutput([]string{
+		"get", "csv", "-n", f.OperatorNamespace,
+		"-l", "operators.coreos.com/compliance-operator." + f.OperatorNamespace + "=",
+		"-o", "jsonpath={.items[0].metadata.name}",
+	})
+	if err != nil {
+		return "", err
+	}
+	name := strings.TrimSpace(strings.Trim(out, "'"))
+	if name == "" {
+		return "", fmt.Errorf("installed CSV not found in namespace %s", f.OperatorNamespace)
+	}
+	return name, nil
+}
+
+// IsComplianceOperatorUpgradable checks if catalog/channel advertises newer CSV than installed.
+func (f *Framework) IsComplianceOperatorUpgradable(catalogSource, channel string) (bool, error) {
+	oldCSV, err := f.GetInstalledComplianceOperatorCSV()
+	if err != nil {
+		return false, err
+	}
+	oldVersion := strings.TrimPrefix(oldCSV, "compliance-operator.v")
+
+	out, err := runOCandGetOutput([]string{
+		"get", "packagemanifest", "-n", "openshift-marketplace",
+		"-l", fmt.Sprintf("catalog=%s", catalogSource),
+		"-o", "json",
+	})
+	if err != nil {
+		return false, err
+	}
+	var pm struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Status struct {
+				Channels []struct {
+					Name       string `json:"name"`
+					CurrentCSV string `json:"currentCSV"`
+				} `json:"channels"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(out), &pm); err != nil {
+		return false, err
+	}
+	for _, item := range pm.Items {
+		if item.Metadata.Name != "compliance-operator" {
+			continue
+		}
+		for _, ch := range item.Status.Channels {
+			if ch.Name != channel {
+				continue
+			}
+			curVersion := strings.TrimPrefix(ch.CurrentCSV, "compliance-operator.v")
+			return compareVersion(curVersion, oldVersion) == 1, nil
+		}
+	}
+	return false, nil
+}
+
+func (f *Framework) PatchComplianceOperatorSubscriptionSource(source string) error {
+	_, err := runOCandGetOutput([]string{
+		"patch", "subscription", "compliance-operator", "-n", f.OperatorNamespace,
+		"--type", "merge", "-p", fmt.Sprintf(`{"spec":{"source":"%s"}}`, source),
+	})
+	return err
+}
+
+func (f *Framework) WaitForComplianceOperatorCSVUpgrade(oldCSV string) error {
+	return wait.PollImmediate(10*time.Second, Timeout, func() (bool, error) {
+		curCSVOut, err := runOCandGetOutput([]string{
+			"get", "subscription", "compliance-operator", "-n", f.OperatorNamespace,
+			"-o", "jsonpath={.status.currentCSV}",
+		})
+		if err != nil {
+			return false, nil
+		}
+		curCSV := strings.TrimSpace(curCSVOut)
+		if curCSV == "" || curCSV == oldCSV {
+			return false, nil
+		}
+		phaseOut, err := runOCandGetOutput([]string{
+			"get", "csv", curCSV, "-n", f.OperatorNamespace,
+			"-o", "jsonpath={.status.phase}",
+		})
+		if err != nil {
+			return false, nil
+		}
+		return strings.Contains(strings.TrimSpace(phaseOut), "Succeeded"), nil
+	})
+}
+
+func (f *Framework) AssertComplianceOperatorPodRunning() error {
+	pods, err := f.KubeClient.CoreV1().Pods(f.OperatorNamespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "name=compliance-operator",
+	})
+	if err != nil {
+		return err
+	}
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no compliance-operator pod found in %s", f.OperatorNamespace)
+	}
+	if pods.Items[0].Status.Phase != corev1.PodRunning {
+		return fmt.Errorf("compliance-operator pod phase is %s", pods.Items[0].Status.Phase)
+	}
+	return nil
+}
+
+func (f *Framework) AssertMetricsContain(ssbName string) error {
+	want := []string{
+		`compliance_operator_compliance_scan_status_total{name="ocp4-cis",phase="DONE",result=`,
+		fmt.Sprintf(`compliance_operator_compliance_state{name="%s"}`, ssbName),
+	}
+	deadline := time.Now().Add(180 * time.Second)
+	for time.Now().Before(deadline) {
+		out, err := getMetricResults(f.OperatorNamespace)
+		if err == nil {
+			ok := true
+			for _, m := range want {
+				if !strings.Contains(out, m) {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				return nil
+			}
+		}
+		time.Sleep(5 * time.Second)
+	}
+	return fmt.Errorf("metrics did not contain expected substrings")
+}
+
+func (f *Framework) AssertPrometheusRule() error {
+	out, err := runOCandGetOutput([]string{"get", "prometheusrule", "-n", f.OperatorNamespace, "-o", "json"})
+	if err != nil {
+		return err
+	}
+	var pr struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Spec struct {
+				Groups []struct {
+					Rules []struct {
+						Alert string `json:"alert"`
+					} `json:"rules"`
+				} `json:"groups"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(out), &pr); err != nil {
+		return err
+	}
+	for _, item := range pr.Items {
+		if !strings.Contains(strings.ToLower(item.Metadata.Name), "compliance") {
+			continue
+		}
+		if len(item.Spec.Groups) == 0 || len(item.Spec.Groups[0].Rules) == 0 {
+			continue
+		}
+		if strings.Contains(item.Spec.Groups[0].Rules[0].Alert, "NonCompliant") {
+			return nil
+		}
+	}
+	return fmt.Errorf("no compliance PrometheusRule with NonCompliant alert found")
+}
+
+func (f *Framework) WaitForAlertAbsent(alertName string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	promQL := fmt.Sprintf(`ALERTS{namespace="%s"}`, f.OperatorNamespace)
+	script := fmt.Sprintf(`
+TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+curl -k -s -G "https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query" \
+  --data-urlencode 'query=%s' \
+  -H "Authorization: Bearer ${TOKEN}" \
+  --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+`, promQL)
+	for time.Now().Before(deadline) {
+		out, err := runOCandGetOutput([]string{
+			"run", "--rm", "-i", "--restart=Never", "--image=registry.fedoraproject.org/fedora:latest",
+			"-n", f.OperatorNamespace,
+			`--overrides={"spec":{"serviceAccountName":"` + PrometheusTestSA + `"}}`,
+			"prom-alerts", "--", "bash", "-c", script,
+		})
+		if err == nil {
+			// Require a successful Prometheus JSON response before concluding the alert is absent.
+			// Raw string matching would treat HTML/503/error bodies as "absent".
+			trimmed := trimOutput(out)
+			if trimmed == "" {
+				time.Sleep(3 * time.Second)
+				continue
+			}
+			var resp struct {
+				Status string `json:"status"`
+				Data   struct {
+					Result []struct {
+						Metric map[string]string `json:"metric"`
+					} `json:"result"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal([]byte(trimmed), &resp); err != nil || resp.Status != "success" {
+				time.Sleep(3 * time.Second)
+				continue
+			}
+			found := false
+			for _, r := range resp.Data.Result {
+				if name, ok := r.Metric["alertname"]; ok && strings.Contains(name, alertName) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return nil
+			}
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return fmt.Errorf("%s still present in ALERTS query output", alertName)
 }

--- a/tests/e2e/upgrade/main_test.go
+++ b/tests/e2e/upgrade/main_test.go
@@ -1,0 +1,140 @@
+package upgrade_e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/ComplianceAsCode/compliance-operator/tests/e2e/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMain(m *testing.M) {
+	f := framework.NewFramework()
+
+	// Use with TEST_OPERATOR_NAMESPACE=openshift-compliance (or your install ns) when Compliance
+	// Operator is already installed. Skips manifest deploy, CRD apply, e2e MCP, and TearDown.
+	skipSetup := os.Getenv("E2E_SKIP_FRAMEWORK_SETUP") == "true"
+	if skipSetup {
+		if err := f.EnsureE2ESchemes(); err != nil {
+			log.Fatalf("EnsureE2ESchemes: %v", err)
+		}
+	} else {
+		if err := f.SetUp(); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	exitCode := m.Run()
+	if !skipSetup && (exitCode == 0 || (exitCode > 0 && f.CleanUpOnError())) {
+		if err := f.TearDown(); err != nil {
+			log.Fatal(err)
+		}
+	}
+	os.Exit(exitCode)
+}
+
+// TestUpgradeTargetDownNotRaised ports test case 56353: after an optional OLM upgrade to a newer
+// compliance-operator CSV from the compliance-operator catalog, run ocp4-cis via ScanSettingBinding,
+// verify metrics, PrometheusRule, Alertmanager non-compliance alert (label name + description), and assert ALERTS for the
+// operator namespace does not contain TargetDown.
+func TestUpgradeTargetDownNotRaised(t *testing.T) {
+	f := framework.Global
+
+	arch := f.ClusterArchitecture()
+	if arch == framework.ArchARM64 || arch == framework.ArchMULTI {
+		t.Skipf("skipping on architecture %s (upstream parity)", arch.String())
+	}
+
+	upgradable, err := f.IsComplianceOperatorUpgradable("compliance-operator", "stable")
+	if err != nil {
+		t.Fatalf("check upgradable: %v", err)
+	}
+	if !upgradable {
+		t.Skip("compliance-operator stable channel has no newer CSV than installed")
+	}
+
+	oldCSV, err := f.GetInstalledComplianceOperatorCSV()
+	if err != nil {
+		t.Fatalf("get installed CSV: %v", err)
+	}
+	t.Logf("Old CSV version: %v", oldCSV)
+	if err := f.PatchComplianceOperatorSubscriptionSource("compliance-operator"); err != nil {
+		t.Fatalf("patch subscription source: %v", err)
+	}
+	time.Sleep(10 * time.Second)
+
+	if err := f.WaitForComplianceOperatorCSVUpgrade(oldCSV); err != nil {
+		t.Fatalf("wait for upgraded CSV: %v", err)
+	}
+	if err := f.AssertComplianceOperatorPodRunning(); err != nil {
+		t.Fatalf("compliance-operator pod is not running: %v", err)
+	}
+	if err := f.WaitForProfileBundleStatus("ocp4", compv1alpha1.DataStreamValid); err != nil {
+		t.Fatalf("ocp4 profile bundle is not VALID: %v", err)
+	}
+	if arch == framework.ArchAMD64 {
+		if err := f.WaitForProfileBundleStatus("rhcos4", compv1alpha1.DataStreamValid); err != nil {
+			t.Fatalf("rhcos4 profile bundle is not VALID: %v", err)
+		}
+	}
+
+	if err := f.SetupRBACForMetricsTest(); err != nil {
+		if errors.Is(err, framework.ErrAlertManagerRBACUnavailable) {
+			t.Skipf("Skipping test: %v", err)
+		}
+		t.Fatalf("setup metrics RBAC: %v", err)
+	}
+	defer f.CleanUpRBACForMetricsTest()
+
+	ssbName := framework.GetObjNameFromTest(t) + "-upg-metrics"
+	ssb := &compv1alpha1.ScanSettingBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ssbName,
+			Namespace: f.OperatorNamespace,
+		},
+		Profiles: []compv1alpha1.NamedObjectReference{
+			{
+				Name:     "ocp4-cis",
+				Kind:     "Profile",
+				APIGroup: "compliance.openshift.io/v1alpha1",
+			},
+		},
+		SettingsRef: &compv1alpha1.NamedObjectReference{
+			Name:     "default",
+			Kind:     "ScanSetting",
+			APIGroup: "compliance.openshift.io/v1alpha1",
+		},
+	}
+	if err := f.Client.Create(context.TODO(), ssb, nil); err != nil {
+		t.Fatalf("create ScanSettingBinding %s: %v", ssbName, err)
+	}
+	defer func() {
+		if err := f.DeleteScanSettingBindingAndWaitForCleanup(ssb); err != nil {
+			t.Logf("cleanup ScanSettingBinding %s: %v", ssbName, err)
+		}
+	}()
+
+	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, ssbName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant); err != nil {
+		t.Fatalf("suite %s not DONE/NON-COMPLIANT: %v", ssbName, err)
+	}
+
+	if err := f.AssertMetricsContain(ssbName); err != nil {
+		t.Fatalf("metrics assertions: %v", err)
+	}
+	if err := f.AssertPrometheusRule(); err != nil {
+		t.Fatalf("prometheusrule assertions: %v", err)
+	}
+	want := fmt.Sprintf("The compliance suite %s returned as NON-COMPLIANT, ERROR, or INCONSISTENT", ssbName)
+	if err := f.AssertAlertManagerAlertExists(ssbName, want, 300*time.Second); err != nil {
+		t.Fatalf("alertmanager alert: %v", err)
+	}
+	if err := f.WaitForAlertAbsent("TargetDown", 180*time.Second); err != nil {
+		t.Fatalf("TargetDown absence check: %v", err)
+	}
+}


### PR DESCRIPTION
This testcase needs CO installed from OLM and a catalogsource compliance-operator with the newer version of the operator available in the catalogsources in openshift-marketplace to be able to upgrade. 

It should work once PR #1001  is merged and it is partly using the logic I have already used to query the metrics in this PR #1083 - if it merges first, this PR needs to be rebased and slimmed. 