### PR TITLE
CMP-4351: Capture ephemeral e2e pod logs and quiet the metrics test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -610,53 +610,53 @@ e2e-test-wait:
 
 .PHONY: e2e-parallel
 e2e-parallel: e2e-set-image prep-e2e ## Run non-destructive end-to-end tests concurrently.
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/parallel $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-parallel.log
+	@LOG_CONTAINER_OUTPUT=1 CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/parallel $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-parallel.log
 
 .PHONY: e2e-scan-config
 e2e-scan-config: e2e-set-image prep-e2e ## Run scan and suite configuration end-to-end tests concurrently.
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/scan-config $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-scan-config.log
+	@LOG_CONTAINER_OUTPUT=1 CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/scan-config $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-scan-config.log
 
 .PHONY: e2e-deployment
 e2e-deployment: e2e-set-image prep-e2e ## Run operator deployment end-to-end tests concurrently.
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/deployment $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-deployment-test.log
+	@LOG_CONTAINER_OUTPUT=1 CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/deployment $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-deployment-test.log
 
 .PHONY: e2e-serial
 e2e-serial: e2e-set-image prep-e2e ## Run destructive end-to-end tests serially.
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/serial $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-serial.log
+	@LOG_CONTAINER_OUTPUT=1 CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/serial $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-serial.log
 
 .PHONY: e2e-tailoring
 e2e-tailoring: e2e-set-image prep-e2e ## Run profile tailoring end-to-end tests.
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/tailoring_tests $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
+	@LOG_CONTAINER_OUTPUT=1 CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/tailoring_tests $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
 
 .PHONY: e2e-tailoring-critical
 e2e-tailoring-critical: e2e-set-image prep-e2e ## Run critical profile tailoring e2e tests. That are all the tests that lack the criticalOnly skip check at the beginning.
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/tailoring_tests $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) -critical | tee tests/e2e-test.log
+	@LOG_CONTAINER_OUTPUT=1 CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/tailoring_tests $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) -critical | tee tests/e2e-test.log
 
 .PHONY: e2e-parsing
 e2e-parsing: e2e-set-image prep-e2e ## Run profile parsing end-to-end tests.
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/parsing_tests $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
+	@LOG_CONTAINER_OUTPUT=1 CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/parsing_tests $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
 
 .PHONY: e2e-parsing-critical
 e2e-parsing-critical: e2e-set-image prep-e2e ## Run critical profile parsing e2e tests. That are all the tests that lack the criticalOnly skip check at the beginning.
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/parsing_tests $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) -critical | tee tests/e2e-test.log
+	@LOG_CONTAINER_OUTPUT=1 CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/parsing_tests $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) -critical | tee tests/e2e-test.log
 
 .PHONY: e2e-cel
 e2e-cel: e2e-set-image prep-e2e ## Run profile parsing end-to-end tests.
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/cel_tests $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
+	@LOG_CONTAINER_OUTPUT=1 CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/cel_tests $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
 
 .PHONY: e2e-cel-critical
 e2e-cel-critical: e2e-set-image prep-e2e ## ## Run critical cel e2e tests. That are all the tests that lack the criticalOnly skip check at the beginning.
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/cel_tests $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) -critical | tee tests/e2e-test.log
+	@LOG_CONTAINER_OUTPUT=1 CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/cel_tests $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) -critical | tee tests/e2e-test.log
 
 .PHONY: e2e-prerelease
 e2e-prerelease: e2e-set-image prep-e2e ## Run prerelease e2e tests (e.g. default ProfileBundles and Profiles per architecture).
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/prerelease $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
+	@LOG_CONTAINER_OUTPUT=1 CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/prerelease $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-test.log
 
 ## Convert --platform to using $PLATFORM if we make this target more generic
 ## for other offerings.
 .PHONY: e2e-rosa
 e2e-rosa: e2e-set-image prep-e2e ## Run tests against managed ROSA environment concurrently
-	@$(GO) test ./tests/e2e/rosa $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) --platform rosa | tee tests/e2e-rosa.log
+	@LOG_CONTAINER_OUTPUT=1 $(GO) test ./tests/e2e/rosa $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) --platform rosa | tee tests/e2e-rosa.log
 
 .PHONY: prep-e2e
 prep-e2e: kustomize

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -72,6 +72,9 @@ type Framework struct {
 	schemeMutex       sync.Mutex
 	LocalOperator     bool
 	cleanupOnError    bool
+
+	// stopPodLogs cancels the background pod-log collector started in SetUp.
+	stopPodLogs func()
 }
 
 type frameworkOpts struct {

--- a/tests/e2e/framework/main_entry.go
+++ b/tests/e2e/framework/main_entry.go
@@ -63,6 +63,11 @@ func (f *Framework) SetUp() error {
 		return fmt.Errorf("unable to create or use namespace %s for testing: %w", f.OperatorNamespace, err)
 	}
 
+	// Start streaming pod logs to $ARTIFACT_DIR as early as possible so that
+	// short-lived scan pods are captured before the operator reaps them. No-op
+	// when ARTIFACT_DIR is unset (local runs).
+	f.stopPodLogs = f.StartPodLogCollector()
+
 	log.Printf("creating cluster resources in %s", f.globalManPath)
 	err = f.createFromYAMLFile(&f.globalManPath)
 	if err != nil {
@@ -139,6 +144,12 @@ func (f *Framework) SetUp() error {
 // If we don't properly cleanup resources before deleting CRDs, it leaves resources in a
 // terminating state, making them harder to cleanup.
 func (f *Framework) TearDown() error {
+	// Stop the pod-log collector first so its log files are flushed and closed
+	// before we start deleting resources.
+	if f.stopPodLogs != nil {
+		f.stopPodLogs()
+	}
+
 	// Make sure all scans are cleaned up before we delete the CRDs. Scans should be cleaned up
 	// because they're owned by ScanSettingBindings or ScanSuites, which should be cleaned up
 	// by each individual test either directly or through deferred cleanup. If the test fails

--- a/tests/e2e/framework/podlogcollector.go
+++ b/tests/e2e/framework/podlogcollector.go
@@ -1,0 +1,150 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// podLogCollector continuously streams the logs of every container of every pod
+// in the operator namespace to $ARTIFACT_DIR/pod-logs. The compliance operator
+// reaps short-lived pods (per-node scanner pods, resultserver, aggregator,
+// api-resource-collector, and parser init containers) as each scan progresses,
+// so by the time prow's end-of-run gather (oc adm inspect / must-gather) runs
+// those pods are already gone and their logs never reach CI artifacts. By
+// following each container's logs as soon as it starts, we capture them up to
+// the moment the pod is deleted.
+type podLogCollector struct {
+	f   *Framework
+	dir string
+	// started dedupes streamers by "<podUID>/<container>" so a container is only
+	// followed once per pod instance.
+	started sync.Map
+	wg      sync.WaitGroup
+}
+
+// StartPodLogCollector starts background pod-log streaming if ARTIFACT_DIR is
+// set, and returns a stop function that cancels streaming and waits (bounded)
+// for the in-flight writers to flush. When ARTIFACT_DIR is unset — e.g. a local
+// `make e2e` — it is a no-op, so local runs are unchanged.
+func (f *Framework) StartPodLogCollector() func() {
+	artifacts := os.Getenv("ARTIFACT_DIR")
+	if artifacts == "" {
+		return func() {}
+	}
+	dir := filepath.Join(artifacts, "pod-logs")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		log.Printf("pod-log collector: cannot create %s: %v", dir, err)
+		return func() {}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &podLogCollector{f: f, dir: dir}
+	c.wg.Add(1)
+	go c.run(ctx)
+	log.Printf("pod-log collector: streaming pod logs from namespace %q to %s", f.OperatorNamespace, dir)
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			cancel()
+			done := make(chan struct{})
+			go func() { c.wg.Wait(); close(done) }()
+			select {
+			case <-done:
+			case <-time.After(15 * time.Second):
+				log.Printf("pod-log collector: timed out waiting for log streams to flush")
+			}
+		})
+	}
+}
+
+// run polls the namespace for new started containers and launches a streamer for
+// each. Polling (rather than an informer) keeps the collector dependency-free
+// and robust to watch resets; CO scan pods live for seconds to minutes, well
+// above the poll interval.
+func (c *podLogCollector) run(ctx context.Context) {
+	defer c.wg.Done()
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	for {
+		c.discover(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// discover lists pods and starts a streamer for each container that has started
+// (running or terminated) and is not already being streamed.
+func (c *podLogCollector) discover(ctx context.Context) {
+	pods, err := c.f.KubeClient.CoreV1().Pods(c.f.OperatorNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return
+	}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		statuses := append([]core.ContainerStatus{}, pod.Status.InitContainerStatuses...)
+		statuses = append(statuses, pod.Status.ContainerStatuses...)
+		for _, cs := range statuses {
+			// A follow request against a container that has not started yet errors
+			// out, so only stream once it is running or has terminated. Terminated
+			// containers (e.g. the parser init container) still yield their full
+			// logs followed by EOF.
+			if cs.State.Running == nil && cs.State.Terminated == nil {
+				continue
+			}
+			key := string(pod.UID) + "/" + cs.Name
+			if _, loaded := c.started.LoadOrStore(key, struct{}{}); loaded {
+				continue
+			}
+			c.wg.Add(1)
+			go c.stream(ctx, pod.Name, cs.Name)
+		}
+	}
+}
+
+// stream follows one container's logs to a file until the container ends, the
+// pod is deleted, or the context is cancelled. A broken stream on pod deletion
+// is expected and not logged — the bytes already written are what we are after.
+func (c *podLogCollector) stream(ctx context.Context, podName, container string) {
+	defer c.wg.Done()
+
+	req := c.f.KubeClient.CoreV1().Pods(c.f.OperatorNamespace).GetLogs(podName, &core.PodLogOptions{
+		Container: container,
+		Follow:    true,
+	})
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		// The pod may have gone away between discovery and now; nothing to capture.
+		return
+	}
+	defer stream.Close()
+
+	name := fmt.Sprintf("%s__%s.log", podName, sanitizeLogName(container))
+	file, err := os.Create(filepath.Join(c.dir, name))
+	if err != nil {
+		log.Printf("pod-log collector: cannot create %s: %v", name, err)
+		return
+	}
+	defer file.Close()
+
+	// io.Copy writes directly to the file in chunks, so logs are persisted as they
+	// arrive — even if the test process exits before the stop function runs.
+	_, _ = io.Copy(file, stream)
+}
+
+func sanitizeLogName(s string) string {
+	return strings.ReplaceAll(s, "/", "_")
+}

--- a/tests/e2e/framework/utils.go
+++ b/tests/e2e/framework/utils.go
@@ -368,9 +368,12 @@ func AssertEachMetric(namespace string, expectedMetrics map[string]int) error {
 		}
 	}
 	if len(metricErrs) > 0 {
-		for err := range metricErrs {
+		for _, err := range metricErrs {
 			log.Println(err)
 		}
+		// Dump the full metrics payload only on failure, to aid debugging without
+		// spamming the log with the whole endpoint on every successful assertion.
+		log.Printf("metrics output:\n%s\n", metricsOutput)
 		return errors.New("unexpected metrics value")
 	}
 	return nil
@@ -656,7 +659,6 @@ func getMetricResults(namespace string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error getting output %s", err)
 	}
-	log.Printf("metrics output:\n%s\n", string(out))
 	return string(out), nil
 }
 


### PR DESCRIPTION
## Summary

The e2e suites create many short-lived pods (per-node scanner pods, resultserver, aggregator, api-resource-collector, parser init containers) that the operator reaps as each scan progresses. Prow's end-of-run gather (`oc adm inspect` / must-gather) runs only after the test, so those pods are already gone and their logs never reach CI artifacts — making failures like `ProfileBundle failed to reach VALID` and scanner connection errors hard to diagnose.

This change captures those logs while they exist, and quiets the metrics test that drowns the build log.

### What changed
- **Continuous pod-log collector** (`tests/e2e/framework/podlogcollector.go`): started in `SetUp`, stopped in `TearDown`, so all three suites (parallel/serial/rosa) get it. It polls the operator namespace and follows every started container's logs (including terminated init containers) into `$ARTIFACT_DIR/pod-logs/<pod>__<container>.log`, capturing pods up to the moment they're reaped. Writes stream straight to disk, so logs survive even if a failing run skips `TearDown`. **No-op when `ARTIFACT_DIR` is unset**, so local `make e2e` is unchanged.
- **Enable `LOG_CONTAINER_OUTPUT`** on the e2e make targets so the existing per-scan `logContainerOutput` snapshot also runs in CI (complements the collector; still gated on `ARTIFACT_DIR`, so local runs are unaffected).
- **Metrics test noise**: `AssertEachMetric` no longer dumps the full `/metrics` payload into the log on every call — it's logged only on assertion failure. Also fixes the failure loop that ranged over slice indices instead of the errors.

### Test plan
- [x] `make verify` (go vet + gosec) clean
- [x] `go build ./tests/e2e/...` clean
- [x] `go vet ./tests/e2e/framework ./tests/e2e/parallel ./tests/e2e/serial ./tests/e2e/rosa` clean
- [x] `gofmt` clean
- [ ] e2e run on a live cluster to confirm reaped scanner pod logs appear under `artifacts/.../pod-logs/` (follow-vs-reap timing needs a real run)

Closes CMP-4351