### PR TITLE
CMP-4425: Grant scanner RBAC for OpenShift Virtualization resources

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1072,6 +1072,49 @@ spec:
           - list
           - watch
         - apiGroups:
+          - kubevirt.io
+          resources:
+          - virtualmachines
+          - virtualmachineinstances
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - instancetype.kubevirt.io
+          resources:
+          - virtualmachineclusterinstancetypes
+          - virtualmachineclusterpreferences
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - cdi.kubevirt.io
+          resources:
+          - cdis
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - k8s.cni.cncf.io
+          resources:
+          - network-attachment-definitions
+          - multi-networkpolicies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - sriovnetwork.openshift.io
+          resources:
+          - sriovnetworks
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - compliance.openshift.io
           resources:
           - compliancecheckresults

--- a/config/rbac/api_resource_collector_cluster_role.yaml
+++ b/config/rbac/api_resource_collector_cluster_role.yaml
@@ -829,6 +829,50 @@ rules:
       - get
       - list
       - watch
+  # Necessary for CEL scanning of the CIS OpenShift Virtualization benchmark
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - instancetype.kubevirt.io
+    resources:
+      - virtualmachineclusterinstancetypes
+      - virtualmachineclusterpreferences
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - cdis
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - k8s.cni.cncf.io
+    resources:
+      - network-attachment-definitions
+      - multi-networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - sriovnetwork.openshift.io
+    resources:
+      - sriovnetworks
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - compliance.openshift.io
     resources:


### PR DESCRIPTION
## What

Adds `get`/`list`/`watch` RBAC to the `api-resource-collector` ClusterRole for the OpenShift Virtualization resource types needed by the CIS OpenShift Virtualization benchmark CEL content:

- `kubevirt.io` — virtualmachines, virtualmachineinstances
- `instancetype.kubevirt.io` — virtualmachineclusterinstancetypes, virtualmachineclusterpreferences
- `cdi.kubevirt.io` — cdis
- `k8s.cni.cncf.io` — network-attachment-definitions, multi-networkpolicies
- `sriovnetwork.openshift.io` — sriovnetworks

(`hco.kubevirt.io` is already granted.) The CSV `clusterPermissions` were regenerated via `make bundle`.

## Why

The CEL scanner runs as the `api-resource-collector` service account, whose ClusterRole is a curated allow-list (no wildcard). When a CEL rule references a resource the SA cannot read, the fetch is denied and the SDK degrades to an **empty resource map**, which yields a misleading PASS/FAIL rather than an error. Granting read access to these OCP-Virt types lets the benchmark's VM/network rules evaluate correctly out of the box.

## Testing

Read-only RBAC addition; `make bundle` validates clean. End-to-end validation against a CNV cluster will follow once a test cluster is available (tracked in CMP-4475).

Jira: https://issues.redhat.com/browse/CMP-4425

🤖 Generated with [Claude Code](https://claude.com/claude-code)