### PR TITLE
CMP-3765: Fix CustomRule name typo in OpenShift Virt samples

### DIFF
--- a/config/samples/custom-rules/openshift-virtualization/kustomization.yaml
+++ b/config/samples/custom-rules/openshift-virtualization/kustomization.yaml
@@ -5,6 +5,6 @@ resources:
   - kubevirt-nonroot-feature-gate-is-enabled.yaml
   - kubevirt-no-permitted-host-devices.yaml
   - kubevirt-persistent-reservation-disabled.yaml
-  - kubevirt-no-vms-overcommiting-guest-memory
+  - kubevirt-no-vms-overcommitting-guest-memory.yaml
   - tailored-profile.yaml
   - scan-setting-binding.yaml

--- a/config/samples/custom-rules/openshift-virtualization/tailored-profile.yaml
+++ b/config/samples/custom-rules/openshift-virtualization/tailored-profile.yaml
@@ -29,7 +29,7 @@ spec:
         to storage resources, potentially impacting availability and enabling
         resource manipulation outside normal access controls.
     - kind: CustomRule
-      name: kubevirt-no-vms-overcommiting-guest-memory
+      name: kubevirt-no-vms-overcommitting-guest-memory
       rationale: |-
         This is a hypervisor-level feature that allows nodes to host more
         virtual machines than would normally be allowed by KubeVirt’s


### PR DESCRIPTION
## Summary

- Fix typo in `config/samples/custom-rules/openshift-virtualization/tailored-profile.yaml`: the rule name `kubevirt-no-vms-overcommiting-guest-memory` (single 't') does not match the actual CustomRule `kubevirt-no-vms-overcommitting-guest-memory` (double 't'), causing the TailoredProfile to reference a non-existent rule
- Fix the same typo and a missing `.yaml` extension in `kustomization.yaml`
- Add CHANGELOG entry under Fixes

## Test plan

- [x] Verified the correct CustomRule metadata name is `kubevirt-no-vms-overcommitting-guest-memory` (in `kubevirt-no-vms-overcommitting-guest-memory.yaml`)
- [x] Applied the fixed TailoredProfile to an OpenShift cluster with the compliance operator — TailoredProfile reaches READY state and all 5 rules execute successfully in a compliance scan