### PR TITLE
CMP-4379: Use must-gather image built from Konflux

### DIFF
--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -2676,7 +2676,7 @@ func getMustGatherImage(f *framework.Framework) string {
 	}
 
 	// Fall back to default upstream image
-	defaultImage := "ghcr.io/complianceascode/must-gather-ocp:latest"
+	defaultImage := "quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-must-gather-dev:master"
 	log.Printf("Using default must-gather image: %s", defaultImage)
 	return defaultImage
 }


### PR DESCRIPTION
The images build from Konflux are the most up to date, and supports the expected architectures.