### PR TITLE
CMP-4481: Enable running the full suite with already existing CO by making new Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,10 @@ E2E_TEST_TYPE?=all
 # variable to true if you prefer the tests to cleanup regardless of test status, e.g.:
 # E2E_CLEANUP_ON_ERROR=true make e2e
 E2E_CLEANUP_ON_ERROR?=false
+# Namespace of the compliance-operator when running make e2e-existing.
+E2E_OPERATOR_NAMESPACE?=$(OPERATOR_NAMESPACE)
+# Env prefix for make e2e-existing only.
+E2E_EXISTING_TEST_ENV=E2E_USE_EXISTING_OPERATOR=true TEST_OPERATOR_NAMESPACE=$(E2E_OPERATOR_NAMESPACE) CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH)
 E2E_ARGS=-root=$(PROJECT_DIR) -globalMan=$(TEST_CRD) -namespacedMan=$(TEST_DEPLOY) -cleanupOnError=$(E2E_CLEANUP_ON_ERROR) -testType=$(E2E_TEST_TYPE)
 TEST_OPTIONS?=-timeout=20m
 # Skip pushing the container to your cluster
@@ -611,6 +615,15 @@ e2e-test-wait:
 .PHONY: e2e-parallel
 e2e-parallel: e2e-set-image prep-e2e ## Run non-destructive end-to-end tests concurrently.
 	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/parallel $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
+
+.PHONY: e2e-periodic
+e2e-periodic: ## Run parallel, serial, and tailoring e2e tests against an already-installed compliance-operator (setup once, teardown once). Used for periodic test runs.
+	@set -o pipefail; e2e_exit=0; \
+	$(E2E_EXISTING_TEST_ENV) E2E_SKIP_FRAMEWORK_TEARDOWN=true $(GO) test ./tests/e2e/parallel $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log || e2e_exit=1; \
+	$(E2E_EXISTING_TEST_ENV) E2E_SKIP_FRAMEWORK_SETUP=true E2E_SKIP_FRAMEWORK_TEARDOWN=true $(GO) test ./tests/e2e/serial $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log || e2e_exit=1; \
+	$(E2E_EXISTING_TEST_ENV) E2E_SKIP_FRAMEWORK_SETUP=true E2E_SKIP_FRAMEWORK_TEARDOWN=true $(GO) test ./tests/e2e/tailoring_tests $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log || e2e_exit=1; \
+	E2E_USE_EXISTING_OPERATOR=true E2E_TEARDOWN_ONLY=true TEST_OPERATOR_NAMESPACE=$(E2E_OPERATOR_NAMESPACE) $(GO) test ./tests/e2e/parallel $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) || { echo "e2e-existing: framework teardown failed"; exit 1; }; \
+	exit $$e2e_exit
 
 .PHONY: e2e-serial
 e2e-serial: e2e-set-image prep-e2e ## Run destructive end-to-end tests serially.

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -469,6 +469,15 @@ func (f *Framework) WaitForDeployment(name string, replicas int, retryInterval, 
 	return nil
 }
 
+func (f *Framework) ensureExistingOperatorNamespace() error {
+	_, err := f.KubeClient.CoreV1().Namespaces().Get(context.TODO(), f.OperatorNamespace, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return fmt.Errorf("namespace %s not found; deploy the operator first or unset %s",
+			f.OperatorNamespace, UseExistingOperatorEnv)
+	}
+	return err
+}
+
 func (f *Framework) ensureTestNamespaceExists() error {
 	// create namespace only if it doesn't already exist
 	_, err := f.KubeClient.CoreV1().Namespaces().Get(context.TODO(), f.OperatorNamespace, metav1.GetOptions{})

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -69,9 +69,10 @@ type Framework struct {
 	localOperatorArgs string
 	kubeconfigPath    string
 	testType          string
-	schemeMutex       sync.Mutex
-	LocalOperator     bool
-	cleanupOnError    bool
+	schemeMutex          sync.Mutex
+	LocalOperator        bool
+	cleanupOnError       bool
+	useExistingOperator  bool
 }
 
 type frameworkOpts struct {
@@ -82,8 +83,8 @@ type frameworkOpts struct {
 	localOperatorArgs string
 	testType          string
 	isLocalOperator   bool
-	cleanupOnError    bool
-	platform          string
+	cleanupOnError      bool
+	platform            string
 }
 
 const (
@@ -105,6 +106,11 @@ const (
 
 	TestOperatorNamespaceEnv = "TEST_OPERATOR_NAMESPACE"
 	TestWatchNamespaceEnv    = "TEST_WATCH_NAMESPACE"
+	UseExistingOperatorEnv   = "E2E_USE_EXISTING_OPERATOR"
+	OperatorNamespaceEnv     = "OPERATOR_NAMESPACE"
+	SkipFrameworkSetupEnv    = "E2E_SKIP_FRAMEWORK_SETUP"
+	SkipFrameworkTearDownEnv = "E2E_SKIP_FRAMEWORK_TEARDOWN"
+	TearDownOnlyEnv          = "E2E_TEARDOWN_ONLY"
 )
 
 func (opts *frameworkOpts) addToFlagSet(flagset *flag.FlagSet) {
@@ -126,19 +132,40 @@ func (opts *frameworkOpts) addToFlagSet(flagset *flag.FlagSet) {
 		"The type of deployment hosting the tests. Options include \"openshift\" and \"rosa\".")
 }
 
+func envBool(name string) bool {
+	switch os.Getenv(name) {
+	case "1", "true", "TRUE", "yes", "YES":
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveOperatorNamespace(useExisting bool) string {
+	if useExisting {
+		if ns := os.Getenv(TestOperatorNamespaceEnv); ns != "" {
+			return ns
+		}
+		if ns := os.Getenv(OperatorNamespaceEnv); ns != "" {
+			return ns
+		}
+		return "openshift-compliance"
+	}
+
+	if ns, ok := os.LookupEnv(TestOperatorNamespaceEnv); ok && ns != "" {
+		return ns
+	}
+	return "osdk-e2e-" + uuid.New()
+}
+
 func newFramework(opts *frameworkOpts) (*Framework, error) {
 	kubeconfig, _, err := GetKubeconfigAndNamespace(opts.kubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build the kubeconfig: %w", err)
 	}
 
-	var operatorNamespace string
-	ns, ok := os.LookupEnv(TestOperatorNamespaceEnv)
-	if ok && ns != "" {
-		operatorNamespace = ns
-	} else {
-		operatorNamespace = "osdk-e2e-" + uuid.New()
-	}
+	useExistingOperator := envBool(UseExistingOperatorEnv)
+	operatorNamespace := resolveOperatorNamespace(useExistingOperator)
 
 	kubeclient, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
@@ -176,8 +203,9 @@ func newFramework(opts *frameworkOpts) (*Framework, error) {
 		localOperatorArgs: opts.localOperatorArgs,
 		kubeconfigPath:    opts.kubeconfigPath,
 		restMapper:        restMapper,
-		cleanupOnError:    opts.cleanupOnError,
-		testType:          opts.testType,
+		cleanupOnError:      opts.cleanupOnError,
+		testType:            opts.testType,
+		useExistingOperator: useExistingOperator,
 	}
 	return framework, nil
 }

--- a/tests/e2e/framework/main_entry.go
+++ b/tests/e2e/framework/main_entry.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -51,11 +52,86 @@ func (f *Framework) CleanUpOnError() bool {
 	return f.cleanupOnError
 }
 
+// RunE2ESuite is the shared TestMain entry point for e2e test packages.
+func RunE2ESuite(m *testing.M) {
+	f := NewFramework()
+
+	if tearDownOnly() {
+		runFrameworkTearDownOnly(f)
+		return
+	}
+
+	if envBool(SkipFrameworkSetupEnv) {
+		log.Println("E2E_SKIP_FRAMEWORK_SETUP is set, skipping framework setup")
+		if err := f.prepareForTests(); err != nil {
+			log.Fatal(err)
+		}
+		if err := f.addFrameworks(); err != nil {
+			log.Fatal(err)
+		}
+	} else if err := f.SetUp(); err != nil {
+		log.Fatal(err)
+	}
+
+	if os.Getenv("CONTENT_IMAGE") == "" {
+		fmt.Println("Please set the 'CONTENT_IMAGE' environment variable")
+		os.Exit(1)
+	}
+	if os.Getenv("BROKEN_CONTENT_IMAGE") == "" {
+		fmt.Println("Please set the 'BROKEN_CONTENT_IMAGE' environment variable")
+		os.Exit(1)
+	}
+
+	exitCode := m.Run()
+	if shouldRunFrameworkTearDown(exitCode, f.CleanUpOnError()) {
+		if err := f.TearDown(); err != nil {
+			log.Fatal(err)
+		}
+	} else if envBool(SkipFrameworkTearDownEnv) {
+		log.Println("E2E_SKIP_FRAMEWORK_TEARDOWN is set, skipping framework teardown")
+	}
+	os.Exit(exitCode)
+}
+
+func tearDownOnly() bool {
+	return envBool(TearDownOnlyEnv)
+}
+
+func runFrameworkTearDownOnly(f *Framework) {
+	log.Println("E2E_TEARDOWN_ONLY is set, running framework teardown only")
+	if err := f.prepareForTests(); err != nil {
+		log.Fatal(err)
+	}
+	if err := f.addFrameworks(); err != nil {
+		log.Fatal(err)
+	}
+	if err := f.TearDown(); err != nil {
+		log.Fatal(err)
+	}
+	os.Exit(0)
+}
+
+func shouldRunFrameworkTearDown(exitCode int, cleanupOnError bool) bool {
+	if envBool(SkipFrameworkTearDownEnv) {
+		return false
+	}
+	return exitCode == 0 || cleanupOnError
+}
+
+func (f *Framework) prepareForTests() error {
+	log.Printf("switching to %s directory to execute tests", f.projectRoot)
+	return os.Chdir(f.projectRoot)
+}
+
 func (f *Framework) SetUp() error {
 	log.Printf("switching to %s directory to setup and execute tests", f.projectRoot)
 	err := os.Chdir(f.projectRoot)
 	if err != nil {
 		return fmt.Errorf("failed to change directory to project root: %w", err)
+	}
+
+	if f.useExistingOperator {
+		return f.setUpExistingOperator()
 	}
 
 	err = f.ensureTestNamespaceExists()
@@ -85,7 +161,26 @@ func (f *Framework) SetUp() error {
 		return fmt.Errorf("failed to setup test resources: %w", err)
 	}
 
-	err = f.initializeMetricsTestResources()
+	return f.finishSetUp()
+}
+
+func (f *Framework) setUpExistingOperator() error {
+	log.Printf("using existing compliance-operator in namespace %s", f.OperatorNamespace)
+	err := f.ensureExistingOperatorNamespace()
+	if err != nil {
+		return fmt.Errorf("unable to use namespace %s for testing: %w", f.OperatorNamespace, err)
+	}
+
+	err = f.addFrameworks()
+	if err != nil {
+		return err
+	}
+
+	return f.finishSetUp()
+}
+
+func (f *Framework) finishSetUp() error {
+	err := f.initializeMetricsTestResources()
 	if err != nil {
 		return fmt.Errorf("failed to initialize cluster resources for metrics: %v", err)
 	}
@@ -147,6 +242,10 @@ func (f *Framework) TearDown() error {
 	err := f.WaitForScanCleanup()
 	if err != nil {
 		return err
+	}
+
+	if f.useExistingOperator {
+		return f.tearDownExistingOperator()
 	}
 
 	log.Printf("cleaning up Profile Bundles")
@@ -221,6 +320,38 @@ func (f *Framework) TearDown() error {
 		return fmt.Errorf("namespace %s deletion did not complete: %w", f.OperatorNamespace, err)
 	}
 	log.Printf("Namespace %s successfully deleted\n", f.OperatorNamespace)
+
+	return nil
+}
+
+func (f *Framework) tearDownExistingOperator() error {
+	log.Printf("skipping operator uninstall for existing deployment in namespace %s", f.OperatorNamespace)
+
+	if os.Getenv("SKIP_MCP_SETUP") != "" {
+		log.Println("SKIP_MCP_SETUP is set, skipping e2e ScanSettings and MachineConfigPool cleanup")
+		return nil
+	}
+
+	err := f.deleteScanSettings("e2e-default")
+	if err != nil {
+		return err
+	}
+	err = f.deleteScanSettings("e2e-default-auto-apply")
+	if err != nil {
+		return err
+	}
+	err = f.restoreNodeLabelsForPool("e2e")
+	if err != nil {
+		return err
+	}
+	err = f.cleanUpMachineConfigPool("e2e")
+	if err != nil {
+		return err
+	}
+	err = f.cleanUpMachineConfigPool("e2e-invalid")
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -30,32 +30,9 @@ var brokenContentImagePath string
 var contentImagePath string
 
 func TestMain(m *testing.M) {
-	f := framework.NewFramework()
-	err := f.SetUp()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	contentImagePath = os.Getenv("CONTENT_IMAGE")
-	if contentImagePath == "" {
-		fmt.Println("Please set the 'CONTENT_IMAGE' environment variable")
-		os.Exit(1)
-	}
-
 	brokenContentImagePath = os.Getenv("BROKEN_CONTENT_IMAGE")
-
-	if brokenContentImagePath == "" {
-		fmt.Println("Please set the 'BROKEN_CONTENT_IMAGE' environment variable")
-		os.Exit(1)
-	}
-
-	exitCode := m.Run()
-	if exitCode == 0 || (exitCode > 0 && f.CleanUpOnError()) {
-		if err = f.TearDown(); err != nil {
-			log.Fatal(err)
-		}
-	}
-	os.Exit(exitCode)
+	framework.RunE2ESuite(m)
 }
 
 func TestProfileVersion(t *testing.T) {

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -28,31 +28,9 @@ var brokenContentImagePath string
 var contentImagePath string
 
 func TestMain(m *testing.M) {
-	f := framework.NewFramework()
-	err := f.SetUp()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	contentImagePath = os.Getenv("CONTENT_IMAGE")
-	if contentImagePath == "" {
-		fmt.Println("Please set the 'CONTENT_IMAGE' environment variable")
-		os.Exit(1)
-	}
-
 	brokenContentImagePath = os.Getenv("BROKEN_CONTENT_IMAGE")
-
-	if brokenContentImagePath == "" {
-		fmt.Println("Please set the 'BROKEN_CONTENT_IMAGE' environment variable")
-		os.Exit(1)
-	}
-	exitCode := m.Run()
-	if exitCode == 0 || (exitCode > 0 && f.CleanUpOnError()) {
-		if err = f.TearDown(); err != nil {
-			log.Fatal(err)
-		}
-	}
-	os.Exit(exitCode)
+	framework.RunE2ESuite(m)
 }
 
 func TestScanStorageOutOfQuotaRangeFails(t *testing.T) {

--- a/tests/e2e/tailoring_tests/main_test.go
+++ b/tests/e2e/tailoring_tests/main_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"testing"
@@ -25,31 +24,9 @@ var contentImagePath string
 var criticalOnly = flag.Bool("critical", false, "run ONLY critical tests")
 
 func TestMain(m *testing.M) {
-	f := framework.NewFramework()
-	err := f.SetUp()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	contentImagePath = os.Getenv("CONTENT_IMAGE")
-	if contentImagePath == "" {
-		fmt.Println("Please set the 'CONTENT_IMAGE' environment variable")
-		os.Exit(1)
-	}
-
 	brokenContentImagePath = os.Getenv("BROKEN_CONTENT_IMAGE")
-
-	if brokenContentImagePath == "" {
-		fmt.Println("Please set the 'BROKEN_CONTENT_IMAGE' environment variable")
-		os.Exit(1)
-	}
-	exitCode := m.Run()
-	if exitCode == 0 || (exitCode > 0 && f.CleanUpOnError()) {
-		if err = f.TearDown(); err != nil {
-			log.Fatal(err)
-		}
-	}
-	os.Exit(exitCode)
+	framework.RunE2ESuite(m)
 }
 
 // TestScanTailoredProfileIsDeprecated verifies deprecated profile warnings surface when a TP extends a deprecated profile.


### PR DESCRIPTION
When trying to implement periodic testing of CO from bundle image I found out I need a Makefile target that would run the whole suite and skip the installation of the Compliance operator (and teardown after each suite). 

This is first draft that Cursor came up with after multiple iterations of what it is supposed to do and what not to change. 

This still needs to be tested as I do not trust him one bit. 

Created-by: Cursor