### PR TITLE
Use Konflux-built bundle for catalog generation

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -5,53 +5,9 @@ on:
     branches: ["master"]
 
 jobs:
-  # Push to latest
-  operator-container-push-latest:
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
-    with:
-      name: compliance-operator
-      registry_org: complianceascode
-      tag: latest
-      dockerfile_path: build/Dockerfile
-      vendor: "Compliance Operator Authors"
-      platforms: "linux/amd64,linux/ppc64le,linux/s390x,linux/arm64"
-
-  bundle-container-push-latest:
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
-    with:
-      name: compliance-operator-bundle
-      registry_org: complianceascode
-      tag: latest
-      dockerfile_path: bundle.Dockerfile
-      vendor: "Compliance Operator Authors"
-      platforms: "linux/amd64,linux/ppc64le,linux/s390x,linux/arm64"
-
-  openscap-container-push-latest:
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
-    with:
-      name: openscap-ocp
-      registry_org: complianceascode
-      tag: latest
-      dockerfile_path: images/openscap/Dockerfile
-      vendor: "Compliance Operator Authors"
-      platforms: "linux/amd64,linux/ppc64le,linux/s390x,linux/arm64"
-
+  # Build catalog from Konflux bundle
+  # Operator, bundle, openscap, and must-gather images are built by Konflux
   catalog-container-push-pr:
-    needs:
-      - operator-container-push-latest
-      - bundle-container-push-latest
     permissions:
       contents: read
       id-token: write
@@ -64,19 +20,5 @@ jobs:
       dockerfile_path: catalog.Dockerfile
       vendor: "Compliance Operator Authors"
       prepare_command: |
-        make catalog-docker BUNDLE_IMGS=ghcr.io/complianceascode/compliance-operator-bundle:latest
+        make catalog-docker BUNDLE_IMGS=quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-bundle-dev:master
       platforms: "linux/amd64,linux/ppc64le,linux/s390x,linux/arm64"
-
-  must-gather-latest:
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
-    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
-    with:
-      name: must-gather-ocp
-      registry_org: complianceascode
-      tag: latest
-      dockerfile_path: images/must-gather/Dockerfile.ocp
-      vendor: "Compliance Operator Authors"
-      platforms: "linux/amd64"


### PR DESCRIPTION
## Summary

This PR updates the `release-latest.yml` workflow to use Konflux-built bundles instead of GitHub Actions-built images for catalog generation.

## Changes

- **Removed** 4 duplicate image build jobs:
  - `operator-container-push-latest`
  - `bundle-container-push-latest`
  - `openscap-container-push-latest`
  - `must-gather-latest`
  
- **Updated** `catalog-container-push-pr` job:
  - Removed job dependencies (`needs` section)
  - Changed bundle image from `ghcr.io/complianceascode/compliance-operator-bundle:latest` to `quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-bundle-dev:master`

## Benefits

1. **Eliminates duplication**: Operator, bundle, OpenSCAP, and must-gather images are already built by Konflux CI
2. **Faster builds**: No dependencies between jobs, catalog builds immediately
3. **Always latest**: Uses Konflux's `:master` tag which is automatically updated on every merge
4. **Version-agnostic**: Catalog works on any OCP cluster version (not tied to specific versions)
5. **Simplified workflow**: Reduces workflow by ~60 lines

## Testing

The catalog will still be published to `ghcr.io/complianceascode/compliance-operator-catalog:latest`, so existing consumers (e2e tests in content/ocp4e2e repositories) will automatically use the Konflux-based catalog without any changes.

## Context

Konflux automatically tags bundle images with both commit SHA and branch name (`:master`), making it easy to reference the latest build from master without dynamic SHA resolution.