### PR TITLE
CMP-3871: Add testcase for ROSA HCP (73945) to upstream

### DIFF
--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -3,11 +3,13 @@ package framework
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -32,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 
-	"encoding/json"
+
 	"math"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
@@ -3551,4 +3553,210 @@ func (f *Framework) ClusterArchitecture() Architecture {
 		}
 	}
 	return ArchUNKNOWN
+}
+
+// RegisterComplianceResourceSchemes registers Compliance Operator and framework-related API types.
+// Call after cluster CRDs exist (for example after an OLM Subscription installs the operator CSV).
+func (f *Framework) RegisterComplianceResourceSchemes() error {
+	return f.addFrameworks()
+}
+
+// InitRosa73945FrameworkWithoutManifest switches to the project root and ensures the operator namespace exists.
+// Used when E2E_SKIP_FRAMEWORK_SETUP=true to install the operator via Subscription instead of YAML manifests.
+func (f *Framework) InitRosa73945FrameworkWithoutManifest() error {
+	log.Printf("switching to %s directory for ROSA 73945 OLM setup", f.projectRoot)
+	if err := os.Chdir(f.projectRoot); err != nil {
+		return fmt.Errorf("failed to change directory to project root: %w", err)
+	}
+	return f.ensureTestNamespaceExists()
+}
+
+func ocApplyYAMLString(yamlStr string) error {
+	ocPath, err := exec.LookPath("oc")
+	if err != nil {
+		return fmt.Errorf("oc binary not found: %w", err)
+	}
+	cmd := exec.Command(ocPath, "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(yamlStr)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("oc apply: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// InstallComplianceOperatorSubscriptionRosa73945 applies an OperatorGroup and Subscription with
+// PLATFORM=rosa in spec.config.env and a worker nodeSelector, matching TC 73945 / subscription_hypershift_env.
+func (f *Framework) InstallComplianceOperatorSubscriptionRosa73945(channel, catalogSource, catalogSourceNamespace string) error {
+	ns := f.OperatorNamespace
+	yamlDoc := fmt.Sprintf(`apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  targetNamespaces:
+  - %s
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: compliance-operator
+  namespace: %s
+spec:
+  channel: %s
+  installPlanApproval: Automatic
+  name: compliance-operator
+  source: %s
+  sourceNamespace: %s
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/worker: ""
+    env:
+    - name: PLATFORM
+      value: rosa
+`, ns, ns, ns, ns, channel, catalogSource, catalogSourceNamespace)
+
+	if err := ocApplyYAMLString(yamlDoc); err != nil {
+		return err
+	}
+	retryInterval := 5 * time.Second
+	timeout := 30 * time.Minute
+	return f.WaitForDeployment("compliance-operator", 1, retryInterval, timeout)
+}
+
+// SkipRosa73945Preconditions returns a skip reason if the cluster is not suitable for TC 73945, or "" if OK.
+// Expects Platform=rosa, hosted control plane (External topology), single-arch amd64 workers, and CatalogSource present.
+func (f *Framework) SkipRosa73945Preconditions(catalogSourceName, catalogSourceNamespace string) (string, error) {
+	if f.Platform != "rosa" {
+		return fmt.Sprintf("platform is %q (need --platform rosa)", f.Platform), nil
+	}
+	if f.OperatorNamespace != "openshift-compliance" {
+		return fmt.Sprintf("operator namespace is %q (set %s=openshift-compliance for TC 73945)", f.OperatorNamespace, TestOperatorNamespaceEnv), nil
+	}
+
+	// Use oc (not the dynamic client): before RegisterComplianceResourceSchemes, config.openshift.io
+	// types are not registered on the framework scheme.
+	infraOut, err := runOCandGetOutput([]string{
+		"get", "infrastructure", "cluster", "-o", "jsonpath={.status.controlPlaneTopology}",
+	})
+	if err != nil {
+		return "", fmt.Errorf("get infrastructure controlPlaneTopology: %w", err)
+	}
+	topology := strings.TrimSpace(infraOut)
+	if topology != string(configv1.ExternalTopologyMode) {
+		return fmt.Sprintf("ControlPlaneTopology is %q (ROSA HCP expects %q)", topology, configv1.ExternalTopologyMode), nil
+	}
+
+	nodes, err := f.KubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+	if len(nodes.Items) == 0 {
+		return "no nodes in cluster", nil
+	}
+	for _, n := range nodes.Items {
+		arch := n.Labels[corev1.LabelArchStable]
+		if arch != "" && arch != "amd64" {
+			return fmt.Sprintf("node %s has arch %q (TC 73945 expects single-arch amd64)", n.Name, arch), nil
+		}
+	}
+
+	out, err := runOCandGetOutput([]string{
+		"get", "catalogsources", catalogSourceName, "-n", catalogSourceNamespace,
+		"-o", "jsonpath={.metadata.name}",
+	})
+	if err != nil || strings.TrimSpace(out) == "" {
+		return fmt.Sprintf("CatalogSource %s/%s not found or not readable", catalogSourceNamespace, catalogSourceName), nil
+	}
+
+	return "", nil
+}
+
+// AssertSubscriptionConfigEnvContainsPlatformRosa checks that the compliance-operator Subscription's
+// spec.config.env includes PLATFORM=rosa (substring match on serialized env).
+func (f *Framework) AssertSubscriptionConfigEnvContainsPlatformRosa() error {
+	out, err := runOCandGetOutput([]string{
+		"get", "subscription", "compliance-operator", "-n", f.OperatorNamespace,
+		"-o", "jsonpath={.spec.config.env}",
+	})
+	if err != nil {
+		return fmt.Errorf("get subscription config env: %w", err)
+	}
+	if !strings.Contains(out, "rosa") {
+		return fmt.Errorf("expected subscription spec.config.env to contain PLATFORM rosa; got: %s", strings.TrimSpace(out))
+	}
+	return nil
+}
+
+// AssertScanSettingRolesJSON checks default ScanSetting roles match exactly ["worker"] (JSON array form).
+func (f *Framework) AssertScanSettingRolesJSON(scanSettingName string) error {
+	ss := &compv1alpha1.ScanSetting{}
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: scanSettingName, Namespace: f.OperatorNamespace}, ss)
+	if err != nil {
+		return fmt.Errorf("get ScanSetting %s: %w", scanSettingName, err)
+	}
+	b, err := json.Marshal(ss.Roles)
+	if err != nil {
+		return err
+	}
+	if string(b) != `["worker"]` {
+		return fmt.Errorf("ScanSetting %s roles want [\"worker\"] as JSON, got %s", scanSettingName, string(b))
+	}
+	return nil
+}
+
+// AssertScanSettingDoesNotExist fails if a ScanSetting exists with the given name.
+func (f *Framework) AssertScanSettingDoesNotExist(name string) error {
+	ss := &compv1alpha1.ScanSetting{}
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: f.OperatorNamespace}, ss)
+	if err == nil {
+		return fmt.Errorf("ScanSetting %s exists but must not", name)
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get ScanSetting %s: %w", name, err)
+	}
+	return nil
+}
+
+// AssertProfileDoesNotExist fails if a Profile exists with the given name.
+func (f *Framework) AssertProfileDoesNotExist(name string) error {
+	p := &compv1alpha1.Profile{}
+	err := f.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: f.OperatorNamespace}, p)
+	if err == nil {
+		return fmt.Errorf("Profile %s exists but must not", name)
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get Profile %s: %w", name, err)
+	}
+	return nil
+}
+
+// AssertSuiteScanExitCodesContainSubstring checks each ComplianceScan labeled for the suite
+// has a result ConfigMap whose exit-code data contains the given substring (e.g. "2" for non-compliant).
+func (f *Framework) AssertSuiteScanExitCodesContainSubstring(suiteName, wantSubstring string) error {
+	scanList := &compv1alpha1.ComplianceScanList{}
+	sel, err := labels.Parse(compv1alpha1.SuiteLabel + "=" + suiteName)
+	if err != nil {
+		return err
+	}
+	if err := f.Client.List(context.TODO(), scanList, &client.ListOptions{
+		Namespace:     f.OperatorNamespace,
+		LabelSelector: sel,
+	}); err != nil {
+		return fmt.Errorf("list scans for suite %s: %w", suiteName, err)
+	}
+	if len(scanList.Items) == 0 {
+		return fmt.Errorf("no ComplianceScans for suite label %s", suiteName)
+	}
+	for _, scan := range scanList.Items {
+		code, _, err := f.GetScanExitCodeAndErrorMsg(scan.Name, f.OperatorNamespace)
+		if err != nil {
+			return fmt.Errorf("scan %s: %w", scan.Name, err)
+		}
+		if !strings.Contains(strings.TrimSpace(code), wantSubstring) {
+			return fmt.Errorf("scan %s exit-code %q does not contain %q", scan.Name, code, wantSubstring)
+		}
+	}
+	return nil
 }

--- a/tests/e2e/rosa/main_test.go
+++ b/tests/e2e/rosa/main_test.go
@@ -8,6 +8,7 @@ import (
 
 	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/ComplianceAsCode/compliance-operator/tests/e2e/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var brokenContentImagePath string
@@ -15,13 +16,19 @@ var contentImagePath string
 
 func TestMain(m *testing.M) {
 	f := framework.NewFramework()
-	err := f.SetUp()
+	skipManifest := os.Getenv("E2E_SKIP_FRAMEWORK_SETUP") == "true"
+	var err error
+	if !skipManifest {
+		err = f.SetUp()
+	} else {
+		err = f.InitRosa73945FrameworkWithoutManifest()
+	}
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	exitCode := m.Run()
-	if exitCode == 0 || (exitCode > 0 && f.CleanUpOnError()) {
+	if !skipManifest && (exitCode == 0 || (exitCode > 0 && f.CleanUpOnError())) {
 		if err = f.TearDown(); err != nil {
 			log.Fatal(err)
 		}
@@ -30,6 +37,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestInstallOnlyParsesNodeProfiles(t *testing.T) {
+	if os.Getenv("E2E_SKIP_FRAMEWORK_SETUP") == "true" {
+		t.Skip("requires manifest-based SetUp; run without E2E_SKIP_FRAMEWORK_SETUP")
+	}
 	t.Parallel()
 	f := framework.Global
 
@@ -54,6 +64,9 @@ func TestInstallOnlyParsesNodeProfiles(t *testing.T) {
 }
 
 func TestScanSetting(t *testing.T) {
+	if os.Getenv("E2E_SKIP_FRAMEWORK_SETUP") == "true" {
+		t.Skip("requires manifest-based SetUp; run without E2E_SKIP_FRAMEWORK_SETUP")
+	}
 	f := framework.Global
 	// prinout all scan settings
 	scanSettingList := compv1alpha1.ScanSettingList{}
@@ -75,5 +88,110 @@ func TestScanSetting(t *testing.T) {
 			t.Logf("Role: %s", role)
 
 		}
+	}
+}
+
+// Test73945RosaHCPSubscriptionAndNodeProfilesScan ports TC 73945: ROSA HCP cluster with Compliance Operator
+// installed via OLM Subscription (PLATFORM=rosa in spec.config.env), hosted profile expectations, and a
+// two-profile node scan (ocp4-pci-dss-node + ocp4-cis-node) expecting COMPLIANT and exit code 0 in result ConfigMaps.
+//
+// Run (dedicated job only — this does not use manifest SetUp):
+//
+//	E2E_SKIP_FRAMEWORK_SETUP=true TEST_OPERATOR_NAMESPACE=openshift-compliance \
+//	  go test ./tests/e2e/rosa -v -args -root=<repo> -globalMan=<crd> -namespacedMan=<deploy> --platform rosa
+//
+// Optional: E2E_OLM_CHANNEL=stable E2E_OLM_SOURCE=redhat-operators E2E_OLM_SOURCE_NAMESPACE=openshift-marketplace
+func Test73945RosaHCPSubscriptionAndNodeProfilesScan(t *testing.T) {
+	if os.Getenv("E2E_SKIP_FRAMEWORK_SETUP") != "true" {
+		t.Skip("TC 73945 requires OLM Subscription install: set E2E_SKIP_FRAMEWORK_SETUP=true and TEST_OPERATOR_NAMESPACE=openshift-compliance")
+	}
+	f := framework.Global
+
+	channel := os.Getenv("E2E_OLM_CHANNEL")
+	if channel == "" {
+		channel = "stable"
+	}
+	catalogSource := os.Getenv("E2E_OLM_SOURCE")
+	if catalogSource == "" {
+		catalogSource = "redhat-operators"
+	}
+	catalogNS := os.Getenv("E2E_OLM_SOURCE_NAMESPACE")
+	if catalogNS == "" {
+		catalogNS = "openshift-marketplace"
+	}
+
+	skipReason, err := f.SkipRosa73945Preconditions(catalogSource, catalogNS)
+	if err != nil {
+		t.Fatalf("73945 preconditions: %v", err)
+	}
+	if skipReason != "" {
+		t.Skip(skipReason)
+	}
+
+	if err := f.InstallComplianceOperatorSubscriptionRosa73945(channel, catalogSource, catalogNS); err != nil {
+		t.Fatalf("install via Subscription: %v", err)
+	}
+	if err := f.RegisterComplianceResourceSchemes(); err != nil {
+		t.Fatalf("register compliance schemes: %v", err)
+	}
+
+	if err := f.WaitForProfileBundleStatus("ocp4", compv1alpha1.DataStreamValid); err != nil {
+		t.Fatalf("ocp4 profile bundle not VALID: %v", err)
+	}
+	if err := f.WaitForProfileBundleStatus("rhcos4", compv1alpha1.DataStreamValid); err != nil {
+		t.Fatalf("rhcos4 profile bundle not VALID: %v", err)
+	}
+
+	if err := f.AssertSubscriptionConfigEnvContainsPlatformRosa(); err != nil {
+		t.Fatalf("subscription PLATFORM env: %v", err)
+	}
+	if err := f.AssertScanSettingRolesJSON("default"); err != nil {
+		t.Fatalf("ScanSetting default roles: %v", err)
+	}
+	if err := f.AssertScanSettingDoesNotExist("default-auto-apply"); err != nil {
+		t.Fatalf("ScanSetting default-auto-apply must not exist: %v", err)
+	}
+	if err := f.AssertProfileDoesNotExist("ocp4-cis"); err != nil {
+		t.Fatalf("Profile ocp4-cis must not exist on hosted profile set: %v", err)
+	}
+
+	ssbName := framework.GetObjNameFromTest(t) + "-73945"
+	ssb := &compv1alpha1.ScanSettingBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ssbName,
+			Namespace: f.OperatorNamespace,
+		},
+		Profiles: []compv1alpha1.NamedObjectReference{
+			{
+				Name:     "ocp4-pci-dss-node",
+				Kind:     "Profile",
+				APIGroup: "compliance.openshift.io/v1alpha1",
+			},
+			{
+				Name:     "ocp4-cis-node",
+				Kind:     "Profile",
+				APIGroup: "compliance.openshift.io/v1alpha1",
+			},
+		},
+		SettingsRef: &compv1alpha1.NamedObjectReference{
+			Name:     "default",
+			Kind:     "ScanSetting",
+			APIGroup: "compliance.openshift.io/v1alpha1",
+		},
+	}
+	if err := f.Client.Create(context.TODO(), ssb, nil); err != nil {
+		t.Fatalf("create ScanSettingBinding %s: %v", ssbName, err)
+	}
+	defer func() {
+		if err := f.DeleteScanSettingBindingAndWaitForCleanup(ssb); err != nil {
+			t.Logf("cleanup ScanSettingBinding %s: %v", ssbName, err)
+		}
+	}()
+
+	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, ssbName, compv1alpha1.PhaseDone, compv1alpha1.ResultCompliant); err != nil {
+		t.Fatalf("suite %s not DONE/COMPLIANT: %v", ssbName, err)
+	}
+	if err := f.AssertSuiteScanExitCodesContainSubstring(ssbName, "0"); err != nil {
+		t.Fatalf("scan exit-code in result ConfigMaps: %v", err)
 	}
 }


### PR DESCRIPTION
Testcase passed on ROSA HCP 4.20 cluster: 

```
E2E_SKIP_FRAMEWORK_SETUP=true \
TEST_OPERATOR_NAMESPACE=openshift-compliance \
go test ./tests/e2e/rosa -v \
  -run Test73945RosaHCPSubscriptionAndNodeProfilesScan \
  -timeout 120m \
  -args \
    -root="$(pwd)" \
    -globalMan=tests/_setup/crd.yaml \
    -namespacedMan=tests/_setup/deploy_rbac.yaml \
    --platform rosa
2026/04/07 18:24:58 switching to /home/akoudelk/work_repos/CaC_compliance_op/compliance-operator directory for ROSA 73945 OLM setup
2026/04/07 18:24:59 creating namespace openshift-compliance
=== RUN   Test73945RosaHCPSubscriptionAndNodeProfilesScan
2026/04/07 18:25:07 Waiting for availability of Deployment: compliance-operator in Namespace: openshift-compliance 
2026/04/07 18:25:12 Waiting for full availability of compliance-operator deployment (0/1)
2026/04/07 18:25:17 Deployment available (1/1)
2026/04/07 18:25:28 waiting ProfileBundle ocp4 to become VALID (PENDING)
2026/04/07 18:25:33 waiting ProfileBundle ocp4 to become VALID (PENDING)
2026/04/07 18:25:38 waiting ProfileBundle ocp4 to become VALID (PENDING)
2026/04/07 18:25:43 waiting ProfileBundle ocp4 to become VALID (PENDING)
2026/04/07 18:25:48 waiting ProfileBundle ocp4 to become VALID (PENDING)
2026/04/07 18:25:53 ProfileBundle ready (VALID)
2026/04/07 18:25:59 waiting ProfileBundle rhcos4 to become VALID (PENDING)
2026/04/07 18:26:04 waiting ProfileBundle rhcos4 to become VALID (PENDING)
2026/04/07 18:26:09 waiting ProfileBundle rhcos4 to become VALID (PENDING)
2026/04/07 18:26:14 waiting ProfileBundle rhcos4 to become VALID (PENDING)
2026/04/07 18:26:18 waiting ProfileBundle rhcos4 to become VALID (PENDING)
2026/04/07 18:26:24 waiting ProfileBundle rhcos4 to become VALID (PENDING)
2026/04/07 18:26:29 waiting ProfileBundle rhcos4 to become VALID (PENDING)
2026/04/07 18:26:33 waiting ProfileBundle rhcos4 to become VALID (PENDING)
2026/04/07 18:26:39 waiting ProfileBundle rhcos4 to become VALID (PENDING)
2026/04/07 18:26:44 ProfileBundle ready (VALID)
2026/04/07 18:26:51 waiting until suite test73945-rosa-h-c-p-subscription-and-node-profiles-scan-73945 reaches target status 'DONE'. Current status: LAUNCHING
2026/04/07 18:26:55 waiting until suite test73945-rosa-h-c-p-subscription-and-node-profiles-scan-73945 reaches target status 'DONE'. Current status: RUNNING
2026/04/07 18:27:00 waiting until suite test73945-rosa-h-c-p-subscription-and-node-profiles-scan-73945 reaches target status 'DONE'. Current status: RUNNING
2026/04/07 18:27:05 waiting until suite test73945-rosa-h-c-p-subscription-and-node-profiles-scan-73945 reaches target status 'DONE'. Current status: RUNNING
2026/04/07 18:27:11 waiting until suite test73945-rosa-h-c-p-subscription-and-node-profiles-scan-73945 reaches target status 'DONE'. Current status: RUNNING
2026/04/07 18:27:16 waiting until suite test73945-rosa-h-c-p-subscription-and-node-profiles-scan-73945 reaches target status 'DONE'. Current status: RUNNING
2026/04/07 18:27:21 waiting until suite test73945-rosa-h-c-p-subscription-and-node-profiles-scan-73945 reaches target status 'DONE'. Current status: RUNNING
2026/04/07 18:27:26 waiting until suite test73945-rosa-h-c-p-subscription-and-node-profiles-scan-73945 reaches target status 'DONE'. Current status: RUNNING
2026/04/07 18:27:31 waiting until suite test73945-rosa-h-c-p-subscription-and-node-profiles-scan-73945 reaches target status 'DONE'. Current status: AGGREGATING
2026/04/07 18:27:36 waiting until suite test73945-rosa-h-c-p-subscription-and-node-profiles-scan-73945 reaches target status 'DONE'. Current status: AGGREGATING
2026/04/07 18:27:41 waiting until suite test73945-rosa-h-c-p-subscription-and-node-profiles-scan-73945 reaches target status 'DONE'. Current status: AGGREGATING
2026/04/07 18:27:46 waiting until suite test73945-rosa-h-c-p-subscription-and-node-profiles-scan-73945 reaches target status 'DONE'. Current status: AGGREGATING
2026/04/07 18:27:56 ComplianceScan ready (DONE)
2026/04/07 18:28:01 ComplianceScan ready (DONE)
2026/04/07 18:28:01 All scans in ComplianceSuite have finished (test73945-rosa-h-c-p-subscription-and-node-profiles-scan-73945)
--- PASS: Test73945RosaHCPSubscriptionAndNodeProfilesScan (188.57s)
PASS
ok  	github.com/ComplianceAsCode/compliance-operator/tests/e2e/rosa	189.247s
```