### PR TITLE
CMP-4375: Match go packages based on data sources

### DIFF
--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -17,14 +17,14 @@
       // Disable Go module updates on release branches — those are done
       // explicitly when needed. RPM updates are still proposed automatically.
       {
-        "matchManagers": ["gomod"],
+        "matchDatasources": ["go"],
         "matchBaseBranches": ["/^release-.*/"],
         "enabled": false
       },
       // Group all Go module digest, patch, and minor updates into a single
       // PR instead of one per dependency to reduce CI churn.
       {
-        "matchManagers": ["gomod"],
+        "matchDatasources": ["go"],
         "matchUpdateTypes": ["digest", "patch", "minor"],
         "groupName": "Go module updates",
         "groupSlug": "go-modules"


### PR DESCRIPTION
We made recent changes to group go module updates, which worked
partially because mintmaker is proposing a single update for golang
dependencies. But, it's still opening PRs for individual updates, too.

This commit attempts to fix that by grouping based on the data source
instead of just the package manager, which is what mintmaker itself does
to group it's own golang updates.

https://github.com/konflux-ci/mintmaker/blob/main/.github/renovate.json
