### PR TITLE
Backport bump of MCO dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/openshift/api v0.0.1
 	github.com/openshift/library-go v0.0.0-20260326200317-12d8376369b7
-	github.com/openshift/machine-config-operator v0.0.1-0.20260402190815-ec284905f7c9
+	github.com/openshift/machine-config-operator v0.0.1-0.20260410020757-449e78f7ec94
 	github.com/pborman/uuid v1.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.90.1

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,8 @@ github.com/openshift/client-go v0.0.0-20260330134249-7e1499aaacd7 h1:5GSoQlywIwY
 github.com/openshift/client-go v0.0.0-20260330134249-7e1499aaacd7/go.mod h1:HhXTUIMhgzxR3Ln/zEkr4QjTL0NN7A+t9Py/we9j2ug=
 github.com/openshift/library-go v0.0.0-20260326200317-12d8376369b7 h1:GRQO8uAHckyv3vG02M1AkA+b7RNnMxFqaKGxgwgN1Mw=
 github.com/openshift/library-go v0.0.0-20260326200317-12d8376369b7/go.mod h1:3bi4pLpYRdVd1aEhsHfRTJkwxwPLfRZ+ZePn3RmJd2k=
-github.com/openshift/machine-config-operator v0.0.1-0.20260402190815-ec284905f7c9 h1:ifnz/YxGBUXnTtlAuJxHppEY3MOWw9Io2PZhx1fpQoQ=
-github.com/openshift/machine-config-operator v0.0.1-0.20260402190815-ec284905f7c9/go.mod h1:1bxaFBDJPzXjyEemdFfpaPRqH1dfvoe9U1rz/GPEHUQ=
+github.com/openshift/machine-config-operator v0.0.1-0.20260410020757-449e78f7ec94 h1:yOOrCtGX3QZ8EOjhwjFrR7fOKoFO9CQhT+iOEvzrbrA=
+github.com/openshift/machine-config-operator v0.0.1-0.20260410020757-449e78f7ec94/go.mod h1:Yw5V0UkMteEhSKJXzCEiyUwOGJ5944HpEX7W9EECV3g=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pin/tftp v2.1.0+incompatible/go.mod h1:xVpZOMCXTy+A5QMjEVN0Glwa1sUvaJhFXbr/aAxuxGY=

--- a/vendor/github.com/openshift/machine-config-operator/pkg/apihelpers/apihelpers.go
+++ b/vendor/github.com/openshift/machine-config-operator/pkg/apihelpers/apihelpers.go
@@ -134,6 +134,55 @@ var (
 					},
 				},
 			},
+			{
+				Path: constants.IRIRegistryConfigPath,
+				Actions: []opv1.NodeDisruptionPolicyStatusAction{
+					{
+						Type: opv1.RestartStatusAction,
+						Restart: &opv1.RestartService{
+							ServiceName: constants.IRIRegistryServiceName,
+						},
+					},
+				},
+			},
+			{
+				Path: constants.IRILoadImageScriptPath,
+				Actions: []opv1.NodeDisruptionPolicyStatusAction{
+					{
+						Type: opv1.RestartStatusAction,
+						Restart: &opv1.RestartService{
+							ServiceName: constants.IRIRegistryServiceName,
+						},
+					},
+				},
+			},
+			{
+				Path: constants.IRIRootCAPath,
+				Actions: []opv1.NodeDisruptionPolicyStatusAction{
+					{
+						Type: opv1.RestartStatusAction,
+						Restart: &opv1.RestartService{
+							ServiceName: constants.UpdateCATrustServiceName,
+						},
+					},
+				},
+			},
+		},
+		Units: []opv1.NodeDisruptionPolicyStatusUnit{
+			{
+				Name: constants.IRIRegistryServiceName,
+				Actions: []opv1.NodeDisruptionPolicyStatusAction{
+					{
+						Type: opv1.DaemonReloadStatusAction,
+					},
+					{
+						Type: opv1.RestartStatusAction,
+						Restart: &opv1.RestartService{
+							ServiceName: constants.IRIRegistryServiceName,
+						},
+					},
+				},
+			},
 		},
 		SSHKey: opv1.NodeDisruptionPolicyStatusSSHKey{
 			Actions: []opv1.NodeDisruptionPolicyStatusAction{

--- a/vendor/github.com/openshift/machine-config-operator/pkg/controller/common/images.go
+++ b/vendor/github.com/openshift/machine-config-operator/pkg/controller/common/images.go
@@ -130,16 +130,6 @@ func validateMCOConfigMap(cm *corev1.ConfigMap, name string, reqDataKeys, reqBin
 	return nil
 }
 
-// Gets and parses the OSImageURL data from the machine-config-osimageurl ConfigMap.
-func GetOSImageURLConfig(ctx context.Context, kubeclient clientset.Interface) (*OSImageURLConfig, error) {
-	cm, err := kubeclient.CoreV1().ConfigMaps(MCONamespace).Get(ctx, MachineConfigOSImageURLConfigMapName, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("could not get ConfigMap %s: %w", MachineConfigOSImageURLConfigMapName, err)
-	}
-
-	return ParseOSImageURLConfigMap(cm)
-}
-
 // Gets and parse the Images data from the machine-config-operator-images ConfigMap.
 func GetImagesConfig(ctx context.Context, kubeclient clientset.Interface) (*Images, error) {
 	cm, err := kubeclient.CoreV1().ConfigMaps(MCONamespace).Get(ctx, MachineConfigOperatorImagesConfigMapName, metav1.GetOptions{})

--- a/vendor/github.com/openshift/machine-config-operator/pkg/daemon/constants/constants.go
+++ b/vendor/github.com/openshift/machine-config-operator/pkg/daemon/constants/constants.go
@@ -149,6 +149,12 @@ const (
 
 	KubeletCrioImageCredProviderConfPath = "/etc/systemd/system/kubelet.service.d/40-kubelet-crio-image-credential-provider.conf"
 
+	// IRI (InternalReleaseImage) registry paths and service
+	IRIRegistryConfigPath  = "/etc/iri-registry"
+	IRILoadImageScriptPath = "/usr/local/bin/load-registry-image.sh"
+	IRIRootCAPath          = "/etc/pki/ca-trust/source/anchors/iri-root-ca.crt"
+	IRIRegistryServiceName = "iri-registry.service"
+
 	// rpm-ostree command arguments
 	RPMOSTreeUpdateArg    = "update"
 	RPMOSTreeInstallArg   = "--install"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -700,7 +700,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/resource/resourceread
 github.com/openshift/library-go/pkg/operator/resourcesynccontroller
 github.com/openshift/library-go/pkg/operator/v1helpers
-# github.com/openshift/machine-config-operator v0.0.1-0.20260402190815-ec284905f7c9
+# github.com/openshift/machine-config-operator v0.0.1-0.20260410020757-449e78f7ec94
 ## explicit; go 1.25.3
 github.com/openshift/machine-config-operator/internal/clients
 github.com/openshift/machine-config-operator/pkg/apihelpers


### PR DESCRIPTION
Bump MCO to v0.0.1-0.20260410020757-449e78f7ec94

Backport of https://github.com/ComplianceAsCode/compliance-operator/pull/1178

Changeset differs a bit as `master` doesn't have https://github.com/ComplianceAsCode/compliance-operator/pull/1146 merged yet.