### PR TITLE
CMP-3829: The metrics and alerts are getting reported for Compliance …

### DIFF
--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -3248,4 +3249,43 @@ func (f *Framework) AssertNodeNameIsInTargetAndFactIdentifierInCM(nodes []core.N
 		}
 	}
 	return nil
+}
+
+// AssertPrometheusRuleComplianceNonCompliantAlert checks that some PrometheusRule in the operator
+// namespace has a name containing "compliance" and an alert name containing "NonCompliant"
+// (TC 43072 / observability parity with openshift-tests).
+func (f *Framework) AssertPrometheusRuleComplianceNonCompliantAlert() error {
+	out, err := runOCandGetOutput([]string{"get", "prometheusrule", "-n", f.OperatorNamespace, "-o", "json"})
+	if err != nil {
+		return fmt.Errorf("list prometheusrule: %w", err)
+	}
+	var pr struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Spec struct {
+				Groups []struct {
+					Rules []struct {
+						Alert string `json:"alert"`
+					} `json:"rules"`
+				} `json:"groups"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(out), &pr); err != nil {
+		return fmt.Errorf("parse prometheusrule list: %w", err)
+	}
+	for _, item := range pr.Items {
+		if !strings.Contains(strings.ToLower(item.Metadata.Name), "compliance") {
+			continue
+		}
+		if len(item.Spec.Groups) == 0 || len(item.Spec.Groups[0].Rules) == 0 {
+			continue
+		}
+		if strings.Contains(item.Spec.Groups[0].Rules[0].Alert, "NonCompliant") {
+			return nil
+		}
+	}
+	return fmt.Errorf("no compliance PrometheusRule with NonCompliant alert found in %s", f.OperatorNamespace)
 }

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -4078,3 +4078,42 @@ curl -k -s -G "https://prometheus-k8s.openshift-monitoring.svc:9091/api/v1/query
 	}
 	return fmt.Errorf("%s still present in ALERTS query output", alertName)
 }
+
+// AssertPrometheusRuleComplianceNonCompliantAlert checks that some PrometheusRule in the operator
+// namespace has a name containing "compliance" and an alert name containing "NonCompliant"
+// (TC 43072 / observability parity with openshift-tests).
+func (f *Framework) AssertPrometheusRuleComplianceNonCompliantAlert() error {
+	out, err := runOCandGetOutput([]string{"get", "prometheusrule", "-n", f.OperatorNamespace, "-o", "json"})
+	if err != nil {
+		return fmt.Errorf("list prometheusrule: %w", err)
+	}
+	var pr struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Spec struct {
+				Groups []struct {
+					Rules []struct {
+						Alert string `json:"alert"`
+					} `json:"rules"`
+				} `json:"groups"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(out), &pr); err != nil {
+		return fmt.Errorf("parse prometheusrule list: %w", err)
+	}
+	for _, item := range pr.Items {
+		if !strings.Contains(strings.ToLower(item.Metadata.Name), "compliance") {
+			continue
+		}
+		if len(item.Spec.Groups) == 0 || len(item.Spec.Groups[0].Rules) == 0 {
+			continue
+		}
+		if strings.Contains(item.Spec.Groups[0].Rules[0].Alert, "NonCompliant") {
+			return nil
+		}
+	}
+	return fmt.Errorf("no compliance PrometheusRule with NonCompliant alert found in %s", f.OperatorNamespace)
+}

--- a/tests/e2e/framework/utils.go
+++ b/tests/e2e/framework/utils.go
@@ -48,6 +48,67 @@ type PrometheusTarget struct {
 	ScrapeTimeout      string            `json:"scrapeTimeout"`
 }
 
+// labelSetJSON unmarshals Prometheus /api/v1/targets "labels" as either a JSON object (common)
+// or an array of {name,value} pairs, so we do not depend on vendoring prometheus/prometheus.
+type labelSetJSON struct {
+	m map[string]string
+}
+
+func (l *labelSetJSON) UnmarshalJSON(data []byte) error {
+	l.m = nil
+	s := strings.TrimSpace(string(data))
+	if s == "" || s == "null" {
+		return nil
+	}
+	if strings.HasPrefix(s, "{") {
+		if err := json.Unmarshal(data, &l.m); err != nil {
+			return err
+		}
+		return nil
+	}
+	if strings.HasPrefix(s, "[") {
+		var pairs []struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		}
+		if err := json.Unmarshal(data, &pairs); err != nil {
+			return err
+		}
+		l.m = make(map[string]string, len(pairs))
+		for _, p := range pairs {
+			if p.Name != "" {
+				l.m[p.Name] = p.Value
+			}
+		}
+		return nil
+	}
+	return fmt.Errorf("unexpected Prometheus target labels JSON (prefix %.80q)", s)
+}
+
+func (l labelSetJSON) labelEquals(name, value string) bool {
+	if l.m == nil {
+		return false
+	}
+	v, ok := l.m[name]
+	return ok && v == value
+}
+
+func (l labelSetJSON) String() string {
+	if l.m == nil {
+		return "{}"
+	}
+	return fmt.Sprintf("%v", l.m)
+}
+
+// prometheusScrapeTarget mirrors the subset of fields we need from Prometheus targets API JSON
+// without importing github.com/prometheus/prometheus (not vendored; breaks -mod=vendor builds).
+type prometheusScrapeTarget struct {
+	Labels     labelSetJSON `json:"labels"`
+	Health     string       `json:"health"`
+	LastScrape string       `json:"lastScrape"`
+	LastError  string       `json:"lastError"`
+}
+
 func (f *Framework) AssertMustHaveParsedProfiles(pbName, productType, productName string) error {
 	var l compv1alpha1.ProfileList
 	o := &client.ListOptions{
@@ -409,10 +470,11 @@ func runOCandGetOutput(arg []string) (string, error) {
 
 	cmd := exec.Command(ocPath, arg...)
 	out, err := cmd.CombinedOutput()
+	outStr := string(out)
 	if err != nil {
-		return "", fmt.Errorf("Failed to run oc command: %v", err)
+		return outStr, fmt.Errorf("Failed to run oc command: %v", err)
 	}
-	return string(out), nil
+	return outStr, nil
 }
 
 // createServiceAccount creates a service account
@@ -614,6 +676,30 @@ func getMetricResults(namespace string) (string, error) {
 	}
 	log.Printf("metrics output:\n%s\n", string(out))
 	return string(out), nil
+}
+
+// WaitForMetricOutputContainsAll polls the operator metrics-co scrape (same path as getMetricResults)
+// until the response body contains every substring (TC 43072 style substring checks).
+func WaitForMetricOutputContainsAll(namespace string, substrings []string, timeout, interval time.Duration) error {
+	var lastMiss string
+	err := wait.Poll(interval, timeout, func() (bool, error) {
+		out, gerr := getMetricResults(namespace)
+		if gerr != nil {
+			lastMiss = gerr.Error()
+			return false, nil
+		}
+		for _, s := range substrings {
+			if !strings.Contains(out, s) {
+				lastMiss = fmt.Sprintf("missing substring %q", s)
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("wait for metric substrings: %w (last: %s)", err, lastMiss)
+	}
+	return nil
 }
 
 func getTestMetricsCMD(namespace string) string {

--- a/tests/e2e/framework/utils.go
+++ b/tests/e2e/framework/utils.go
@@ -49,6 +49,67 @@ type PrometheusTarget struct {
 	ScrapeTimeout      string            `json:"scrapeTimeout"`
 }
 
+// labelSetJSON unmarshals Prometheus /api/v1/targets "labels" as either a JSON object (common)
+// or an array of {name,value} pairs, so we do not depend on vendoring prometheus/prometheus.
+type labelSetJSON struct {
+	m map[string]string
+}
+
+func (l *labelSetJSON) UnmarshalJSON(data []byte) error {
+	l.m = nil
+	s := strings.TrimSpace(string(data))
+	if s == "" || s == "null" {
+		return nil
+	}
+	if strings.HasPrefix(s, "{") {
+		if err := json.Unmarshal(data, &l.m); err != nil {
+			return err
+		}
+		return nil
+	}
+	if strings.HasPrefix(s, "[") {
+		var pairs []struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		}
+		if err := json.Unmarshal(data, &pairs); err != nil {
+			return err
+		}
+		l.m = make(map[string]string, len(pairs))
+		for _, p := range pairs {
+			if p.Name != "" {
+				l.m[p.Name] = p.Value
+			}
+		}
+		return nil
+	}
+	return fmt.Errorf("unexpected Prometheus target labels JSON (prefix %.80q)", s)
+}
+
+func (l labelSetJSON) labelEquals(name, value string) bool {
+	if l.m == nil {
+		return false
+	}
+	v, ok := l.m[name]
+	return ok && v == value
+}
+
+func (l labelSetJSON) String() string {
+	if l.m == nil {
+		return "{}"
+	}
+	return fmt.Sprintf("%v", l.m)
+}
+
+// prometheusScrapeTarget mirrors the subset of fields we need from Prometheus targets API JSON
+// without importing github.com/prometheus/prometheus (not vendored; breaks -mod=vendor builds).
+type prometheusScrapeTarget struct {
+	Labels     labelSetJSON `json:"labels"`
+	Health     string       `json:"health"`
+	LastScrape string       `json:"lastScrape"`
+	LastError  string       `json:"lastError"`
+}
+
 func (f *Framework) AssertMustHaveParsedProfiles(pbName, productType, productName string) error {
 	var l compv1alpha1.ProfileList
 	o := &client.ListOptions{
@@ -712,6 +773,30 @@ func getMetricResults(namespace string) (string, error) {
 		return "", fmt.Errorf("error getting output %s", err)
 	}
 	return string(out), nil
+}
+
+// WaitForMetricOutputContainsAll polls the operator metrics-co scrape (same path as getMetricResults)
+// until the response body contains every substring (TC 43072 style substring checks).
+func WaitForMetricOutputContainsAll(namespace string, substrings []string, timeout, interval time.Duration) error {
+	var lastMiss string
+	err := wait.Poll(interval, timeout, func() (bool, error) {
+		out, gerr := getMetricResults(namespace)
+		if gerr != nil {
+			lastMiss = gerr.Error()
+			return false, nil
+		}
+		for _, s := range substrings {
+			if !strings.Contains(out, s) {
+				lastMiss = fmt.Sprintf("missing substring %q", s)
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("wait for metric substrings: %w (last: %s)", err, lastMiss)
+	}
+	return nil
 }
 
 func getTestMetricsCMD(namespace string) string {

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -2877,3 +2877,76 @@ func TestOpenSCAPRuleMetadataPropagation(t *testing.T) {
 		t.Errorf("operator-managed scan label should not be overridden, got %q", checkResult.Labels[compv1alpha1.ComplianceScanLabel])
 	}
 }
+
+// TestErrorMetricsPrometheusRule uses a suite intended to reach phase DONE, result ERROR:
+// real content image with a non-existent content path so OpenSCAP cannot load the data stream
+// and the scan ends DONE/ERROR.
+func TestErrorMetricsPrometheusRule(t *testing.T) {
+	f := framework.Global
+
+	ns := &corev1.Namespace{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: f.OperatorNamespace}, ns); err != nil {
+		t.Fatal(err)
+	}
+	if ns.Labels == nil || ns.Labels["openshift.io/cluster-monitoring"] != "true" {
+		t.Fatalf("namespace %s does not have openshift.io/cluster-monitoring=true", f.OperatorNamespace)
+	}
+	metricsSvc := &corev1.Service{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: "metrics", Namespace: f.OperatorNamespace}, metricsSvc); err != nil {
+		t.Fatal(err)
+	}
+
+	base := framework.GetObjNameFromTest(t)
+	suiteName := base + "-test-suite"
+	scanName := base + "-scan"
+	selectWorkers := map[string]string{"node-role.kubernetes.io/worker": ""}
+
+	suite := &compv1alpha1.ComplianceSuite{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      suiteName,
+			Namespace: f.OperatorNamespace,
+		},
+		Spec: compv1alpha1.ComplianceSuiteSpec{
+			ComplianceSuiteSettings: compv1alpha1.ComplianceSuiteSettings{
+				AutoApplyRemediations: false,
+			},
+			Scans: []compv1alpha1.ComplianceScanSpecWrapper{
+				{
+					Name: scanName,
+					ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
+						Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+						Content:      "this-file-does-not-exist.xml",
+						ContentImage: "quay.io/compliance-operator/compliance-operator-content:latest",
+						NodeSelector: selectWorkers,
+					},
+				},
+			},
+		},
+	}
+
+	if err := f.Client.Create(context.TODO(), suite, nil); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = f.Client.Delete(context.TODO(), suite)
+	}()
+
+	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultError); err != nil {
+		t.Fatalf("suite %s did not reach DONE/ERROR: %v", suiteName, err)
+	}
+
+	wantScanMetric := fmt.Sprintf(`compliance_operator_compliance_scan_status_total{name="%s",phase="DONE",result="ERROR"`, scanName)
+	wantSuiteMetric := fmt.Sprintf(`compliance_operator_compliance_state{name="%s"}`, suiteName)
+	if err := framework.WaitForMetricOutputContainsAll(
+		f.OperatorNamespace,
+		[]string{wantScanMetric, wantSuiteMetric},
+		3*time.Minute,
+		framework.RetryInterval,
+	); err != nil {
+		t.Fatalf("metrics scrape (same path as getMetricResults / TestSingleScanSucceeds style): %v", err)
+	}
+
+	if err := f.AssertPrometheusRuleComplianceNonCompliantAlert(); err != nil {
+		t.Fatalf("PrometheusRule NonCompliant alert: %v", err)
+	}
+}

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -3766,3 +3766,76 @@ func TestTokenRulesPassOauthClientsConfigurable(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestErrorMetricsPrometheusRule uses a suite intended to reach phase DONE, result ERROR:
+// real content image with a non-existent content path so OpenSCAP cannot load the data stream
+// and the scan ends DONE/ERROR.
+func TestErrorMetricsPrometheusRule(t *testing.T) {
+	f := framework.Global
+
+	ns := &corev1.Namespace{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: f.OperatorNamespace}, ns); err != nil {
+		t.Fatal(err)
+	}
+	if ns.Labels == nil || ns.Labels["openshift.io/cluster-monitoring"] != "true" {
+		t.Fatalf("namespace %s does not have openshift.io/cluster-monitoring=true", f.OperatorNamespace)
+	}
+	metricsSvc := &corev1.Service{}
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: "metrics", Namespace: f.OperatorNamespace}, metricsSvc); err != nil {
+		t.Fatal(err)
+	}
+
+	base := framework.GetObjNameFromTest(t)
+	suiteName := base + "-test-suite"
+	scanName := base + "-scan"
+	selectWorkers := map[string]string{"node-role.kubernetes.io/worker": ""}
+
+	suite := &compv1alpha1.ComplianceSuite{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      suiteName,
+			Namespace: f.OperatorNamespace,
+		},
+		Spec: compv1alpha1.ComplianceSuiteSpec{
+			ComplianceSuiteSettings: compv1alpha1.ComplianceSuiteSettings{
+				AutoApplyRemediations: false,
+			},
+			Scans: []compv1alpha1.ComplianceScanSpecWrapper{
+				{
+					Name: scanName,
+					ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
+						Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+						Content:      "this-file-does-not-exist.xml",
+						ContentImage: "quay.io/compliance-operator/compliance-operator-content:latest",
+						NodeSelector: selectWorkers,
+					},
+				},
+			},
+		},
+	}
+
+	if err := f.Client.Create(context.TODO(), suite, nil); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = f.Client.Delete(context.TODO(), suite)
+	}()
+
+	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultError); err != nil {
+		t.Fatalf("suite %s did not reach DONE/ERROR: %v", suiteName, err)
+	}
+
+	wantScanMetric := fmt.Sprintf(`compliance_operator_compliance_scan_status_total{name="%s",phase="DONE",result="ERROR"`, scanName)
+	wantSuiteMetric := fmt.Sprintf(`compliance_operator_compliance_state{name="%s"}`, suiteName)
+	if err := framework.WaitForMetricOutputContainsAll(
+		f.OperatorNamespace,
+		[]string{wantScanMetric, wantSuiteMetric},
+		3*time.Minute,
+		framework.RetryInterval,
+	); err != nil {
+		t.Fatalf("metrics scrape (same path as getMetricResults / TestSingleScanSucceeds style): %v", err)
+	}
+
+	if err := f.AssertPrometheusRuleComplianceNonCompliantAlert(); err != nil {
+		t.Fatalf("PrometheusRule NonCompliant alert: %v", err)
+	}
+}


### PR DESCRIPTION
…Operator error(43072)

Currently passing on 4.22 cluster: 
```
=== RUN   TestErrorMetricsPrometheusRule
2026/04/27 20:52:42 waiting until suite test-error-metrics-prometheus-rule-test-suite reaches target status 'DONE'. Current status: RUNNING
2026/04/27 20:52:47 waiting until suite test-error-metrics-prometheus-rule-test-suite reaches target status 'DONE'. Current status: RUNNING
2026/04/27 20:52:52 waiting until suite test-error-metrics-prometheus-rule-test-suite reaches target status 'DONE'. Current status: RUNNING
2026/04/27 20:52:57 waiting until suite test-error-metrics-prometheus-rule-test-suite reaches target status 'DONE'. Current status: RUNNING
2026/04/27 20:53:02 All scans in ComplianceSuite have finished (test-error-metrics-prometheus-rule-test-suite)
2026/04/27 20:53:14 metrics output:
Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "metrics-test" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "metrics-test" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "metrics-test" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "metrics-test" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
# HELP compliance_operator_compliance_scan_error_total A counter for the total number of errors for a particular scan
# TYPE compliance_operator_compliance_scan_error_total counter
compliance_operator_compliance_scan_error_total{name="test-error-metrics-prometheus-rule-scan"} 1
# HELP compliance_operator_compliance_scan_status_total A counter for the total number of updates to the status of a ComplianceScan
# TYPE compliance_operator_compliance_scan_status_total counter
compliance_operator_compliance_scan_status_total{name="test-error-metrics-prometheus-rule-scan",phase="AGGREGATING",result="NOT-AVAILABLE"} 1
compliance_operator_compliance_scan_status_total{name="test-error-metrics-prometheus-rule-scan",phase="DONE",result="ERROR"} 1
compliance_operator_compliance_scan_status_total{name="test-error-metrics-prometheus-rule-scan",phase="LAUNCHING",result="NOT-AVAILABLE"} 1
compliance_operator_compliance_scan_status_total{name="test-error-metrics-prometheus-rule-scan",phase="PENDING",result=""} 2
compliance_operator_compliance_scan_status_total{name="test-error-metrics-prometheus-rule-scan",phase="RUNNING",result="NOT-AVAILABLE"} 1
# HELP compliance_operator_compliance_state A gauge for the compliance state of a ComplianceSuite. Set to 0 when COMPLIANT, 1 when NON-COMPLIANT, 2 when INCONSISTENT, and 3 when ERROR
# TYPE compliance_operator_compliance_state gauge
compliance_operator_compliance_state{name="test-error-metrics-prometheus-rule-test-suite"} 3
# HELP go_gc_duration_seconds A summary of the wall-time pause (stop-the-world) duration in garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 2.6458e-05
go_gc_duration_seconds{quantile="0.25"} 4.4938e-05
go_gc_duration_seconds{quantile="0.5"} 4.941e-05
go_gc_duration_seconds{quantile="0.75"} 0.000137018
go_gc_duration_seconds{quantile="1"} 0.080819652
go_gc_duration_seconds_sum 0.081834252
go_gc_duration_seconds_count 13
# HELP go_gc_gogc_percent Heap size target percentage configured by the user, otherwise 100. This value is set by the GOGC environment variable, and the runtime/debug.SetGCPercent function. Sourced from /gc/gogc:percent.
# TYPE go_gc_gogc_percent gauge
go_gc_gogc_percent 100
# HELP go_gc_gomemlimit_bytes Go runtime memory limit configured by the user, otherwise math.MaxInt64. This value is set by the GOMEMLIMIT environment variable, and the runtime/debug.SetMemoryLimit function. Sourced from /gc/gomemlimit:bytes.
# TYPE go_gc_gomemlimit_bytes gauge
go_gc_gomemlimit_bytes 9.223372036854776e+18
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 293
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.25.9"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated in heap and currently in use. Equals to /memory/classes/heap/objects:bytes.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 3.2005544e+07
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated in heap until now, even if released already. Equals to /gc/heap/allocs:bytes.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 9.9680616e+07
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table. Equals to /memory/classes/profiling/buckets:bytes.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 1.487546e+06
# HELP go_memstats_frees_total Total number of heap objects frees. Equals to /gc/heap/frees:objects + /gc/heap/tiny/allocs:objects.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 678627
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata. Equals to /memory/classes/metadata/other:bytes.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 4.415248e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and currently in use, same as go_memstats_alloc_bytes. Equals to /memory/classes/heap/objects:bytes.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 3.2005544e+07
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used. Equals to /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 3.923968e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 3.6216832e+07
# HELP go_memstats_heap_objects Number of currently allocated objects. Equals to /gc/heap/objects:objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 218842
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS. Equals to /memory/classes/heap/released:bytes.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 3.923968e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system. Equals to /memory/classes/heap/objects:bytes + /memory/classes/heap/unused:bytes + /memory/classes/heap/released:bytes + /memory/classes/heap/free:bytes.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 4.01408e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.7773159577358656e+09
# HELP go_memstats_mallocs_total Total number of heap objects allocated, both live and gc-ed. Semantically a counter version for go_memstats_heap_objects gauge. Equals to /gc/heap/allocs:objects + /gc/heap/tiny/allocs:objects.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 897469
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures. Equals to /memory/classes/metadata/mcache/inuse:bytes.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 2416
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system. Equals to /memory/classes/metadata/mcache/inuse:bytes + /memory/classes/metadata/mcache/free:bytes.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 15704
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures. Equals to /memory/classes/metadata/mspan/inuse:bytes.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 544960
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system. Equals to /memory/classes/metadata/mspan/inuse:bytes + /memory/classes/metadata/mspan/free:bytes.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 554880
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place. Equals to /gc/heap/goal:bytes.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 4.0626122e+07
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations. Equals to /memory/classes/other:bytes.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 692838
# HELP go_memstats_stack_inuse_bytes Number of bytes obtained from system for stack allocator in non-CGO environments. Equals to /memory/classes/heap/stacks:bytes.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 1.80224e+06
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator. Equals to /memory/classes/heap/stacks:bytes + /memory/classes/os-stacks:bytes.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 1.80224e+06
# HELP go_memstats_sys_bytes Number of bytes obtained from system. Equals to /memory/classes/total:byte.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 4.9109256e+07
# HELP go_sched_gomaxprocs_threads The current runtime.GOMAXPROCS setting, or the number of operating system threads that can execute user-level Go code simultaneously. Sourced from /sched/gomaxprocs:threads.
# TYPE go_sched_gomaxprocs_threads gauge
go_sched_gomaxprocs_threads 2
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 9
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 1.07
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 524287
# HELP process_network_receive_bytes_total Number of bytes received by the process over the network.
# TYPE process_network_receive_bytes_total counter
process_network_receive_bytes_total 6.872282e+06
# HELP process_network_transmit_bytes_total Number of bytes sent by the process over the network.
# TYPE process_network_transmit_bytes_total counter
process_network_transmit_bytes_total 418997
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 15
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 9.9094528e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.77731588529e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1.863929856e+09
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 5
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
pod "metrics-test" deleted

--- PASS: TestErrorMetricsPrometheusRule (38.44s)
PASS
...
ok  	github.com/ComplianceAsCode/compliance-operator/tests/e2e/serial	200.531s
```