### PR TITLE
Pin CO release images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ endif
 CATALOG_DEPLOY_NS ?= $(NAMESPACE)
 
 BUNDLE_CSV_FILE=bundle/manifests/compliance-operator.clusterserviceversion.yaml
-DEFAULT_OPERATOR_IMAGE=$(DEFAULT_REPO)/$(APP_NAME):$(DEFAULT_TAG)
+DEFAULT_OPERATOR_IMAGE=$(DEFAULT_REPO)/$(APP_NAME)-dev:$(DEFAULT_TAG)
 
 ##@ General
 
@@ -514,7 +514,7 @@ deploy: manifests kustomize install ## Deploy controller to the K8s cluster spec
 	$(KUSTOMIZE) build config/default | sed -e 's%$(DEFAULT_OPERATOR_IMAGE)%$(OPERATOR_IMAGE)%' -e 's%$(DEFAULT_CONTENT_IMAGE)%$(CONTENT_IMAGE)%' | kubectl apply -f -
 
 .PHONY: deploy-local
-deploy-local: manifests kustomize image-to-cluster install  ## Deploy after pushing images to the cluster registry.
+deploy-local: manifests kustomize image-to-cluster install  ## Deploy after pushing images to the cluster registry with imagePullPolicy: Always.
 	cd config/manager && $(KUSTOMIZE) edit set image $(APP_NAME)=${OPERATOR_IMAGE}
 	$(KUSTOMIZE) build config/$(PLATFORM) | sed -e 's%$(DEFAULT_OPERATOR_IMAGE)%$(OPERATOR_IMAGE)%' -e 's%$(DEFAULT_CONTENT_IMAGE)%$(CONTENT_IMAGE)%' -e 's%$(DEFAULT_OPENSCAP_IMAGE)%$(OPENSCAP_IMAGE)%' | kubectl apply -f -
 
@@ -682,6 +682,21 @@ must-gather-push: must-gather-image
 must-gather: must-gather-image must-gather-push  ## Build and push the must-gather image
 
 ##@ Release
+
+.PHONY: release-pin-images
+release-pin-images: ## Pin Konflux images in upstream manifests for release
+	@echo "Extracting Konflux image specs from bundle-hack/update_csv.go"
+	$(eval KONFLUX_OPERATOR_IMAGE := $(shell go run ./bundle-hack/extract-images/main.go --format=makefile | grep KONFLUX_OPERATOR_IMAGE | cut -d= -f2))
+	$(eval KONFLUX_CONTENT_IMAGE := $(shell go run ./bundle-hack/extract-images/main.go --format=makefile | grep KONFLUX_CONTENT_IMAGE | cut -d= -f2))
+	$(eval KONFLUX_OPENSCAP_IMAGE := $(shell go run ./bundle-hack/extract-images/main.go --format=makefile | grep KONFLUX_OPENSCAP_IMAGE | cut -d= -f2))
+	@echo "Pinning images in config/manager/deployment.yaml"
+	@sed 's|value: "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-openscap-dev:master"|value: "$(KONFLUX_OPENSCAP_IMAGE)"|' config/manager/deployment.yaml > config/manager/deployment.yaml.tmp && mv config/manager/deployment.yaml.tmp config/manager/deployment.yaml
+	@sed 's|value: "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-dev:master"|value: "$(KONFLUX_OPERATOR_IMAGE)"|' config/manager/deployment.yaml > config/manager/deployment.yaml.tmp && mv config/manager/deployment.yaml.tmp config/manager/deployment.yaml
+	@sed 's|value: "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master"|value: "$(KONFLUX_CONTENT_IMAGE)"|' config/manager/deployment.yaml > config/manager/deployment.yaml.tmp && mv config/manager/deployment.yaml.tmp config/manager/deployment.yaml
+	@echo "Pinning image in config/manager/kustomization.yaml"
+	@sed 's|newName: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-dev|newName: $(shell echo $(KONFLUX_OPERATOR_IMAGE) | cut -d@ -f1)|' config/manager/kustomization.yaml > config/manager/kustomization.yaml.tmp && mv config/manager/kustomization.yaml.tmp config/manager/kustomization.yaml
+	@sed 's|newTag: master|newTag: $(shell echo $(KONFLUX_OPERATOR_IMAGE) | cut -d@ -f2)|' config/manager/kustomization.yaml > config/manager/kustomization.yaml.tmp && mv config/manager/kustomization.yaml.tmp config/manager/kustomization.yaml
+	@echo "Successfully pinned Konflux images in upstream manifests"
 
 .PHONY: package-version-to-tag
 package-version-to-tag: check-operator-version ## Explicitly override $TAG with $VERSION. This is a useful utility for other release targets.

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export PLATFORM?=openshift # target platform for the operator (openshift, generi
 
 # Runtime variables
 # =================
-DEFAULT_REPO=ghcr.io/complianceascode
+DEFAULT_REPO=quay.io/redhat-user-workloads/ocp-isc-tenant
 IMAGE_REPO?=$(DEFAULT_REPO)
 RUNTIME?=podman
 # Required for podman < 3.4.7 and buildah to use microdnf in fedora 35
@@ -60,13 +60,13 @@ PREVIOUS_VERSION?=$(shell ./utils/get-current-version.sh)
 
 # Image variables
 # ===============
-DEFAULT_TAG=latest
+DEFAULT_TAG=master
 # Image tag to use. Set this if you want to use a specific tag for building
 # or your e2e tests.
 TAG?=$(DEFAULT_TAG)
 
-OPENSCAP_NAME=openscap-ocp
-DEFAULT_OPENSCAP_TAG=latest
+OPENSCAP_NAME=compliance-operator-openscap-dev
+DEFAULT_OPENSCAP_TAG=master
 OPENSCAP_TAG?=$(DEFAULT_OPENSCAP_TAG)
 OPENSCAP_DOCKER_FILE=./images/openscap/Containerfile
 DEFAULT_OPENSCAP_IMAGE=$(DEFAULT_REPO)/$(OPENSCAP_NAME):$(DEFAULT_OPENSCAP_TAG)
@@ -75,7 +75,7 @@ OPENSCAP_IMAGE?=$(DEFAULT_OPENSCAP_IMAGE)
 # Image path to use. Set this if you want to use a specific path for building
 # or your e2e tests. This is overwritten if we build the image and push it to
 # the cluster or if we're on CI.
-OPERATOR_TAG_BASE=$(IMAGE_REPO)/$(APP_NAME)
+OPERATOR_TAG_BASE=$(IMAGE_REPO)/$(APP_NAME)-dev
 OPERATOR_IMAGE?=$(OPERATOR_TAG_BASE):$(TAG)
 
 # Build variables
@@ -94,7 +94,7 @@ BENCHMARK_PKG?=github.com/ComplianceAsCode/compliance-operator/pkg/utils
 # go source files, ignore vendor directory
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./_output/*")
 
-MUST_GATHER_IMAGE_PATH?=$(IMAGE_REPO)/must-gather-ocp
+MUST_GATHER_IMAGE_PATH?=$(IMAGE_REPO)/compliance-operator-must-gather-dev
 MUST_GATHER_IMAGE_TAG?=$(TAG)
 
 # Kubernetes variables
@@ -137,16 +137,16 @@ E2E_USE_DEFAULT_IMAGES?=false
 E2E_SKIP_CONTAINER_BUILD?=false
 
 # Used for substitutions
-DEFAULT_CONTENT_IMAGE=ghcr.io/complianceascode/k8scontent:latest
+DEFAULT_CONTENT_IMAGE=quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master
 CONTENT_IMAGE?=$(DEFAULT_CONTENT_IMAGE)
 # Specifies the image path to use for the content in the tests
-E2E_CONTENT_IMAGE_PATH?=ghcr.io/complianceascode/k8scontent:latest
+E2E_CONTENT_IMAGE_PATH?=quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master
 # We specifically omit the tag here since we use this for testing
 # different images referenced by different tags.
 E2E_BROKEN_CONTENT_IMAGE_PATH?=ghcr.io/complianceascode/test-broken-content-ocp
 
-MUST_GATHER_IMAGE_PATH?=ghcr.io/complianceascode/must-gather-ocp
-MUST_GATHER_IMAGE_TAG?=latest
+MUST_GATHER_IMAGE_PATH?=quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-must-gather-dev
+MUST_GATHER_IMAGE_TAG?=master
 
 # New Makefile variables
 
@@ -179,7 +179,7 @@ IMAGE_TAG_BASE=$(IMAGE_REPO)/$(APP_NAME)
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_TAG_BASE= $(IMAGE_TAG_BASE)-bundle
+BUNDLE_TAG_BASE= $(IMAGE_TAG_BASE)-bundle-dev
 BUNDLE_IMG ?= $(BUNDLE_TAG_BASE):$(TAG)
 
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command

--- a/bundle-hack/extract-images/main.go
+++ b/bundle-hack/extract-images/main.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"log"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	format := flag.String("format", "makefile", "Output format: makefile, json, or shell")
+	flag.Parse()
+
+	// Parse update_csv.go to extract Konflux pull specs
+	updateCSVPath := filepath.Join("bundle-hack", "update_csv.go")
+	images, err := extractKonfluxImages(updateCSVPath)
+	if err != nil {
+		log.Fatalf("Failed to extract images: %v", err)
+	}
+
+	// Output in requested format
+	switch *format {
+	case "makefile":
+		outputMakefile(images)
+	case "shell":
+		outputShell(images)
+	case "json":
+		outputJSON(images)
+	default:
+		log.Fatalf("Unknown format: %s", *format)
+	}
+}
+
+type KonfluxImages struct {
+	Operator   string
+	Content    string
+	Openscap   string
+	MustGather string
+}
+
+func extractKonfluxImages(filepath string) (*KonfluxImages, error) {
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, filepath, nil, parser.ParseComments)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse file: %w", err)
+	}
+
+	images := &KonfluxImages{}
+
+	// Walk the AST to find variable declarations
+	ast.Inspect(node, func(n ast.Node) bool {
+		if genDecl, ok := n.(*ast.GenDecl); ok && genDecl.Tok == token.VAR {
+			for _, spec := range genDecl.Specs {
+				if valueSpec, ok := spec.(*ast.ValueSpec); ok {
+					for i, name := range valueSpec.Names {
+						if i < len(valueSpec.Values) {
+							if basicLit, ok := valueSpec.Values[i].(*ast.BasicLit); ok {
+								value := strings.Trim(basicLit.Value, `"`)
+								switch name.Name {
+								case "konfluxOperatorPullSpec":
+									images.Operator = value
+								case "konfluxContentPullSpec":
+									images.Content = value
+								case "konfluxOpenscapPullSpec":
+									images.Openscap = value
+								case "konfluxMustGatherPullSpec":
+									images.MustGather = value
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		return true
+	})
+
+	// Validate that we found all required images
+	if images.Operator == "" || images.Content == "" || images.Openscap == "" || images.MustGather == "" {
+		return nil, fmt.Errorf("failed to extract all required image specs")
+	}
+
+	return images, nil
+}
+
+func outputMakefile(images *KonfluxImages) {
+	fmt.Printf("KONFLUX_OPERATOR_IMAGE=%s\n", images.Operator)
+	fmt.Printf("KONFLUX_CONTENT_IMAGE=%s\n", images.Content)
+	fmt.Printf("KONFLUX_OPENSCAP_IMAGE=%s\n", images.Openscap)
+	fmt.Printf("KONFLUX_MUST_GATHER_IMAGE=%s\n", images.MustGather)
+}
+
+func outputShell(images *KonfluxImages) {
+	fmt.Printf("export KONFLUX_OPERATOR_IMAGE='%s'\n", images.Operator)
+	fmt.Printf("export KONFLUX_CONTENT_IMAGE='%s'\n", images.Content)
+	fmt.Printf("export KONFLUX_OPENSCAP_IMAGE='%s'\n", images.Openscap)
+	fmt.Printf("export KONFLUX_MUST_GATHER_IMAGE='%s'\n", images.MustGather)
+}
+
+func outputJSON(images *KonfluxImages) {
+	fmt.Printf(`{
+  "operator": "%s",
+  "content": "%s",
+  "openscap": "%s",
+  "mustGather": "%s"
+}
+`, images.Operator, images.Content, images.Openscap, images.MustGather)
+}

--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
             "scans": [
               {
                 "content": "ssg-rhcos4-ds.xml",
-                "contentImage": "ghcr.io/complianceascode/k8scontent:latest",
+                "contentImage": "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master",
                 "name": "workers-scan",
                 "nodeSelector": {
                   "node-role.kubernetes.io/worker": ""
@@ -47,7 +47,7 @@ metadata:
               },
               {
                 "content": "ssg-ocp4-ds.xml",
-                "contentImage": "ghcr.io/complianceascode/k8scontent:latest",
+                "contentImage": "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master",
                 "name": "platform-scan",
                 "profile": "xccdf_org.ssgproject.content_profile_moderate",
                 "scanType": "Platform"
@@ -64,7 +64,7 @@ metadata:
           },
           "spec": {
             "contentFile": "ssg-ocp4-ds.xml",
-            "contentImage": "ghcr.io/complianceascode/k8scontent:latest"
+            "contentImage": "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master"
           }
         },
         {
@@ -160,7 +160,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    must-gather-image: ghcr.io/complianceascode/must-gather-ocp:latest
+    must-gather-image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-must-gather-dev:master
     olm.skipRange: '>=0.1.17 <1.8.0-dev'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
@@ -1360,12 +1360,12 @@ spec:
                     fieldRef:
                       fieldPath: metadata.name
                 - name: RELATED_IMAGE_OPENSCAP
-                  value: ghcr.io/complianceascode/openscap-ocp:latest
+                  value: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-openscap-dev:master
                 - name: RELATED_IMAGE_OPERATOR
-                  value: ghcr.io/complianceascode/compliance-operator:latest
+                  value: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-dev:master
                 - name: RELATED_IMAGE_PROFILE
-                  value: ghcr.io/complianceascode/k8scontent:latest
-                image: ghcr.io/complianceascode/compliance-operator:latest
+                  value: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master
+                image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-dev:master
                 imagePullPolicy: IfNotPresent
                 name: compliance-operator
                 resources:
@@ -1734,11 +1734,11 @@ spec:
     name: Red Hat Inc.
     url: www.redhat.com
   relatedImages:
-  - image: ghcr.io/complianceascode/openscap-ocp:latest
+  - image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-openscap-dev:master
     name: openscap
-  - image: ghcr.io/complianceascode/compliance-operator:latest
+  - image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-dev:master
     name: operator
-  - image: ghcr.io/complianceascode/k8scontent:latest
+  - image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master
     name: profile
   replaces: compliance-operator.v1.7.1
   version: 1.8.0-dev

--- a/config/helm/templates/deployment.yaml
+++ b/config/helm/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: compliance-operator
       containers:
         - name: compliance-operator
-          image: "ghcr.io/complianceascode/compliance-operator:latest"
+          image: "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-dev:master"
           command:
           - compliance-operator
           - operator
@@ -53,11 +53,11 @@ spec:
                   fieldPath: metadata.name
             - name: RELATED_IMAGE_OPENSCAP
               # Hardcoding this temporarily until its propagated to CI
-              value: "ghcr.io/complianceascode/openscap-ocp:latest"
+              value: "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-openscap-dev:master"
             - name: RELATED_IMAGE_OPERATOR
-              value: "ghcr.io/complianceascode/compliance-operator:latest"
+              value: "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-dev:master"
             - name: RELATED_IMAGE_PROFILE
-              value: "ghcr.io/complianceascode/k8scontent:latest"
+              value: "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master"
           volumeMounts:
             - name: serving-cert
               mountPath: /var/run/secrets/serving-cert

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -52,11 +52,11 @@ spec:
                   fieldPath: metadata.name
             - name: RELATED_IMAGE_OPENSCAP
               # Hardcoding this temporarily until its propagated to CI
-              value: "ghcr.io/complianceascode/openscap-ocp:latest"
+              value: "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-openscap-dev:master"
             - name: RELATED_IMAGE_OPERATOR
-              value: "ghcr.io/complianceascode/compliance-operator:latest"
+              value: "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-dev:master"
             - name: RELATED_IMAGE_PROFILE
-              value: "ghcr.io/complianceascode/k8scontent:latest"
+              value: "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master"
           volumeMounts:
             - name: serving-cert
               mountPath: /var/run/secrets/serving-cert

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 
 images:
 - name: compliance-operator
-  newName: ghcr.io/complianceascode/compliance-operator
-  newTag: latest
+  newName: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-dev
+  newTag: master
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -38,7 +38,7 @@ metadata:
             "scans": [
               {
                 "content": "ssg-rhcos4-ds.xml",
-                "contentImage": "ghcr.io/complianceascode/k8scontent:latest",
+                "contentImage": "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master",
                 "name": "workers-scan",
                 "nodeSelector": {
                   "node-role.kubernetes.io/worker": ""
@@ -47,7 +47,7 @@ metadata:
               },
               {
                 "content": "ssg-ocp4-ds.xml",
-                "contentImage": "ghcr.io/complianceascode/k8scontent:latest",
+                "contentImage": "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master",
                 "name": "platform-scan",
                 "profile": "xccdf_org.ssgproject.content_profile_moderate",
                 "scanType": "Platform"
@@ -64,7 +64,7 @@ metadata:
           },
           "spec": {
             "contentFile": "ssg-ocp4-ds.xml",
-            "contentImage": "ghcr.io/complianceascode/k8scontent:latest"
+            "contentImage": "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master"
           }
         },
         {
@@ -160,7 +160,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    must-gather-image: ghcr.io/complianceascode/must-gather-ocp:latest
+    must-gather-image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-must-gather-dev:master
     olm.skipRange: '>=0.1.17 <1.8.0-dev'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
@@ -1247,12 +1247,12 @@ spec:
                     fieldRef:
                       fieldPath: metadata.name
                 - name: RELATED_IMAGE_OPENSCAP
-                  value: ghcr.io/complianceascode/openscap-ocp:latest
+                  value: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-openscap-dev:master
                 - name: RELATED_IMAGE_OPERATOR
-                  value: ghcr.io/complianceascode/compliance-operator:latest
+                  value: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-dev:master
                 - name: RELATED_IMAGE_PROFILE
-                  value: ghcr.io/complianceascode/k8scontent:latest
-                image: ghcr.io/complianceascode/compliance-operator:latest
+                  value: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master
+                image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-dev:master
                 imagePullPolicy: IfNotPresent
                 name: compliance-operator
                 resources:

--- a/config/samples/compliance.openshift.io_v1alpha1_compliancesuite_cr.yaml
+++ b/config/samples/compliance.openshift.io_v1alpha1_compliancesuite_cr.yaml
@@ -9,11 +9,11 @@ spec:
     - name: workers-scan
       profile: xccdf_org.ssgproject.content_profile_moderate
       content: ssg-rhcos4-ds.xml
-      contentImage: ghcr.io/complianceascode/k8scontent:latest
+      contentImage: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master
       nodeSelector:
         node-role.kubernetes.io/worker: ""
     - name: platform-scan
       scanType: Platform
       profile: xccdf_org.ssgproject.content_profile_moderate
       content: ssg-ocp4-ds.xml
-      contentImage: ghcr.io/complianceascode/k8scontent:latest
+      contentImage: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master

--- a/config/samples/compliance.openshift.io_v1alpha1_profilebundle_cr.yaml
+++ b/config/samples/compliance.openshift.io_v1alpha1_profilebundle_cr.yaml
@@ -3,5 +3,5 @@ kind: ProfileBundle
 metadata:
   name: ocp4
 spec:
-  contentImage: ghcr.io/complianceascode/k8scontent:latest
+  contentImage: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master
   contentFile: ssg-ocp4-ds.xml

--- a/doc/contributor.md
+++ b/doc/contributor.md
@@ -193,7 +193,7 @@ The following is an example release note for a feature with a security note.
 
 ## Proposing Releases
 
-The release process is separated into three phases, with dedicated `make`
+The release process is separated into multiple phases, with dedicated `make`
 targets. All targets require that you set the environment variable `VERSION` prior to
 running `make`, which should be a semantic version formatted string (e.g.,
 `VERSION=0.1.49`).
@@ -203,26 +203,49 @@ to unset the `IMAGE_REPO` and  `TAG` environment variables in your shell, if you
 have been previously developing test images. This ensures that the release applies
 to the correct upstream images.
 
-### Preparing the Release
+### Step 1: Update Konflux Image References
 
-The first phase of the release process is preparing the release locally. You
-can do this by running the `make prepare-release` target. All changes are
+Before preparing the release, update the Konflux image references in
+`bundle-hack/update_csv.go` with the latest SHA256 digests from the Konflux builds.
+These digests will be used to pin images in the upstream manifests.
+
+### Step 2: Pin Images for Upstream Release
+
+Pin the Konflux images with SHA256 digests in the upstream manifests by running:
+
+```
+make release-pin-images
+```
+
+This target:
+- Extracts the latest Konflux image specs from `bundle-hack/update_csv.go`
+- Pins them in `config/manager/deployment.yaml` with SHA256 digests
+- Pins them in `config/manager/kustomization.yaml`
+
+This ensures that upstream users installing from the release get deterministic,
+SHA-pinned images that match the tested Konflux builds.
+
+### Step 3: Preparing the Release
+
+Prepare the release locally by running the `make prepare-release` target. All changes are
 staged locally. This is intentional so that you have the opportunity to
 review the changes before proposing the release in the next step.
 
-### Proposing the Release
+**Note:** The `prepare-release` target internally runs `make bundle`, which will
+preserve the SHA-pinned images from the previous step.
 
-The second phase of the release is to push the release to a dedicated branch
-against the origin repository. You can perform this step using the `make
+### Step 4: Proposing the Release
+
+Push the release to a dedicated branch against the origin repository using the `make
 push-release` target.
 
 Please note, this step makes changes to the upstream repository, so it is
 imperative that you review the changes you're committing prior to this step.
 This step also requires that you have necessary permissions on the repository.
 
-### Releasing Images
+### Step 5: Releasing Images
 
-The third and final step of the release is to build new images and push them to
+The final step of the release is to build new images and push them to
 an official image registry. You can build new images and push using `make
 release-images`. Note that this operation also requires you have proper
 permissions on the remote registry.

--- a/doc/contributor.md
+++ b/doc/contributor.md
@@ -203,6 +203,31 @@ to unset the `IMAGE_REPO` and  `TAG` environment variables in your shell, if you
 have been previously developing test images. This ensures that the release applies
 to the correct upstream images.
 
+### Understanding the Dual Release Workflow
+
+The compliance-operator has **two separate release workflows** that produce different artifacts:
+
+**Upstream Releases (GitHub → ghcr.io)**
+- **Purpose**: Community users and upstream installations
+- **Triggered by**: Git tags (v*)
+- **Destination**: ghcr.io/complianceascode (GitHub Container Registry)
+- **Bundle images**: Use quay.io Konflux images with SHA256 digests (deterministic, publicly accessible)
+- **Process**: GitHub Actions builds bundle image from committed bundle/manifests in git
+
+**Downstream Releases (Tekton → registry.redhat.io)**
+- **Purpose**: Red Hat customers and downstream installations
+- **Triggered by**: Changes to bundle/*** or bundle-hack/*** paths in any branch
+- **Destination**: registry.redhat.io (Red Hat Container Registry)
+- **Bundle images**: Use registry.redhat.io images (automatically copied from quay.io)
+- **Process**: Tekton builds bundle using bundle.openshift.Dockerfile which regenerates the CSV with registry.redhat.io URLs
+
+**Key distinction**: Upstream bundles use what's committed to git (quay.io images). Downstream bundles are regenerated during the Tekton build to replace quay.io → registry.redhat.io.
+
+**Image naming conventions:**
+- Master branch: Images have `-dev` suffix (e.g., compliance-operator-dev)
+- Release branches: Images have `-release` suffix (e.g., compliance-operator-release)
+- This is managed in bundle-hack/update_csv.go per branch
+
 ### Step 1: Update Konflux Image References
 
 Before preparing the release, update the Konflux image references in
@@ -210,6 +235,9 @@ Before preparing the release, update the Konflux image references in
 These digests will be used to pin images in the upstream manifests.
 
 ### Step 2: Pin Images for Upstream Release
+
+**This step is for upstream GitHub releases only.** Downstream Tekton builds automatically
+handle image registry replacement via bundle.openshift.Dockerfile and do not use these pinned manifests.
 
 Pin the Konflux images with SHA256 digests in the upstream manifests by running:
 
@@ -219,11 +247,19 @@ make release-pin-images
 
 This target:
 - Extracts the latest Konflux image specs from `bundle-hack/update_csv.go`
-- Pins them in `config/manager/deployment.yaml` with SHA256 digests
+- Pins them in `config/manager/deployment.yaml` with SHA256 digests (RELATED_IMAGE_* env vars)
 - Pins them in `config/manager/kustomization.yaml`
 
-This ensures that upstream users installing from the release get deterministic,
-SHA-pinned images that match the tested Konflux builds.
+This ensures that upstream users installing from GitHub releases get deterministic,
+SHA-pinned quay.io images that match the exact images tested in Konflux CI.
+
+**What gets committed to git:**
+- config/manager/deployment.yaml with SHA-pinned quay.io images
+- bundle/manifests/*.clusterserviceversion.yaml with SHA-pinned quay.io images (generated in Step 3)
+- These files are used by GitHub Actions to build the ghcr.io bundle image
+
+**Downstream workflow:** Tekton builds ignore these git files and regenerate the bundle
+during the image build process, automatically replacing quay.io → registry.redhat.io.
 
 ### Step 3: Preparing the Release
 

--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	DefaultContentContainerImage = "ghcr.io/complianceascode/k8scontent:latest"
+	DefaultContentContainerImage = "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master"
 	CACertDataKey                = "ca.crt"
 	CAKeyDataKey                 = "ca.key"
 	ServerCertInstanceSuffix     = "-rs"

--- a/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
+++ b/pkg/controller/scansettingbinding/scansettingbinding_controller_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Testing scansettingbinding controller", func() {
 				Namespace: common.GetComplianceOperatorNamespace(),
 			},
 			Spec: compv1alpha1.ProfileBundleSpec{
-				ContentImage: "ghcr.io/complianceascode/k8scontent:latest",
+				ContentImage: "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master",
 				ContentFile:  "ssg-rhcos4-ds.xml",
 			},
 			Status: compv1alpha1.ProfileBundleStatus{

--- a/pkg/utils/images.go
+++ b/pkg/utils/images.go
@@ -14,9 +14,9 @@ var componentDefaults = []struct {
 	defaultImage string
 	envVar       string
 }{
-	{"ghcr.io/complianceascode/openscap-ocp:latest", "RELATED_IMAGE_OPENSCAP"},
-	{"ghcr.io/complianceascode/compliance-operator:latest", "RELATED_IMAGE_OPERATOR"},
-	{"ghcr.io/complianceascode/k8scontent:latest", "RELATED_IMAGE_PROFILE"},
+	{"quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-openscap-dev:master", "RELATED_IMAGE_OPENSCAP"},
+	{"quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-dev:master", "RELATED_IMAGE_OPERATOR"},
+	{"quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master", "RELATED_IMAGE_PROFILE"},
 }
 
 // GetComponentImage returns a full image pull spec for a given component


### PR DESCRIPTION
 ## Summary

  Clarifies the dual-release workflow for upstream and downstream releases in the contributor documentation.

  ## Background

  The compliance-operator has two separate release workflows that were not clearly documented. The operator, content and openscap image, are sourced from quay.io. But the Bundle image will be sourced from different places depending on the type of release:
  - **Upstream releases** (GitHub → ghcr.io) - for community users
  - **Downstream releases** (Tekton → quay.io → registry.redhat.io) - for Red Hat customers

  These workflows produce different bundle artifacts with different image registries, which can be confusing without proper documentation.

  ### Documentation Updates (`doc/contributor.md`)

  1. **Added "Understanding the Dual Release Workflow" section**
     - Explains upstream vs downstream release processes
     - Clarifies which bundle artifacts are used for each
     - Documents image naming conventions (-dev for master, -release for release branches)

  2. **Updated "Pin Images for Upstream Release" section**
     - Clarifies that `make release-pin-images` is for upstream GitHub releases only
     - Explains what gets committed to git (SHA-pinned quay.io images)
     - Notes that downstream Tekton builds ignore git manifests and regenerate with registry.redhat.io

  ### Workflow

  - `make release-pin-images` extracts Konflux images and pins them with SHA256 digests
  - `config/manager/deployment.yaml` gets updated with SHA-pinned quay.io images
  - `config/manager/kustomization.yaml` gets updated with pinned images
  - Dual-release architecture:
    - bundle.Dockerfile (upstream) → copies git bundle/manifests with quay.io
    - bundle.openshift.Dockerfile (downstream) → generates bundle with registry.redhat.io
