### PR TITLE
CMP-4324: Fix ProfileBundle status race that flakes parser re-parse

### DIFF
--- a/cmd/manager/profileparser.go
+++ b/cmd/manager/profileparser.go
@@ -11,6 +11,7 @@ import (
 	"github.com/antchfx/xmlquery"
 	"github.com/spf13/cobra"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -89,29 +90,34 @@ func getProfileBundle(pcfg *profileparser.ParserConfig) (*cmpv1alpha1.ProfileBun
 }
 
 // updateProfileBundleStatus updates the status of the given ProfileBundle. If
-// the given error is nil, the status will be valid, else it'll be invalid
-func updateProfileBundleStatus(pcfg *profileparser.ParserConfig, pb *cmpv1alpha1.ProfileBundle, err error) {
-	if err != nil {
-		// Never update a fetched object, always just a copy
-		pbCopy := pb.DeepCopy()
-		pbCopy.Status.DataStreamStatus = cmpv1alpha1.DataStreamInvalid
-		pbCopy.Status.ErrorMessage = err.Error()
-		pbCopy.Status.SetConditionInvalid()
-		err = pcfg.Client.Status().Update(context.TODO(), pbCopy)
-		if err != nil {
-			cmdLog.Error(err, "Couldn't update ProfileBundle status")
-			os.Exit(1)
+// the given error is nil, the status will be valid, else it'll be invalid.
+//
+// The update is retried on conflict, re-fetching the ProfileBundle each time.
+// A concurrent writer (the controller flipping the status to Pending, or
+// another parser pod during a rollout) bumps the resourceVersion, which would
+// otherwise make our single Status().Update fail and crash the init container
+// into CrashLoopBackOff, leaving the ProfileBundle stuck non-VALID.
+func updateProfileBundleStatus(pcfg *profileparser.ParserConfig, pb *cmpv1alpha1.ProfileBundle, parseErr error) {
+	updateErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Re-fetch on every attempt so we update the latest resourceVersion.
+		fresh := &cmpv1alpha1.ProfileBundle{}
+		if getErr := pcfg.Client.Get(context.TODO(), pcfg.ProfileBundleKey, fresh); getErr != nil {
+			return getErr
 		}
-	} else {
-		// Never update a fetched object, always just a copy
-		pbCopy := pb.DeepCopy()
-		pbCopy.Status.DataStreamStatus = cmpv1alpha1.DataStreamValid
-		pbCopy.Status.SetConditionReady()
-		err = pcfg.Client.Status().Update(context.TODO(), pbCopy)
-		if err != nil {
-			cmdLog.Error(err, "Couldn't update ProfileBundle status")
-			os.Exit(1)
+		if parseErr != nil {
+			fresh.Status.DataStreamStatus = cmpv1alpha1.DataStreamInvalid
+			fresh.Status.ErrorMessage = parseErr.Error()
+			fresh.Status.SetConditionInvalid()
+		} else {
+			fresh.Status.DataStreamStatus = cmpv1alpha1.DataStreamValid
+			fresh.Status.ErrorMessage = ""
+			fresh.Status.SetConditionReady()
 		}
+		return pcfg.Client.Status().Update(context.TODO(), fresh)
+	})
+	if updateErr != nil {
+		cmdLog.Error(updateErr, "Couldn't update ProfileBundle status")
+		os.Exit(1)
 	}
 }
 

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -474,6 +474,16 @@ func (r *ReconcileProfileBundle) newWorkloadForBundle(pb *compliancev1alpha1.Pro
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
+			// Use Recreate so the previous parser pod is fully torn down
+			// before the new one starts. The profileparser writes the
+			// ProfileBundle status, so two pods running at once (e.g. the old
+			// pod still crash-looping on a bad content image while the new pod
+			// parses the fixed image during a RollingUpdate) would race to set
+			// the status and clobber each other, leaving the ProfileBundle
+			// stuck non-VALID.
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,

--- a/pkg/controller/profilebundle/profilebundle_controller_test.go
+++ b/pkg/controller/profilebundle/profilebundle_controller_test.go
@@ -1,0 +1,38 @@
+package profilebundle
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compliancev1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+)
+
+// TestNewWorkloadForBundleUsesRecreateStrategy guards against the profileparser
+// Deployment reverting to the default RollingUpdate strategy. The profileparser
+// init container writes the ProfileBundle status; under RollingUpdate the old
+// pod (e.g. still crash-looping on a bad content image) keeps running alongside
+// the new pod that parses the fixed image, so the two race to set the status
+// and can leave the ProfileBundle stuck non-VALID. Recreate guarantees a single
+// parser pod at a time.
+func TestNewWorkloadForBundleUsesRecreateStrategy(t *testing.T) {
+	r := &ReconcileProfileBundle{}
+	pb := &compliancev1alpha1.ProfileBundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pb",
+			Namespace: "openshift-compliance",
+		},
+		Spec: compliancev1alpha1.ProfileBundleSpec{
+			ContentImage: "example.com/content:from",
+			ContentFile:  "ssg-ocp4-ds.xml",
+		},
+	}
+
+	depl := r.newWorkloadForBundle(pb, pb.Spec.ContentImage)
+
+	if got := depl.Spec.Strategy.Type; got != appsv1.RecreateDeploymentStrategyType {
+		t.Errorf("expected profileparser Deployment to use %q strategy, got %q",
+			appsv1.RecreateDeploymentStrategyType, got)
+	}
+}


### PR DESCRIPTION
## What

The `profileparser` init container writes the `ProfileBundle` status. The parser `Deployment` used the default **RollingUpdate** strategy, so when a `ProfileBundle`'s content image changes (e.g. from a broken image to a fixed one), the old pod keeps crash-looping and writing `INVALID` while the new pod parses the fixed content and writes `VALID`. The two pods race to set the status (last-writer-wins) and can leave the bundle stuck non-`VALID`.

Compounding this, `updateProfileBundleStatus` did a single `Status().Update` and `os.Exit(1)` on **any** error, so a resourceVersion conflict from a concurrent writer crashed the init container into `CrashLoopBackOff`, widening the window further (exponential backoff up to 5m).

## Fix

- Set the parser `Deployment` strategy to **`Recreate`** so the old pod is torn down before the new one starts — a single status writer at a time.
- **Retry the status update on conflict**, re-fetching the `ProfileBundle`, instead of crashing the parser.
- Add a regression unit test asserting the `Recreate` strategy.

## Why

This is the dominant flake in the e2e parallel suite — `TestParsingErrorRestartsParserInitContainer`, ~67% failure rate over a 14-day window. Across all sampled failing runs the failure is localized **exclusively** to the re-parse → `VALID` transition (`failed to reach state VALID`, ~1830s timeout), never the earlier restart assertion.

## Validation

- Reproduced on a live cluster: observed **2 concurrent parser pods** under RollingUpdate (old `:from` crash-looping + new `:to`); after switching the deployment to `Recreate`, **max 1 pod** and the bundle reached `VALID` cleanly.
- `go build`, `go vet`, `gofmt` clean; new unit test passes.
