### PR TITLE
Log oc output in serial tests if it failed

### DIFF
--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -2776,7 +2776,7 @@ func runOCandGetOutput(args []string) (string, error) {
 	cmd := exec.Command(ocPath, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("failed to run oc command: %v", err)
+		return string(out), fmt.Errorf("failed to run oc command: %v", err)
 	}
 	return string(out), nil
 }


### PR DESCRIPTION
We use the oc binary in the serial tests to ensure the must-gather image
works correctly. However, when the oc command fails the serial suite
swallows the error, making it hard to understand why it failed.

This commit adds dianostics if the command fails so that it's printed to
the test log.
