### PR TITLE
CMP-4171: Ignore local claude settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ tests/e2e-*.log
 # Build artifacts from cmd/
 /cel-bundler
 cel-bundle.yaml
+# Claude settings
+.claude/settings.local.json


### PR DESCRIPTION
These are specific to individual users if they're using agentic
development. Exclude them from being tracked as part of the project.
