### PR TITLE
CMP-3843: Add check for the default value of a variable

### DIFF
--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -5611,6 +5611,11 @@ func TestRuleVariableAnnotation(t *testing.T) {
 			expectedVariable: "var-statefulset-limit-namespaces-exempt-regex",
 			description:      "StatefulSet resource limit namespace exemption variable",
 		},
+		{
+			ruleName:         "ocp4-api-server-request-timeout",
+			expectedVariable: "var-api-min-request-timeout",
+			description:      "API server request timeout variable",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -5637,6 +5642,27 @@ func TestRuleVariableAnnotation(t *testing.T) {
 			if variableAnnotation != tc.expectedVariable {
 				t.Fatalf("Rule %s has incorrect variable annotation.\nExpected: %s\nGot: %s\nDescription: %s",
 					tc.ruleName, tc.expectedVariable, variableAnnotation, tc.description)
+			}
+
+			if tc.expectedVariable == "var-api-min-request-timeout" {
+				prefix, _, ok := strings.Cut(tc.ruleName, "-")
+				if !ok {
+					t.Fatalf("rule name %q has no product prefix", tc.ruleName)
+				}
+				variableCRName := prefix + "-" + tc.expectedVariable
+				v := &compv1alpha1.Variable{}
+				err = f.Client.Get(context.TODO(), types.NamespacedName{
+					Name:      variableCRName,
+					Namespace: f.OperatorNamespace,
+				}, v)
+				if err != nil {
+					t.Fatalf("Failed to get Variable %s: %v", variableCRName, err)
+				}
+				const wantDefault = "3600"
+				if v.Value != wantDefault {
+					t.Fatalf("Variable %s default Value: want %q, got %q", variableCRName, wantDefault, v.Value)
+				}
+				t.Logf("Variable %s has expected default value %s", variableCRName, wantDefault)
 			}
 
 			t.Logf("Rule %s correctly has variable annotation: %s", tc.ruleName, tc.expectedVariable)


### PR DESCRIPTION
The downstream test case 47162 checks if the default value of the variable ocp4-var-api-min-request-timeout is 3600. Adding this check to already existing parallel testcase TestRuleVariableAnnotation. 

Testcase passes on OCP 4.21: 
```
=== RUN   TestRuleVariableAnnotation
=== PAUSE TestRuleVariableAnnotation
=== CONT  TestRuleVariableAnnotation
=== RUN   TestRuleVariableAnnotation/ocp4-configure-network-policies-namespaces
    main_test.go:5668: Rule ocp4-configure-network-policies-namespaces correctly has variable annotation: var-network-policies-namespaces-exempt-regex
=== RUN   TestRuleVariableAnnotation/ocp4-resource-requests-limits-in-statefulset
    main_test.go:5668: Rule ocp4-resource-requests-limits-in-statefulset correctly has variable annotation: var-statefulset-limit-namespaces-exempt-regex
=== RUN   TestRuleVariableAnnotation/ocp4-api-server-request-timeout
    main_test.go:5665: Variable ocp4-var-api-min-request-timeout has expected default value 3600
    main_test.go:5668: Rule ocp4-api-server-request-timeout correctly has variable annotation: var-api-min-request-timeout
--- PASS: TestRuleVariableAnnotation (0.84s)
    --- PASS: TestRuleVariableAnnotation/ocp4-configure-network-policies-namespaces (0.23s)
    --- PASS: TestRuleVariableAnnotation/ocp4-resource-requests-limits-in-statefulset (0.15s)
    --- PASS: TestRuleVariableAnnotation/ocp4-api-server-request-timeout (0.47s)
PASS
...
ok  	github.com/ComplianceAsCode/compliance-operator/tests/e2e/parallel	193.808s
```
