### PR TITLE
CMP-4364: Fix metrics test pod name collision in parallel e2e tests

### DIFF
--- a/tests/e2e/framework/utils.go
+++ b/tests/e2e/framework/utils.go
@@ -388,7 +388,7 @@ func (f *Framework) AssertMetricsEndpointUsesHTTPVersion(endpoint, version strin
 	// #nosec
 	cmd := exec.Command(ocPath,
 		"run", "--rm", "-i", "--restart=Never", "--image=registry.fedoraproject.org/fedora-minimal:latest",
-		"-n", f.OperatorNamespace, "metrics-test", "--", "bash", "-c", curlCMD,
+		"-n", f.OperatorNamespace, fmt.Sprintf("metrics-test-%d", time.Now().UnixNano()), "--", "bash", "-c", curlCMD,
 	)
 
 	out, err := cmd.CombinedOutput()
@@ -605,7 +605,7 @@ func getMetricResults(namespace string) (string, error) {
 	// #nosec
 	cmd := exec.Command(ocPath,
 		"run", "--rm", "-i", "--restart=Never", "--image=registry.fedoraproject.org/fedora-minimal:latest",
-		"-n", namespace, "metrics-test", "--", "bash", "-c",
+		"-n", namespace, fmt.Sprintf("metrics-test-%d", time.Now().UnixNano()), "--", "bash", "-c",
 		getTestMetricsCMD(namespace),
 	)
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
Two framework functions (AssertMetricsEndpointUsesHTTPVersion and
getMetricResults) both create ephemeral pods with the hardcoded name
"metrics-test". When parallel tests call these concurrently, one fails
with "exit status 1" because the pod name already exists or is still
terminating. Use a unique timestamp-based pod name for each invocation.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
