### PR TITLE
CMP-4316: [release-1.9] Fix STIG and NERC-CIP reference URL matching for updated CaC content

### DIFF
--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -863,7 +863,7 @@ func newStandardParser() *referenceParser {
 	if crherr != nil {
 		log.Error(crherr, "Could not register CIS Red Hat Linux reference parser") // not much we can do here..
 	}
-	nciperr := p.registerStandard("NERC-CIP", `^https://www\.nerc\.com/pa/Stand/AlignRep/One%20Stop%20Shop\.xlsx$`)
+	nciperr := p.registerStandard("NERC-CIP", `^https://www\.nerc\.com/(pa/Stand/AlignRep/One%20Stop%20Shop\.xlsx|standards/reliability-standards/cip)$`)
 	if nciperr != nil {
 		log.Error(nciperr, "Could not register NERC-CIP reference parser") // not much we can do here..
 	}
@@ -875,9 +875,36 @@ func newStandardParser() *referenceParser {
 	if pcidss4perr != nil {
 		log.Error(nciperr, "Could not register PCI-DSS-4-0 reference parser") // not much we can do here..
 	}
-	stigperr := p.registerStandard("STIG", `^https://public\.cyber\.mil/stigs/downloads/\?_dl_facet_stigs=container-platform`)
+	// Legacy STIG annotation, retained for backward compatibility. ComplianceAsCode
+	// PR #13793 moved the STIG reference URLs from public.cyber.mil to www.cyber.mil,
+	// so match both domains to keep the existing annotation populated.
+	stigperr := p.registerStandard("STIG", `^https://(www|public)\.cyber\.mil/stigs/downloads/\?_dl_facet_stigs=container-platform`)
 	if stigperr != nil {
 		log.Error(stigperr, "Could not register STIG reference parser") // not much we can do here..
+	}
+	// SRG (Security Requirements Guide) IDs, e.g. SRG-APP-000429-CTR-001060. These use
+	// the app-security/application-servers/general-purpose-os facets (see ComplianceAsCode
+	// ssg/constants.py). Matching exact facets keeps SRG distinct from the container-platform
+	// STIGID facet so the same href never lands in two annotations.
+	srgperr := p.registerStandard("SRG", `^https://(www|public)\.cyber\.mil/stigs/downloads/\?_dl_facet_stigs=(operating-systems%2Cgeneral-purpose-os|application-servers|app-security)$`)
+	if srgperr != nil {
+		log.Error(srgperr, "Could not register SRG reference parser") // not much we can do here..
+	}
+	// STIG IDs, e.g. CNTR-OS-000780. OCP4 and RHCOS4 - the only products the
+	// Compliance Operator parses - override this facet to container-platform.
+	stigidperr := p.registerStandard("STIGID", `^https://(www|public)\.cyber\.mil/stigs/downloads/\?_dl_facet_stigs=container-platform$`)
+	if stigidperr != nil {
+		log.Error(stigidperr, "Could not register STIGID reference parser") // not much we can do here..
+	}
+	// STIG Rule IDs, e.g. SV-257564r1050650_rule.
+	stigruleperr := p.registerStandard("STIG-RULE", `^https://(www|public)\.cyber\.mil/stigs/srg-stig-tools/$`)
+	if stigruleperr != nil {
+		log.Error(stigruleperr, "Could not register STIG-RULE reference parser") // not much we can do here..
+	}
+	// CCI (Control Correlation Identifier) IDs, e.g. CCI-000048.
+	cciperr := p.registerStandard("CCI", `^https://(www|public)\.cyber\.mil/stigs/cci/$`)
+	if cciperr != nil {
+		log.Error(cciperr, "Could not register CCI reference parser") // not much we can do here..
 	}
 
 	p.registerFormatter(profileOperatorFormatter)

--- a/pkg/profileparser/profileparser_test.go
+++ b/pkg/profileparser/profileparser_test.go
@@ -688,8 +688,127 @@ var _ = Describe("Testing parse rules", func() {
 		})
 
 		It("Has the expected control NIST annotations in RHACM format", func() {
-			Expect(pwMinLenRule.Annotations).To(HaveKeyWithValue(rhacmStdsAnnotationKey, "NIST-800-53"))
-			Expect(pwMinLenRule.Annotations).To(HaveKeyWithValue(rhacmCtrlsAnnotationsKey, "IA-5(f),IA-5(1)(a),CM-6(a)"))
+			// The rule also carries an SRG (general-purpose-os facet) reference, which
+			// the parser now recognizes, so it appears alongside NIST-800-53.
+			Expect(pwMinLenRule.Annotations).To(HaveKeyWithValue(rhacmStdsAnnotationKey, "NIST-800-53,SRG"))
+			Expect(pwMinLenRule.Annotations).To(HaveKeyWithValue(rhacmCtrlsAnnotationsKey, "IA-5(f),IA-5(1)(a),CM-6(a),SRG-OS-000078-GPOS-00046"))
+		})
+
+		It("Has the expected SRG control annotation in profile operator format", func() {
+			srgKey := controlAnnotationBase + "SRG"
+			Expect(pwMinLenRule.Annotations).To(HaveKeyWithValue(srgKey, "SRG-OS-000078-GPOS-00046"))
+		})
+	})
+})
+
+var _ = Describe("Testing reference parser standard matching", func() {
+	var stdParser *referenceParser
+
+	BeforeEach(func() {
+		stdParser = newStandardParser()
+	})
+
+	Context("NERC-CIP URL matching", func() {
+		It("Matches the legacy NERC-CIP URL", func() {
+			href := "https://www.nerc.com/pa/Stand/AlignRep/One%20Stop%20Shop.xlsx"
+			matched := false
+			for _, std := range stdParser.registeredStds {
+				if std.hrefMatcher.MatchString(href) {
+					Expect(std.Name).To(Equal("NERC-CIP"))
+					matched = true
+					break
+				}
+			}
+			Expect(matched).To(BeTrue())
+		})
+
+		It("Matches the new NERC-CIP URL", func() {
+			href := "https://www.nerc.com/standards/reliability-standards/cip"
+			matched := false
+			for _, std := range stdParser.registeredStds {
+				if std.hrefMatcher.MatchString(href) {
+					Expect(std.Name).To(Equal("NERC-CIP"))
+					matched = true
+					break
+				}
+			}
+			Expect(matched).To(BeTrue())
+		})
+
+		It("Does not match an unrelated NERC URL", func() {
+			href := "https://www.nerc.com/something-else"
+			for _, std := range stdParser.registeredStds {
+				if std.Name == "NERC-CIP" {
+					Expect(std.hrefMatcher.MatchString(href)).To(BeFalse())
+				}
+			}
+		})
+	})
+
+	Context("STIG reference URL matching", func() {
+		// matchingStds returns the names of every registered standard whose href
+		// matcher matches the given href. The parser applies all matching standards
+		// (it does not stop at the first), so overlapping regexes would populate
+		// multiple annotations from a single reference.
+		matchingStds := func(href string) []string {
+			var names []string
+			for _, std := range stdParser.registeredStds {
+				if std.hrefMatcher.MatchString(href) {
+					names = append(names, std.Name)
+				}
+			}
+			return names
+		}
+
+		It("matches the www.cyber.mil STIG reference URLs", func() {
+			cases := map[string]string{
+				"https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=app-security":                           "SRG",
+				"https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers":                    "SRG",
+				"https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os": "SRG",
+				"https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform":                     "STIGID",
+				"https://www.cyber.mil/stigs/srg-stig-tools/":                                                   "STIG-RULE",
+				"https://www.cyber.mil/stigs/cci/":                                                              "CCI",
+			}
+			for href, expectedStd := range cases {
+				Expect(matchingStds(href)).To(ContainElement(expectedStd), "href %q should match %s", href, expectedStd)
+			}
+		})
+
+		It("still matches the legacy public.cyber.mil URLs (backward compatibility)", func() {
+			cases := map[string]string{
+				"https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=app-security":       "SRG",
+				"https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform": "STIGID",
+				"https://public.cyber.mil/stigs/srg-stig-tools/":                               "STIG-RULE",
+				"https://public.cyber.mil/stigs/cci/":                                          "CCI",
+			}
+			for href, expectedStd := range cases {
+				Expect(matchingStds(href)).To(ContainElement(expectedStd), "href %q should match %s", href, expectedStd)
+			}
+		})
+
+		It("keeps SRG and STIGID disjoint - a container-platform href is never tagged SRG", func() {
+			href := "https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform"
+			Expect(matchingStds(href)).NotTo(ContainElement("SRG"))
+		})
+
+		It("keeps SRG and STIGID disjoint - an app-security href is never tagged STIGID", func() {
+			href := "https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=app-security"
+			Expect(matchingStds(href)).NotTo(ContainElement("STIGID"))
+		})
+
+		It("retains the legacy STIG annotation for the container-platform facet", func() {
+			href := "https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform"
+			Expect(matchingStds(href)).To(ContainElement("STIG"))
+		})
+
+		It("does not match an unrelated cyber.mil URL", func() {
+			href := "https://www.cyber.mil/stigs/something-else/"
+			for _, std := range stdParser.registeredStds {
+				switch std.Name {
+				case "SRG", "STIGID", "STIG-RULE", "CCI", "STIG":
+					Expect(std.hrefMatcher.MatchString(href)).To(BeFalse())
+				}
+			}
 		})
 	})
 })


### PR DESCRIPTION
Backport of #1228

Fixes: CMP-4349, CMP-4333

This backports the fix for STIG and NERC-CIP reference URL matching to the release-1.9 branch.