### PR TITLE
CMP-4249: Add go version check into container files

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,23 @@
 # Step one: build compliance-operator
-FROM golang:1.25 AS builder
+FROM golang:1.25.8 AS builder
 
 WORKDIR /go/src/github.com/openshift/compliance-operator
 
 ENV GOFLAGS=-mod=vendor
 
-COPY . . 
+COPY . .
+
+# Verify the Go version in the builder image matches go.mod. Patch versions
+# carry security fixes and CVE scanners use go.mod to determine the Go
+# version, so these must stay in sync.
+RUN expected=$(awk '/^go / { print $2 }' go.mod) && \
+    actual=$(go version | awk '{print $3}' | sed 's/go//') && \
+    if [ "$expected" != "$actual" ]; then \
+        echo "Go version mismatch: go.mod expects go${expected} but builder image has go${actual}." && \
+        echo "Update go.mod or the builder image to resolve this." && \
+        exit 1; \
+    fi
+
 RUN make manager
 
 # Step two: containerize compliance-operator

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ComplianceAsCode/compliance-operator
 
-go 1.25.3
+go 1.25.8
 
 require (
 	github.com/ComplianceAsCode/compliance-sdk v0.0.0-20250930163558-59886979dd19

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -1,10 +1,21 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.8 as builder
 
 WORKDIR /go/src/github.com/ComplianceAsCode/compliance-operator
 
 ENV GOFLAGS="-mod=vendor" BUILD_FLAGS="-tags strictfipsruntime"
 
 COPY . .
+
+# Verify the Go version in the builder image matches go.mod. Patch versions
+# carry security fixes and CVE scanners use go.mod to determine the Go
+# version, so these must stay in sync.
+RUN expected=$(awk '/^go / { print $2 }' go.mod) && \
+    actual=$(go version | awk '{print $3}' | sed 's/go//') && \
+    if [ "$expected" != "$actual" ]; then \
+        echo "Go version mismatch: go.mod expects go${expected} but builder image has go${actual}." && \
+        echo "Update go.mod or the builder image to resolve this." && \
+        exit 1; \
+    fi
 
 RUN make manager
 


### PR DESCRIPTION
Pin Go builder images to the exact patch version from go.mod (1.25.8) and add a build-time check that fails if the two drift apart. This ensures CVE scanners (which read the go directive in go.mod) report against the same Go version that actually compiled the binary.