### PR TITLE
Fix ServiceMonitor rejection by replacing tlsConfig.caFile with ConfigMap reference

### DIFF
--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -153,9 +153,9 @@ var (
 		PlatformHyperShift:       true,
 		PlatformROSA:             false,
 	}
-	serviceMonitorBearerTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-	serviceMonitorTLSCAFile       = "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
-	alertName                     = "compliance"
+	serviceMonitorTLSCAConfigMap = "openshift-service-ca.crt"
+	serviceMonitorTLSCAKey      = "service-ca.crt"
+	alertName                   = "compliance"
 )
 
 const (
@@ -695,9 +695,16 @@ func generateOperatorServiceMonitor(service *v1.Service, namespace string) *moni
 			tlsConfig := &monitoring.TLSConfig{
 				SafeTLSConfig: monitoring.SafeTLSConfig{
 					ServerName: &m,
+					CA: monitoring.SecretOrConfigMap{
+						ConfigMap: &corev1.ConfigMapKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: serviceMonitorTLSCAConfigMap,
+							},
+							Key: serviceMonitorTLSCAKey,
+						},
+					},
 				},
 			}
-			tlsConfig.CAFile = serviceMonitorTLSCAFile
 			serviceMonitor.Spec.Endpoints[i].TLSConfig = tlsConfig
 		}
 	}


### PR DESCRIPTION
## Problem

The Compliance Operator creates a `ServiceMonitor` (`metrics` in `openshift-compliance`) that uses a file-based `tlsConfig.caFile` field. When the `openshift-compliance` namespace does **not** have the `openshift.io/cluster-monitoring: "true"` label, the ServiceMonitor is processed by user-workload Prometheus (`openshift-user-workload-monitoring`), which enforces [`arbitraryFSAccessThroughSMs: { deny: true }`](https://github.com/openshift/cluster-monitoring-operator/blob/main/jsonnet/components/prometheus-user-workload.libsonnet).

This causes the Prometheus Operator to reject the ServiceMonitor, triggering the **`PrometheusOperatorRejectedResources`** alert:

```
level=warn msg="skipping object" kind=ServiceMonitor
error="endpoints[1]: it accesses file system via tls config which Prometheus specification prohibits"
object=openshift-compliance/metrics
```

### Why this must be fixed (not worked around)

The `openshift.io/cluster-monitoring: "true"` label (set via the "Enable operator recommended monitoring" checkbox during installation) routes the ServiceMonitor to platform Prometheus, which allows file paths. However, **this is a workaround, not a solution**, because:

1. **Not all users check this box during installation -- it is optional**
2. **Some organizations have security policies against adding namespaces to platform monitoring scope**
3. **The operator should produce valid ServiceMonitors that work with both monitoring stacks**
4. **Using file paths that only work with one of two Prometheus stacks is a compatibility defect**

The operator must generate ServiceMonitors that are compatible with **both** platform monitoring (`arbitraryFSAccessThroughSMs: allow`) and user-workload monitoring (`arbitraryFSAccessThroughSMs: deny`).

## Root Cause

In `cmd/manager/operator.go`, `generateOperatorServiceMonitor()` sets a file-based CA path:

```go
tlsConfig.CAFile = serviceMonitorTLSCAFile
// where serviceMonitorTLSCAFile = "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt"
```

This file path is blocked by user-workload Prometheus's security policy. The unused `serviceMonitorBearerTokenFile` constant is also still present as dead code.

## Fix

- Replace `tlsConfig.CAFile` (file path) with `tlsConfig.CA` using a `ConfigMapKeySelector` referencing the `openshift-service-ca.crt` ConfigMap, which is auto-created by OpenShift's service-ca operator with annotation `service.beta.openshift.io/inject-cabundle: "true"`
- Remove the unused `serviceMonitorBearerTokenFile` constant (dead code)

**Before:**
```go
tlsConfig := &monitoring.TLSConfig{
    SafeTLSConfig: monitoring.SafeTLSConfig{
        ServerName: &m,
    },
}
tlsConfig.CAFile = serviceMonitorTLSCAFile
```

**After:**
```go
tlsConfig := &monitoring.TLSConfig{
    SafeTLSConfig: monitoring.SafeTLSConfig{
        ServerName: &m,
        CA: monitoring.SecretOrConfigMap{
            ConfigMap: &corev1.ConfigMapKeySelector{
                LocalObjectReference: corev1.LocalObjectReference{
                    Name: serviceMonitorTLSCAConfigMap,
                },
                Key: serviceMonitorTLSCAKey,
            },
        },
    },
}
```

## Relationship to previous fix

[OCPBUGS-39417](https://redhat.atlassian.net/browse/OCPBUGS-39417) (Closed, Sep 2024, Critical) fixed the `authorization.credentials` secret reference but did **not** address the `tlsConfig.caFile` file path, which is also prohibited by user-workload monitoring.

| Aspect | OCPBUGS-39417 (Closed) | This fix |
|---|---|---|
| Rejected field | `authorization.credentials` (wrong secret) | `tlsConfig.caFile` (file path blocked) |
| Error message | `"failed to get token from secret"` | `"it accesses file system via tls config"` |
| `caFile` addressed? | No | **Yes** |

## Testing

Bug reproduced and fix verified across **5 OCP clusters**:

| OCP Version | Compliance Operator | Bug Confirmed | Fix Verified |
|---|---|---|---|
| 4.18 | v1.9.0 | Yes | - |
| 4.19 | v1.9.0 | Yes | - |
| 4.20.23 | v1.9.0 | Yes | - |
| 4.21.17 | v1.9.0 | Yes | **Yes** |
| 4.22.0 | v1.9.0 | Yes | - |

On OCP 4.21.17 after deploying the patched image:
- ServiceMonitor updated: no `caFile`, `ca.configMap` correctly references `openshift-service-ca.crt`
- prometheus-operator logs: **no more rejection warnings**
- `PrometheusOperatorRejectedResources` alert: transitioned to **inactive** (0 active alerts)

Ref: https://redhat.atlassian.net/browse/OCPBUGS-87487

Made with [Cursor](https://cursor.com)

[OCPBUGS-39417]: https://redhat.atlassian.net/browse/OCPBUGS-39417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ