### PR TITLE
CNF-23205: Add Dependabot config for GitHub Actions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds a Dependabot configuration to automatically open PRs when GitHub Actions used in this repo have new versions available.

Currently the repo uses actions pinned to various major/minor versions:
- `actions/checkout@v4` and `@v4.2.2`
- `actions/github-script@v7`
- `actions/upload-artifact@v4`
- `aquasecurity/trivy-action@master`
- `docker/*` actions at various versions
- `github/codeql-action/*@v3`
- `peter-evans/create-pull-request@v7`
- `snnaplab/get-labels-action@v1.0.1`
- `thollander/actions-comment-pull-request@v3`

Dependabot will check weekly and open PRs for any that have newer versions, keeping CI dependencies current and addressing potential security vulnerabilities in action versions.

This is scoped to `github-actions` only — Go module updates are handled separately by Konflux.