### PR TITLE
CMP-3916: Cherry-pick Add runtime SSH configuration validation for compliance scans

### DIFF
--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -1076,7 +1076,38 @@ func (r *ReconcileComplianceScan) deleteKubeletConfigConfigMaps(instance *compv1
 // returns true if the pod is still running, false otherwise
 func isPodRunningInNode(r *ReconcileComplianceScan, scanInstance *compv1alpha1.ComplianceScan, node *corev1.Node, timeout time.Duration, logger logr.Logger) (bool, error) {
 	podName := getPodForNodeName(scanInstance.Name, node.Name)
-	return isPodRunning(r, podName, common.GetComplianceOperatorNamespace(), timeout, logger)
+	running, err := isPodRunning(r, podName, common.GetComplianceOperatorNamespace(), timeout, logger)
+	if !running && err == nil {
+		// Pod finished successfully — check init container termination messages
+		// for warnings (e.g. sshd config failures) and surface them as events.
+		checkInitContainerWarnings(r, scanInstance, podName, logger)
+	}
+	return running, err
+}
+
+// checkInitContainerWarnings inspects init container termination messages and
+// emits warning events on the ComplianceScan for any that reported issues.
+func checkInitContainerWarnings(r *ReconcileComplianceScan, scan *compv1alpha1.ComplianceScan, podName string, logger logr.Logger) {
+	pod := &corev1.Pod{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      podName,
+		Namespace: common.GetComplianceOperatorNamespace(),
+	}, pod)
+	if err != nil {
+		return
+	}
+	for i := range pod.Status.InitContainerStatuses {
+		status := &pod.Status.InitContainerStatuses[i]
+		if status.State.Terminated != nil && status.State.Terminated.Message != "" {
+			logger.Info("Init container reported warning",
+				"container", status.Name,
+				"message", status.State.Terminated.Message,
+				"pod", podName)
+			r.Recorder.Eventf(scan, corev1.EventTypeWarning, "InitContainerWarning",
+				"Init container %q in pod %s: %s",
+				status.Name, podName, status.State.Terminated.Message)
+		}
+	}
 }
 
 // returns true if the pod is still running, false otherwise

--- a/pkg/controller/compliancescan/compliancescan_controller_test.go
+++ b/pkg/controller/compliancescan/compliancescan_controller_test.go
@@ -6,6 +6,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"time"
 
 	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
@@ -421,6 +425,204 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 				Expect(err).To(BeNil())
 				Expect(compliancescaninstance.Status.Phase).To(Equal(compv1alpha1.PhaseRunning))
 			})
+			It("should create scan pods with the runtime SSH config init container", func() {
+				_, err := reconciler.phaseLaunchingHandler(handler, logger)
+				Expect(err).To(BeNil())
+
+				pods := &corev1.PodList{}
+				err = reconciler.Client.List(context.TODO(), pods, client.MatchingLabels{
+					compv1alpha1.ComplianceScanLabel: compliancescaninstance.Name,
+				})
+				Expect(err).To(BeNil())
+				Expect(pods.Items).ToNot(BeEmpty())
+
+				for _, pod := range pods.Items {
+					var initContainer *corev1.Container
+					for i := range pod.Spec.InitContainers {
+						if pod.Spec.InitContainers[i].Name == RuntimeSSHConfigInitContainer {
+							initContainer = &pod.Spec.InitContainers[i]
+							break
+						}
+					}
+					Expect(initContainer).ToNot(BeNil(),
+						"expected init container %s in pod %s", RuntimeSSHConfigInitContainer, pod.Name)
+
+					var hasRuntimeVol, hasHostVol bool
+					for _, vm := range initContainer.VolumeMounts {
+						if vm.Name == RuntimeConfigVolumeName && vm.MountPath == RuntimeConfigFolder {
+							hasRuntimeVol = true
+						}
+						if vm.Name == "host" && vm.MountPath == "/host" {
+							hasHostVol = true
+						}
+					}
+					Expect(hasRuntimeVol).To(BeTrue(), "expected runtime config volume mount in pod %s", pod.Name)
+					Expect(hasHostVol).To(BeTrue(), "expected host volume mount in pod %s", pod.Name)
+
+					var scanner *corev1.Container
+					for i := range pod.Spec.Containers {
+						if pod.Spec.Containers[i].Name == OpenSCAPScanContainerName {
+							scanner = &pod.Spec.Containers[i]
+							break
+						}
+					}
+					Expect(scanner).ToNot(BeNil())
+
+					var readOnlyMount bool
+					for _, vm := range scanner.VolumeMounts {
+						if vm.Name == RuntimeConfigVolumeName && vm.MountPath == RuntimeConfigFolder && vm.ReadOnly {
+							readOnlyMount = true
+							break
+						}
+					}
+					Expect(readOnlyMount).To(BeTrue(),
+						"expected runtime config volume to be mounted read-only in scanner container of pod %s", pod.Name)
+				}
+			})
+
+			// runInitScript runs a script that mirrors the init container logic
+			// using the provided sshdBin path instead of chroot /host/usr/sbin/sshd.
+			// Uses terminationLog as a stand-in for /dev/termination-log (not writable in tests).
+			// Returns combined stdout/stderr output and any exec error.
+			runInitScript := func(runtimeDir, configPath, sshdBin, terminationLog string) (string, error) {
+				script := fmt.Sprintf(`mkdir -p %[1]s && \
+if [ -x %[3]s ]; then \
+  %[3]s -T > /tmp/sshd_out 2>/tmp/sshd_err; \
+  SSHD_EXIT=$?; \
+  if [ $SSHD_EXIT -eq 0 ] && [ -s /tmp/sshd_out ]; then \
+    tr '[:upper:]' '[:lower:]' < /tmp/sshd_out > %[2]s && \
+    chmod 644 %[2]s 2>/dev/null || true; \
+    echo "INFO: Successfully generated effective SSH configuration"; \
+  else \
+    MSG="sshd -T failed (exit code: $SSHD_EXIT). $(cat /tmp/sshd_err 2>/dev/null)"; \
+    echo "WARNING: $MSG"; \
+    echo "$MSG" > %[4]s; \
+  fi; \
+else \
+  echo "INFO: sshd not found at %[3]s, skipping runtime SSH config generation"; \
+fi`, runtimeDir, configPath, sshdBin, terminationLog)
+				cmd := exec.Command("bash", "-c", script)
+				out, err := cmd.CombinedOutput()
+				return string(out), err
+			}
+
+			// Observed on RHCOS 9.6 node:
+			//   - sshd binary missing:  no output, pod exits 0, no config file created
+			//   - sshd -T bad config:   exit 255, stderr e.g. "line 1: Bad configuration option: InvalidDirective"
+			//                           no config file created, termination message written
+			//   - sshd -T valid config: exit 0, 94 lines of lowercase effective config
+
+			It("should not create config file when sshd binary does not exist", func() {
+				tmpDir, err := os.MkdirTemp("", "sshd-test-*")
+				Expect(err).ToNot(HaveOccurred())
+				defer os.RemoveAll(tmpDir)
+
+				runtimeDir := filepath.Join(tmpDir, "runtime")
+				configPath := filepath.Join(runtimeDir, "sshd_effective_config")
+				terminationLog := filepath.Join(tmpDir, "termination-log")
+
+				output, err := runInitScript(runtimeDir, configPath,
+					filepath.Join(tmpDir, "usr", "sbin", "sshd"), terminationLog)
+				Expect(err).ToNot(HaveOccurred(), "script must not crash, output: %s", output)
+				Expect(output).To(ContainSubstring("sshd not found"))
+
+				// Config file should NOT be created
+				_, err = os.Stat(configPath)
+				Expect(os.IsNotExist(err)).To(BeTrue(), "config file should not exist when sshd is missing")
+
+				// No termination message for missing binary (this is expected, not an error)
+				_, err = os.Stat(terminationLog)
+				Expect(os.IsNotExist(err)).To(BeTrue(), "no termination message for missing sshd")
+			})
+
+			It("should not create config file and write termination message when sshd -T fails (exit 255)", func() {
+				tmpDir, err := os.MkdirTemp("", "sshd-test-*")
+				Expect(err).ToNot(HaveOccurred())
+				defer os.RemoveAll(tmpDir)
+
+				runtimeDir := filepath.Join(tmpDir, "runtime")
+				configPath := filepath.Join(runtimeDir, "sshd_effective_config")
+				terminationLog := filepath.Join(tmpDir, "termination-log")
+
+				// Fake sshd that mimics real sshd behavior with a bad drop-in config:
+				//   exit 255, stderr shows file:line and "Bad configuration option"
+				sshdDir := filepath.Join(tmpDir, "usr", "sbin")
+				Expect(os.MkdirAll(sshdDir, 0755)).To(Succeed())
+				fakeSshd := filepath.Join(sshdDir, "sshd")
+				Expect(os.WriteFile(fakeSshd, []byte(
+					"#!/bin/sh\n"+
+						"echo '/etc/ssh/sshd_config.d/99-bad.conf: line 1: Bad configuration option: InvalidDirective' >&2\n"+
+						"echo '/etc/ssh/sshd_config.d/99-bad.conf: terminating, 1 bad configuration options' >&2\n"+
+						"exit 255\n",
+				), 0755)).To(Succeed())
+
+				output, err := runInitScript(runtimeDir, configPath, fakeSshd, terminationLog)
+				Expect(err).ToNot(HaveOccurred(), "script must not crash, output: %s", output)
+				Expect(output).To(ContainSubstring("WARNING:"))
+				Expect(output).To(ContainSubstring("sshd -T failed (exit code: 255)"))
+				Expect(output).To(ContainSubstring("Bad configuration option: InvalidDirective"))
+
+				// Config file should NOT be created
+				_, err = os.Stat(configPath)
+				Expect(os.IsNotExist(err)).To(BeTrue(), "config file should not exist when sshd -T fails")
+
+				// Termination message should contain the error details
+				termMsg, err := os.ReadFile(terminationLog)
+				Expect(err).ToNot(HaveOccurred(), "termination log should exist")
+				Expect(string(termMsg)).To(ContainSubstring("sshd -T failed (exit code: 255)"))
+				Expect(string(termMsg)).To(ContainSubstring("Bad configuration option: InvalidDirective"))
+			})
+
+			It("should generate lowercase effective config when sshd -T succeeds", func() {
+				tmpDir, err := os.MkdirTemp("", "sshd-test-*")
+				Expect(err).ToNot(HaveOccurred())
+				defer os.RemoveAll(tmpDir)
+
+				runtimeDir := filepath.Join(tmpDir, "runtime")
+				configPath := filepath.Join(runtimeDir, "sshd_effective_config")
+				terminationLog := filepath.Join(tmpDir, "termination-log")
+
+				// Fake sshd that outputs config matching real RHCOS sshd -T output
+				sshdDir := filepath.Join(tmpDir, "usr", "sbin")
+				Expect(os.MkdirAll(sshdDir, 0755)).To(Succeed())
+				fakeSshd := filepath.Join(sshdDir, "sshd")
+				Expect(os.WriteFile(fakeSshd, []byte(
+					"#!/bin/sh\n"+
+						"echo 'Port 22'\n"+
+						"echo 'AddressFamily any'\n"+
+						"echo 'PermitRootLogin no'\n"+
+						"echo 'PasswordAuthentication no'\n"+
+						"echo 'GSSAPIAuthentication yes'\n"+
+						"echo 'ClientAliveInterval 180'\n"+
+						"echo 'UsePAM yes'\n"+
+						"echo 'X11Forwarding yes'\n",
+				), 0755)).To(Succeed())
+
+				output, err := runInitScript(runtimeDir, configPath, fakeSshd, terminationLog)
+				Expect(err).ToNot(HaveOccurred(), "script must not crash, output: %s", output)
+				Expect(output).To(ContainSubstring("Successfully generated effective SSH configuration"))
+
+				content, err := os.ReadFile(configPath)
+				Expect(err).ToNot(HaveOccurred())
+				contentStr := strings.TrimSpace(string(content))
+				// All values must be lowercased
+				Expect(contentStr).To(ContainSubstring("port 22"))
+				Expect(contentStr).To(ContainSubstring("addressfamily any"))
+				Expect(contentStr).To(ContainSubstring("permitrootlogin no"))
+				Expect(contentStr).To(ContainSubstring("passwordauthentication no"))
+				Expect(contentStr).To(ContainSubstring("gssapiauthentication yes"))
+				Expect(contentStr).To(ContainSubstring("clientaliveinterval 180"))
+				Expect(contentStr).To(ContainSubstring("usepam yes"))
+				Expect(contentStr).To(ContainSubstring("x11forwarding yes"))
+
+				info, err := os.Stat(configPath)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(info.Size()).To(BeNumerically(">", 0), "config file should not be empty")
+
+				// No termination message on success
+				_, err = os.Stat(terminationLog)
+				Expect(os.IsNotExist(err)).To(BeTrue(), "no termination message on success")
+			})
 		})
 	})
 
@@ -677,3 +879,4 @@ var _ = Describe("Testing compliancescan controller phases", func() {
 		})
 	})
 })
+

--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -29,6 +29,12 @@ const (
 	// This is the folder where the kubeletconfig would be linked in the host
 	KubeletConfigLinkFolder = "/host/var/run/compliance-operator"
 
+	// Runtime SSH configuration constants
+	RuntimeConfigVolumeName       = "runtime-config"
+	RuntimeConfigFolder           = "/host/tmp/runtime"
+	RuntimeSSHConfigPath          = "/host/tmp/runtime/sshd_effective_config"
+	RuntimeSSHConfigInitContainer = "runtime-sshd-config-helper"
+
 	// a configMap with env vars for the script
 	OpenScapEnvConfigMapName = "openscap-env-map"
 	// A configMap same as above but minus hostroot

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -422,6 +422,12 @@ func getNodeScannerPodVolumes(instance *compv1alpha1.ComplianceScan, node *corev
 				},
 			},
 		},
+		{
+			Name: RuntimeConfigVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 	}
 	if instance.Spec.RawResultStorage.Enabled != nil && *instance.Spec.RawResultStorage.Enabled {
 		volumesList = append(volumesList, corev1.Volume{

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -68,6 +68,25 @@ func scanLimits(scanInstance *compv1alpha1.ComplianceScan, defaultMem, defaultCp
 	return &limits
 }
 
+func runtimeSSHConfigCommand() string {
+	return fmt.Sprintf(`mkdir -p %[1]s && \
+if [ -x /host/usr/sbin/sshd ]; then \
+  chroot /host /usr/sbin/sshd -T > /tmp/sshd_out 2>/tmp/sshd_err; \
+  SSHD_EXIT=$?; \
+  if [ $SSHD_EXIT -eq 0 ] && [ -s /tmp/sshd_out ]; then \
+    tr '[:upper:]' '[:lower:]' < /tmp/sshd_out > %[2]s && \
+    chmod 644 %[2]s 2>/dev/null || true; \
+    echo "INFO: Successfully generated effective SSH configuration"; \
+  else \
+    MSG="sshd -T failed (exit code: $SSHD_EXIT). $(cat /tmp/sshd_err 2>/dev/null)"; \
+    echo "WARNING: $MSG"; \
+    echo "$MSG" > /dev/termination-log; \
+  fi; \
+else \
+  echo "INFO: sshd not found at /host/usr/sbin/sshd, skipping runtime SSH config generation"; \
+fi`, RuntimeConfigFolder, RuntimeSSHConfigPath)
+}
+
 func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.Node, logger logr.Logger) *corev1.Pod {
 
 	podName := getPodForNodeName(scanInstance.Name, node.Name)
@@ -137,7 +156,7 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 					},
 					ImagePullPolicy: corev1.PullAlways,
 					SecurityContext: &corev1.SecurityContext{
-						Privileged:             &trueVal,
+						Privileged:             &trueP,
 						ReadOnlyRootFilesystem: &trueP,
 					},
 					Resources: corev1.ResourceRequirements{
@@ -159,6 +178,40 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 							Name:      "kubeletconfig",
 							ReadOnly:  true,
 							MountPath: KubeletConfigMapPath,
+						},
+					},
+				},
+				{
+					Name:  RuntimeSSHConfigInitContainer,
+					Image: utils.GetComponentImage(utils.OPERATOR),
+					Command: []string{
+						"sh",
+						"-c",
+						runtimeSSHConfigCommand(),
+					},
+					ImagePullPolicy: corev1.PullAlways,
+					SecurityContext: &corev1.SecurityContext{
+						Privileged:             &trueP,
+						ReadOnlyRootFilesystem: &falseP,
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("10Mi"),
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "host",
+							MountPath: "/host",
+						},
+						{
+							Name:      RuntimeConfigVolumeName,
+							MountPath: RuntimeConfigFolder,
 						},
 					},
 				},
@@ -255,6 +308,11 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						{
 							Name:      "kubeletconfig",
 							MountPath: KubeletConfigMapPath,
+							ReadOnly:  true,
+						},
+						{
+							Name:      RuntimeConfigVolumeName,
+							MountPath: RuntimeConfigFolder,
 							ReadOnly:  true,
 						},
 					},

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -2413,6 +2413,127 @@ func TestScanTailoredProfileExtendsDeprecated(t *testing.T) {
 	}
 }
 
+func TestRuntimeSSHConfigWithRemediation(t *testing.T) {
+	f := framework.Global
+
+	baselineImage := fmt.Sprintf("%s:%s", brokenContentImagePath, "runtime_sshd")
+	pbName := framework.GetObjNameFromTest(t)
+
+	rhcos4Pb, err := f.CreateProfileBundle(pbName, baselineImage, framework.RhcosContentFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Client.Delete(context.TODO(), rhcos4Pb)
+	if err := f.WaitForProfileBundleStatus(pbName, compv1alpha1.DataStreamValid); err != nil {
+		t.Fatal(err)
+	}
+
+	// This test applies an SSH remediation and verifies runtime checks still work
+	suiteName := "test-runtime-ssh-remediation"
+	scanName := fmt.Sprintf("%s-scan", suiteName)
+
+	suite := &compv1alpha1.ComplianceSuite{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      suiteName,
+			Namespace: f.OperatorNamespace,
+		},
+		Spec: compv1alpha1.ComplianceSuiteSpec{
+			ComplianceSuiteSettings: compv1alpha1.ComplianceSuiteSettings{
+				AutoApplyRemediations: true,
+			},
+			Scans: []compv1alpha1.ComplianceScanSpecWrapper{
+				{
+					ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
+						ContentImage: baselineImage,
+						Profile:      "xccdf_org.ssgproject.content_profile_e8",
+						Rule:         "xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth",
+						Content:      framework.RhcosContentFile,
+						NodeSelector: framework.GetPoolNodeRoleSelector(),
+						ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+							Debug: true,
+						},
+					},
+					Name: scanName,
+				},
+			},
+		},
+	}
+
+	if err := f.Client.Create(context.TODO(), suite, nil); err != nil {
+		t.Fatalf("failed to create ComplianceSuite: %s", err)
+	}
+	defer f.Client.Delete(context.TODO(), suite)
+
+	// Get the MachineConfigPool before remediation
+	poolBeforeRemediation := &mcfgv1.MachineConfigPool{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: framework.TestPoolName}, poolBeforeRemediation); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for initial scan to complete - it should be non-compliant
+	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant); err != nil {
+		// Might already be compliant if previously remediated
+		if err2 := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultCompliant); err2 != nil {
+			t.Fatalf("initial scan did not complete: %v", err)
+		}
+		t.Log("System already compliant, skipping remediation test")
+		return
+	}
+
+	// Check that remediation was auto-applied
+	remName := fmt.Sprintf("%s-sshd-disable-gssapi-auth", scanName)
+	if err := f.WaitForRemediationToBeAutoApplied(remName, f.OperatorNamespace, poolBeforeRemediation); err != nil {
+		t.Logf("Remediation might not be needed or already applied: %v", err)
+	}
+
+	// Re-run the scan to verify compliance with runtime checking
+	if err := f.ReRunScan(scanName, f.OperatorNamespace); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for re-scan to complete - should be compliant now
+	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultCompliant); err != nil {
+		t.Logf("WARNING: Re-scan was not compliant after remediation: %v", err)
+	}
+
+	// Verify the runtime config was still created and used in the re-scan
+	t.Log("Verifying runtime SSH config was used in re-scan after remediation")
+
+	// Get the check result for the SSH rule
+	checkName := fmt.Sprintf("%s-sshd-disable-gssapi-auth", scanName)
+	check := &compv1alpha1.ComplianceCheckResult{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      checkName,
+		Namespace: f.OperatorNamespace,
+	}, check); err != nil {
+		t.Logf("Could not get check result %s: %v", checkName, err)
+	} else {
+		t.Logf("SSH check after remediation - Status: %s", check.Status)
+		if check.Status == compv1alpha1.CheckResultPass {
+			t.Log("SUCCESS: SSH configuration check passed after remediation (runtime config verified)")
+		}
+	}
+
+	// Clean up the remediation if it was applied
+	rem := &compv1alpha1.ComplianceRemediation{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{
+		Name:      remName,
+		Namespace: f.OperatorNamespace,
+	}, rem); err == nil {
+		// Unapply the remediation
+		if err := f.UnApplyRemediationAndCheck(f.OperatorNamespace, remName, framework.TestPoolName); err != nil {
+			t.Logf("Could not unapply remediation: %v", err)
+		}
+
+		// Wait for nodes to be ready again
+		if err := f.WaitForNodesToBeReady(); err != nil {
+			t.Logf("Nodes did not become ready after remediation removal: %v", err)
+		}
+	}
+
+	t.Log("Runtime SSH configuration with remediation test completed")
+}
+
 //testExecution{
 //	Name:       "TestNodeSchedulingErrorFailsTheScan",
 //	IsParallel: false,


### PR DESCRIPTION
Cherry-pick of #961 to `release-1.9`

Surface sshd config failures as events, add logging for SSH config errors with unit tests, and support runtime SSH configuration in the init container.