### PR TITLE
CMP-4293: updated imagePullPolicy to default of IfNotPresent

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1366,7 +1366,7 @@ spec:
                 - name: RELATED_IMAGE_PROFILE
                   value: ghcr.io/complianceascode/k8scontent:latest
                 image: ghcr.io/complianceascode/compliance-operator:latest
-                imagePullPolicy: Always
+                imagePullPolicy: IfNotPresent
                 name: compliance-operator
                 resources:
                   limits:

--- a/config/generic/manager_patch.yaml
+++ b/config/generic/manager_patch.yaml
@@ -1,3 +1,6 @@
+# Local dev workflow uses PullAlways so make deploy-local always picks up
+# freshly-pushed :latest images. Production/OLM-installed deployments use
+# the base default (IfNotPresent).
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,6 +10,7 @@ spec:
     spec:
       containers:
         - name: compliance-operator
+          imagePullPolicy: Always
           command:
             - compliance-operator
             - operator

--- a/config/helm/templates/deployment.yaml
+++ b/config/helm/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           - operator
           - --platform
           - {{ .Values.platform }}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           command:
             - compliance-operator
             - operator
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -1253,7 +1253,7 @@ spec:
                 - name: RELATED_IMAGE_PROFILE
                   value: ghcr.io/complianceascode/k8scontent:latest
                 image: ghcr.io/complianceascode/compliance-operator:latest
-                imagePullPolicy: Always
+                imagePullPolicy: IfNotPresent
                 name: compliance-operator
                 resources:
                   limits:

--- a/config/openshift/manager_patch.yaml
+++ b/config/openshift/manager_patch.yaml
@@ -1,4 +1,8 @@
-# Patch the deployment to run on master nodes
+# Patch the deployment to run on master nodes and use PullAlways for the
+# local dev workflow (make deploy-local pushes a fresh :latest tag and
+# expects kubelet to pull it). Production/OLM-installed deployments use
+# the base default (IfNotPresent) so a registry outage cannot prevent
+# the operator pod from starting.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,6 +10,9 @@ metadata:
 spec:
   template:
     spec:
+      containers:
+        - name: compliance-operator
+          imagePullPolicy: Always
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -58,7 +58,7 @@ func (r *ReconcileComplianceScan) newAggregatorPod(scanInstance *compv1alpha1.Co
 						"-c",
 						fmt.Sprintf("cp %s /content | /bin/true", path.Join("/", scanInstance.Spec.Content)),
 					},
-					ImagePullPolicy: corev1.PullAlways,
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &falseP,
 						ReadOnlyRootFilesystem:   &trueP,
@@ -78,6 +78,7 @@ func (r *ReconcileComplianceScan) newAggregatorPod(scanInstance *compv1alpha1.Co
 				{
 					Name:  "aggregator",
 					Image: utils.GetComponentImage(utils.OPERATOR),
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command: []string{
 						"compliance-operator", "aggregator",
 						"--content=" + absContentPath(scanInstance.Spec.Content),

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -201,7 +201,7 @@ func resultServer(scanInstance *compv1alpha1.ComplianceScan, labels map[string]s
 						{
 							Name:            "result-server",
 							Image:           utils.GetComponentImage(utils.OPERATOR),
-							ImagePullPolicy: corev1.PullAlways,
+							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command: []string{
 								"compliance-operator", "resultserver",
 								"--path=/reports/",

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -121,7 +121,7 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						"-c",
 						fmt.Sprintf("cp %s /content | /bin/true", path.Join("/", scanInstance.Spec.Content)),
 					},
-					ImagePullPolicy: corev1.PullAlways,
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &falseP,
 						ReadOnlyRootFilesystem:   &trueP,
@@ -154,7 +154,7 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						"-c",
 						fmt.Sprintf("mkdir -p %s && ln -s %s %s | /bin/true", KubeletConfigLinkFolder, KubeletConfigMapPath, KubeletConfigLinkPath),
 					},
-					ImagePullPolicy: corev1.PullAlways,
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					SecurityContext: &corev1.SecurityContext{
 						Privileged:             &trueP,
 						ReadOnlyRootFilesystem: &trueP,
@@ -189,7 +189,7 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						"-c",
 						runtimeSSHConfigCommand(),
 					},
-					ImagePullPolicy: corev1.PullAlways,
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					SecurityContext: &corev1.SecurityContext{
 						Privileged:             &trueP,
 						ReadOnlyRootFilesystem: &falseP,
@@ -236,7 +236,7 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 						"--tls-ca=/etc/pki/tls/ca.crt",
 						"--raw-results-output=" + getRawResultsOutputValue(scanInstance),
 					},
-					ImagePullPolicy: corev1.PullAlways,
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &falseP,
 						ReadOnlyRootFilesystem:   &trueP,
@@ -259,6 +259,7 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 				{
 					Name:    OpenSCAPScanContainerName,
 					Image:   utils.GetComponentImage(utils.OPENSCAP),
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command: []string{OpenScapScriptPath},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged:               &falseP,
@@ -360,6 +361,7 @@ func addScannerContainer(scanInstance *compv1alpha1.ComplianceScan, pod *corev1.
 		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
 			Name:  CELScannerContainerName,
 			Image: utils.GetComponentImage(utils.OPERATOR),
+			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command: []string{
 				"compliance-operator", "cel-scanner",
 				// "--api-resource-dir=" + PlatformScanDataRoot,
@@ -409,6 +411,7 @@ func addScannerContainer(scanInstance *compv1alpha1.ComplianceScan, pod *corev1.
 		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
 			Name:    OpenSCAPScanContainerName,
 			Image:   utils.GetComponentImage(utils.OPENSCAP),
+			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command: []string{OpenScapScriptPath},
 			SecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: &falseP,
@@ -556,7 +559,7 @@ func addResultsCollectionPods(scanInstance *compv1alpha1.ComplianceScan, pod *co
 				"--tls-ca=/etc/pki/tls/ca.crt",
 				"--raw-results-output=" + getRawResultsOutputValue(scanInstance),
 			},
-			ImagePullPolicy: corev1.PullAlways,
+			ImagePullPolicy: corev1.PullIfNotPresent,
 			SecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: &falseP,
 				ReadOnlyRootFilesystem:   &trueP,
@@ -646,7 +649,7 @@ func addScannerInitContainer(scanInstance *compv1alpha1.ComplianceScan, pod *cor
 				"-c",
 				fmt.Sprintf("cp %s /content | /bin/true", path.Join("/", scanInstance.Spec.Content)),
 			},
-			ImagePullPolicy: corev1.PullAlways,
+			ImagePullPolicy: corev1.PullIfNotPresent,
 			SecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: &falseP,
 				ReadOnlyRootFilesystem:   &trueP,
@@ -675,7 +678,7 @@ func addScannerInitContainer(scanInstance *compv1alpha1.ComplianceScan, pod *cor
 			Name:            PlatformScanResourceCollectorName,
 			Image:           utils.GetComponentImage(utils.OPERATOR),
 			Command:         collectorCmd,
-			ImagePullPolicy: corev1.PullAlways,
+			ImagePullPolicy: corev1.PullIfNotPresent,
 			SecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: &falseP,
 				ReadOnlyRootFilesystem:   &trueP,

--- a/pkg/controller/compliancesuite/suitererunner_cron_compat.go
+++ b/pkg/controller/compliancesuite/suitererunner_cron_compat.go
@@ -142,6 +142,7 @@ func (r *ReconcileComplianceSuite) getRerunnerPodTemplate(
 				{
 					Name:  "rerunner",
 					Image: utils.GetComponentImage(utils.OPERATOR),
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: &falseP,
 						ReadOnlyRootFilesystem:   &trueP,

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -506,7 +506,7 @@ func (r *ReconcileProfileBundle) newWorkloadForBundle(pb *compliancev1alpha1.Pro
 								"-c",
 								contentCopyCommand(pb),
 							},
-							ImagePullPolicy: corev1.PullAlways,
+							ImagePullPolicy: corev1.PullIfNotPresent,
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: &falseP,
 								ReadOnlyRootFilesystem:   &trueP,
@@ -535,6 +535,7 @@ func (r *ReconcileProfileBundle) newWorkloadForBundle(pb *compliancev1alpha1.Pro
 						{
 							Name:  "profileparser",
 							Image: utils.GetComponentImage(utils.OPERATOR),
+							ImagePullPolicy: corev1.PullIfNotPresent,
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: &falseP,
 								ReadOnlyRootFilesystem:   &trueP,
@@ -571,6 +572,7 @@ func (r *ReconcileProfileBundle) newWorkloadForBundle(pb *compliancev1alpha1.Pro
 						{
 							Name:  "pauser",
 							Image: utils.GetComponentImage(utils.OPERATOR),
+							ImagePullPolicy: corev1.PullIfNotPresent,
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: &falseP,
 								ReadOnlyRootFilesystem:   &trueP,

--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -544,9 +544,6 @@ func TestParsingErrorRestartsParserInitContainer(t *testing.T) {
 	if err := f.WaitForProfileBundleStatus(pbName, compv1alpha1.DataStreamValid); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.WaitForProfileBundleStatus(pbName, compv1alpha1.DataStreamValid); err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestRulesAreClassifiedAppropriately(t *testing.T) {


### PR DESCRIPTION
We need to change the default imagePullPolicy from Always to IfNotPresent as it's causing issues with docker registry.

Closes [CMP-4293](https://redhat.atlassian.net/browse/CMP-4293)



[CMP-4293]: https://redhat.atlassian.net/browse/CMP-4293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ