### PR TITLE
CMP-4414: e2e actually wait for remediation to be applied in WaitForGenericRemediationToBeAutoApplied 

### DIFF
--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -3103,9 +3103,9 @@ func (f *Framework) WaitForGenericRemediationToBeAutoApplied(remName, remNamespa
 		log.Printf("found remediation: %s\n", remName)
 		if rem.Status.ApplicationState == compv1alpha1.RemediationNotApplied || rem.Status.ApplicationState == compv1alpha1.RemediationPending {
 			log.Printf("retrying. remediation not yet applied. Remediation Name: %s, ApplicationState: %s\n", remName, rem.Status.ApplicationState)
+			return false, nil
 		}
-		// wait for the remediation to get applied
-		time.Sleep(5 * time.Second)
+		// the remediation has been applied; stop polling
 		return true, nil
 	})
 	if lastErr != nil {

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -3214,9 +3214,9 @@ func (f *Framework) WaitForGenericRemediationToBeAutoApplied(remName, remNamespa
 		log.Printf("found remediation: %s\n", remName)
 		if rem.Status.ApplicationState == compv1alpha1.RemediationNotApplied || rem.Status.ApplicationState == compv1alpha1.RemediationPending {
 			log.Printf("retrying. remediation not yet applied. Remediation Name: %s, ApplicationState: %s\n", remName, rem.Status.ApplicationState)
+			return false, nil
 		}
-		// wait for the remediation to get applied
-		time.Sleep(5 * time.Second)
+		// the remediation has been applied; stop polling
 		return true, nil
 	})
 	if lastErr != nil {


### PR DESCRIPTION
## Problem

`WaitForGenericRemediationToBeAutoApplied` (`tests/e2e/framework/common.go`) does **not** wait for the remediation to be applied. When the `ComplianceRemediation` is `NotApplied`/`Pending` it logs *"retrying. remediation not yet applied"* but **falls through** to a fixed `time.Sleep(5s)` and `return true, nil` — so it declares success as soon as the object exists, regardless of `ApplicationState`.

Callers (e.g. `TestKubeletConfigRemediation`) then immediately re-run the scan and **intermittently** see `NON-COMPLIANT`, because the kubelet config change hasn't actually taken effect yet:

```
main_test.go:1750: expecting one of [COMPLIANT] got NON-COMPLIANT
```

Seen flaking on `e2e-aws-serial` and `e2e-aws-serial-arm`.

## Fix

- `return false, nil` in the `NotApplied`/`Pending` branch so the poll loop keeps polling until the remediation is actually applied.
- Drop the redundant in-callback `time.Sleep(5s)` — `RetryInterval` already paces the loop; the existing `Timeout` (30m) bounds it.

Makes the wait stricter (correct behavior); low risk.

## Test plan
- [x] `go vet` / `gofmt` clean
- [x] Pre-existing flake; fix makes the helper block until `ApplicationState` advances past `NotApplied`/`Pending`