### PR TITLE
CMP-4373: Fix stale compliance_state metric and suite result

### DIFF
--- a/pkg/controller/compliancesuite/compliancesuite_controller.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller.go
@@ -172,6 +172,13 @@ func (r *ReconcileComplianceSuite) Reconcile(ctx context.Context, request reconc
 	}
 
 	if suiteCopy.IsResultAvailable() {
+		// Re-assert the compliance_state metric from the authoritative suite
+		// result on every reconcile. The gauge lives only in the operator's
+		// in-memory registry, so without this it goes missing after an operator
+		// restart until the next scan phase transition re-emits it (CMP-4373).
+		if err := r.setSuiteMetric(suiteCopy); err != nil {
+			return reconcile.Result{}, err
+		}
 		sCopy := suite.DeepCopy()
 		sCopy.Status.SetConditionReady()
 		updateErr := r.Client.Status().Update(context.TODO(), sCopy)
@@ -188,6 +195,12 @@ func (r *ReconcileComplianceSuite) suiteDeleteHandler(suite *compv1alpha1.Compli
 	if err := r.handleRerunnerDelete(suite, logger); err != nil {
 		return err
 	}
+
+	// Drop the compliance_state series for this suite so a deleted suite stops
+	// being reported. The gauge is keyed by suite name and is otherwise never
+	// cleared, leaving stale series (e.g. a NON-COMPLIANT value) firing alerts
+	// indefinitely after the suite is gone (CMP-4373).
+	r.Metrics.DeleteComplianceStateMetric(suite.Name)
 
 	suiteCopy := suite.DeepCopy()
 	// remove our finalizer from the list and update it.
@@ -349,9 +362,13 @@ func (r *ReconcileComplianceSuite) reconcileScanSpec(scanWrap *compv1alpha1.Comp
 
 // updates the status of a scan in the compliance suite. Note that the suite that this takes is already a copy, so it's safe to modify
 func (r *ReconcileComplianceSuite) updateScanStatus(suite *compv1alpha1.ComplianceSuite, idx int, scanStatusWrap *compv1alpha1.ComplianceScanStatusWrapper, scan *compv1alpha1.ComplianceScan, logger logr.Logger) error {
-	// if yes, update it, if the status differs
-	if scanStatusWrap.Phase == scan.Status.Phase {
-		logger.Info("Not updating scan, the phase is the same", "ComplianceScan.Name", scanStatusWrap.Name, "ComplianceScan.Phase", scanStatusWrap.Phase)
+	// if yes, update it, if the status differs. We compare both the phase and
+	// the result: a rescan returns a scan to the same terminal phase (DONE) it
+	// started from but may carry a different result, so a phase-only check would
+	// miss the change and leave the suite status, events, and the
+	// compliance_state metric stale (CMP-4373).
+	if scanStatusWrap.Phase == scan.Status.Phase && scanStatusWrap.Result == scan.Status.Result {
+		logger.Info("Not updating scan, the phase and result are the same", "ComplianceScan.Name", scanStatusWrap.Name, "ComplianceScan.Phase", scanStatusWrap.Phase, "ComplianceScan.Result", scanStatusWrap.Result)
 		return nil
 	}
 	modScanStatus := compv1alpha1.ScanStatusWrapperFromScan(scan)

--- a/pkg/controller/compliancesuite/compliancesuite_controller_test.go
+++ b/pkg/controller/compliancesuite/compliancesuite_controller_test.go
@@ -166,6 +166,54 @@ var _ = Describe("ComplianceSuiteController", func() {
 		Expect(rem.Spec.Outdated.Object).To(BeNil())
 	}
 
+	Context("When a scan result changes while the phase stays DONE (CMP-4373)", func() {
+		scanKey := types.NamespacedName{Name: "testScanNode", Namespace: namespace}
+
+		BeforeEach(func() {
+			// The suite has already recorded the scan as DONE/NON-COMPLIANT
+			// from a previous cycle.
+			suiteCopy := suite.DeepCopy()
+			suiteCopy.Status.Phase = compv1alpha1.PhaseDone
+			suiteCopy.Status.Result = compv1alpha1.ResultNonCompliant
+			suiteCopy.Status.ScanStatuses = []compv1alpha1.ComplianceScanStatusWrapper{
+				{
+					Name: "testScanNode",
+					ComplianceScanStatus: compv1alpha1.ComplianceScanStatus{
+						Phase:  compv1alpha1.PhaseDone,
+						Result: compv1alpha1.ResultNonCompliant,
+					},
+				},
+			}
+			Expect(reconciler.Client.Status().Update(ctx, suiteCopy)).To(BeNil())
+
+			// The scan itself has since flipped to DONE/COMPLIANT (e.g. after a
+			// rescan) while staying in the DONE phase.
+			scan := &compv1alpha1.ComplianceScan{}
+			Expect(reconciler.Client.Get(ctx, scanKey, scan)).To(BeNil())
+			scanCopy := scan.DeepCopy()
+			scanCopy.Status.Phase = compv1alpha1.PhaseDone
+			scanCopy.Status.Result = compv1alpha1.ResultCompliant
+			Expect(reconciler.Client.Status().Update(ctx, scanCopy)).To(BeNil())
+		})
+
+		It("Should update the suite result even though the phase is unchanged", func() {
+			suiteToReconcile := &compv1alpha1.ComplianceSuite{}
+			suiteKey := types.NamespacedName{Name: suiteName, Namespace: namespace}
+			Expect(reconciler.Client.Get(ctx, suiteKey, suiteToReconcile)).To(BeNil())
+
+			scan := &compv1alpha1.ComplianceScan{}
+			Expect(reconciler.Client.Get(ctx, scanKey, scan)).To(BeNil())
+
+			wrap := suiteToReconcile.Status.ScanStatuses[0]
+			Expect(reconciler.updateScanStatus(suiteToReconcile, 0, &wrap, scan, logger)).To(BeNil())
+
+			updated := &compv1alpha1.ComplianceSuite{}
+			Expect(reconciler.Client.Get(ctx, suiteKey, updated)).To(BeNil())
+			Expect(updated.Status.Result).To(Equal(compv1alpha1.ResultCompliant))
+			Expect(updated.Status.ScanStatuses[0].Result).To(Equal(compv1alpha1.ResultCompliant))
+		})
+	})
+
 	Context("When reconciling generic remediations", func() {
 		BeforeEach(func() {
 			remediation := &compv1alpha1.ComplianceRemediation{

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -197,3 +197,10 @@ func (m *Metrics) SetComplianceStateOutOfCompliance(name string) {
 func (m *Metrics) SetComplianceStateInCompliance(name string) {
 	m.metrics.metricComplianceStateGauge.WithLabelValues(name).Set(METRIC_STATE_COMPLIANT)
 }
+
+// DeleteComplianceStateMetric removes the compliance_state series for the named
+// suite. Called when a ComplianceSuite is deleted so its gauge no longer reports
+// a stale value.
+func (m *Metrics) DeleteComplianceStateMetric(name string) {
+	m.metrics.metricComplianceStateGauge.DeleteLabelValues(name)
+}

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -474,6 +474,25 @@ func (f *Framework) WaitForDeployment(name string, replicas int, retryInterval, 
 	return nil
 }
 
+// RestartComplianceOperator deletes the running operator pod(s) and waits for
+// the deployment to become available again. Used to verify that in-memory
+// state (e.g. the compliance_state metric, which lives only in the operator's
+// Prometheus registry) is correctly rebuilt after a restart.
+func (f *Framework) RestartComplianceOperator() error {
+	log.Print("Restarting the compliance-operator")
+	if _, err := runOCandGetOutput([]string{
+		"delete", "pod", "-l", "name=compliance-operator", "-n", f.OperatorNamespace,
+	}); err != nil {
+		return fmt.Errorf("failed to delete compliance-operator pod: %w", err)
+	}
+	if _, err := runOCandGetOutput([]string{
+		"rollout", "status", "deployment/compliance-operator", "-n", f.OperatorNamespace, "--timeout=300s",
+	}); err != nil {
+		return fmt.Errorf("failed waiting for compliance-operator rollout: %w", err)
+	}
+	return nil
+}
+
 func (f *Framework) ensureTestNamespaceExists() error {
 	// create namespace only if it doesn't already exist
 	_, err := f.KubeClient.CoreV1().Namespaces().Get(context.TODO(), f.OperatorNamespace, metav1.GetOptions{})

--- a/tests/e2e/serial/metrics_test.go
+++ b/tests/e2e/serial/metrics_test.go
@@ -1,0 +1,120 @@
+package serial_e2e
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/ComplianceAsCode/compliance-operator/tests/e2e/framework"
+)
+
+// TestComplianceStateMetricSurvivesOperatorRestart is a regression test for
+// CMP-4373. The compliance_operator_compliance_state gauge lives only in the
+// operator's in-memory Prometheus registry. Before the fix it was written only
+// on a scan phase transition and was never re-synced or cleaned up, so the
+// series went missing after an operator restart and lingered after the suite
+// was deleted.
+//
+// This test asserts the gauge:
+//   - reports the suite result (NON-COMPLIANT = 1) once the scan is Done,
+//   - is still present and correct after the operator is restarted (re-sync),
+//   - is removed once the suite is deleted (cleanup).
+//
+// A NON-COMPLIANT suite is used on purpose: an absent series parses as 0, so a
+// COMPLIANT suite (also 0) could not be distinguished from a missing one.
+func TestComplianceStateMetricSurvivesOperatorRestart(t *testing.T) {
+	f := framework.Global
+	suiteName := "metric-state-restart-suite"
+	scanName := fmt.Sprintf("%s-platform-scan", suiteName)
+
+	if err := f.SetupRBACForMetricsTest(); err != nil {
+		t.Fatalf("failed to set up metrics RBAC: %s", err)
+	}
+	defer f.CleanUpRBACForMetricsTest()
+
+	suite := &compv1alpha1.ComplianceSuite{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      suiteName,
+			Namespace: f.OperatorNamespace,
+		},
+		Spec: compv1alpha1.ComplianceSuiteSpec{
+			Scans: []compv1alpha1.ComplianceScanSpecWrapper{
+				{
+					ComplianceScanSpec: compv1alpha1.ComplianceScanSpec{
+						ScanType:     compv1alpha1.ScanTypePlatform,
+						ContentImage: contentImagePath,
+						Profile:      "xccdf_org.ssgproject.content_profile_cis",
+						Content:      framework.OcpContentFile,
+						ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+							Debug: true,
+						},
+					},
+					Name: scanName,
+				},
+			},
+		},
+	}
+
+	if err := f.Client.Create(context.TODO(), suite, nil); err != nil {
+		t.Fatal(err)
+	}
+	defer f.Client.Delete(context.TODO(), suite)
+
+	// Wait for the platform scan to finish NON-COMPLIANT.
+	if err := f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant); err != nil {
+		t.Fatal(err)
+	}
+
+	stateMetric := fmt.Sprintf("compliance_operator_compliance_state{name=\"%s\"}", suiteName)
+
+	// The gauge should report NON-COMPLIANT (1) before the restart.
+	if err := assertComplianceStateMetricEventually(f, stateMetric, 1); err != nil {
+		t.Fatalf("before restart: %s", err)
+	}
+
+	// Restart the operator. Before the fix, the in-memory gauge is lost on
+	// restart and never re-emitted for an already-Done suite.
+	if err := f.RestartComplianceOperator(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The gauge must be re-synced from the suite status after the restart.
+	if err := assertComplianceStateMetricEventually(f, stateMetric, 1); err != nil {
+		t.Fatalf("after restart (re-sync regression): %s", err)
+	}
+
+	// Deleting the suite must remove the series; otherwise the stale
+	// NON-COMPLIANT value (1) lingers and keeps firing alerts. An absent
+	// series parses as 0.
+	if err := f.Client.Delete(context.TODO(), suite); err != nil {
+		t.Fatal(err)
+	}
+	if err := assertComplianceStateMetricEventually(f, stateMetric, 0); err != nil {
+		t.Fatalf("after delete (cleanup regression): %s", err)
+	}
+}
+
+// assertComplianceStateMetricEventually polls the metrics endpoint until the
+// given compliance_state series reaches the expected value. An absent series
+// parses as 0.
+func assertComplianceStateMetricEventually(f *framework.Framework, metric string, expected int) error {
+	var lastErr error
+	pollErr := wait.PollImmediate(framework.RetryInterval, 5*time.Minute, func() (bool, error) {
+		lastErr = framework.AssertEachMetric(f.OperatorNamespace, map[string]int{metric: expected})
+		if lastErr != nil {
+			log.Printf("waiting for metric %s to reach %d: %s", metric, expected, lastErr)
+			return false, nil
+		}
+		return true, nil
+	})
+	if pollErr != nil {
+		return fmt.Errorf("metric %s did not reach %d: %v (last error: %v)", metric, expected, pollErr, lastErr)
+	}
+	return nil
+}


### PR DESCRIPTION
## What

The ComplianceSuite controller could report a stale compliance result —
`oc get compliancesuite` / the `compliance_operator_compliance_state` gauge /
ScanSettingBinding events showing NON-COMPLIANT while the underlying
ComplianceScan was COMPLIANT — until the operator pod was restarted. This is CMP-4373.

## Root cause

`updateScanStatus` refreshed the suite status (and therefore the metric and the
events derived from it) **only on a scan phase transition**:

```go
if scanStatusWrap.Phase == scan.Status.Phase {
    return nil
}
```

A rescan returns a scan to the same terminal phase (`DONE`) it started from, so
when only the **result** changed (e.g. NON-COMPLIANT → COMPLIANT after
remediation) the phase-only check skipped the update and the suite result went stale.

Two related gauge-lifecycle gaps made it worse: `compliance_state` lives only in
the operator's in-memory registry and was written *exclusively* on that transition
path and never cleaned up — so a live suite could be **missing** from metrics after
a restart, and a **deleted** suite left a stale series firing alerts indefinitely.

## Fix

- Compare the scan **result** as well as the phase in `updateScanStatus`.
- Re-assert `compliance_state` from the authoritative `suite.Status.Result` on
  every reconcile of a `Done` suite (survives operator restart).
- Delete the `compliance_state` series for a suite in `suiteDeleteHandler`.

## Tests

- New unit regression test: a scan whose result flips while its phase stays `DONE`
  must update the suite result. Fails on `master`, passes with this change.
- Verified end-to-end on an OCP 4.22 cluster: reproduced all three behaviours on
  the released 1.9.1 image (stale value, absent-after-restart, ghost-on-delete) and
  confirmed each is resolved by this build.

## Jira

CMP-4373
