### PR TITLE
CMP-4485: Wait for the correct SSH remediation in serial e2e

### DIFF
--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -2485,10 +2485,28 @@ func TestRuntimeSSHConfigWithRemediation(t *testing.T) {
 		return
 	}
 
-	// Check that remediation was auto-applied
-	remName := fmt.Sprintf("%s-sshd-disable-gssapi-auth", scanName)
-	if err := f.WaitForRemediationToBeAutoApplied(remName, f.OperatorNamespace, poolBeforeRemediation); err != nil {
-		t.Logf("Remediation might not be needed or already applied: %v", err)
+	// The sshd_disable_gssapi_auth fix ships two MachineConfig variants gated by
+	// OCP version (<4.13.0 and >=4.13.0). The operator only generates a
+	// ComplianceRemediation for the variant matching the cluster, so the applied
+	// remediation name carries a version-dependent index suffix (e.g. "-1" for the
+	// >=4.13.0 variant). Hard-coding the base name (the <4.13.0 variant) meant the
+	// test waited on a remediation that is never created on modern clusters, so
+	// WaitForRemediationToBeAutoApplied blocked for the full 30m Timeout and
+	// silently timed out every run. The suite scan already reached DONE above, so
+	// any remediation for this scan is already created - discover it by scan label
+	// and wait for the one that actually exists.
+	remList := &compv1alpha1.ComplianceRemediationList{}
+	if err := f.Client.List(context.TODO(), remList, client.InNamespace(f.OperatorNamespace),
+		client.MatchingLabels{compv1alpha1.ComplianceScanLabel: scanName}); err != nil {
+		t.Fatalf("failed to list remediations for scan %s: %v", scanName, err)
+	}
+	if len(remList.Items) == 0 {
+		t.Logf("No ComplianceRemediation generated for scan %s; continuing", scanName)
+	}
+	for i := range remList.Items {
+		if err := f.WaitForRemediationToBeAutoApplied(remList.Items[i].Name, f.OperatorNamespace, poolBeforeRemediation); err != nil {
+			t.Logf("Remediation %s might not be needed or already applied: %v", remList.Items[i].Name, err)
+		}
 	}
 
 	// Re-run the scan to verify compliance with runtime checking
@@ -2519,15 +2537,19 @@ func TestRuntimeSSHConfigWithRemediation(t *testing.T) {
 		}
 	}
 
-	// Clean up the remediation if it was applied
-	rem := &compv1alpha1.ComplianceRemediation{}
-	if err := f.Client.Get(context.TODO(), types.NamespacedName{
-		Name:      remName,
-		Namespace: f.OperatorNamespace,
-	}, rem); err == nil {
+	// Clean up any remediations that were applied
+	for i := range remList.Items {
+		remName := remList.Items[i].Name
+		rem := &compv1alpha1.ComplianceRemediation{}
+		if err := f.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      remName,
+			Namespace: f.OperatorNamespace,
+		}, rem); err != nil {
+			continue
+		}
 		// Unapply the remediation
 		if err := f.UnApplyRemediationAndCheck(f.OperatorNamespace, remName, framework.TestPoolName); err != nil {
-			t.Logf("Could not unapply remediation: %v", err)
+			t.Logf("Could not unapply remediation %s: %v", remName, err)
 		}
 
 		// Wait for nodes to be ready again


### PR DESCRIPTION
`TestRuntimeSSHConfigWithRemediation` is the single most expensive test in the e2e-aws-serial suite — mean ~33 min, ~34% of the whole serial suite (~97 min) — and almost all of it is a 30-minute dead wait.

## Root cause

The `sshd_disable_gssapi_auth` fix in the `runtime_sshd` content ships **two** MachineConfig variants gated by OCP version via `complianceascode.io/ocp-version`:

- one for `<4.13.0`
- one for `>=4.13.0`

The operator's aggregator (`shouldSkipRemediation`) skips the variant that doesn't match the cluster, so on a modern cluster only the `>=4.13.0` variant is generated. Because the fix yields two objects, the generated `ComplianceRemediation` name carries an index suffix: `<scan>-sshd-disable-gssapi-auth-**1**`. The `<4.13.0` variant (the **base** name, no suffix) is never created.

The test hard-coded the **base** name and called `WaitForRemediationToBeAutoApplied` on it, so it waited for a remediation that never exists on 4.13+ clusters, polled the full 30m `Timeout`, timed out (logged non-fatally), and passed anyway on the runtime check — **without ever waiting for the remediation it actually applied.**

Confirmed from the run's gather (PR #1124, build `2074431700057722880`): the only SSH MachineConfig present is `75-test-runtime-ssh-remediation-scan-sshd-disable-gssapi-auth-1`, labeled `machineconfiguration.openshift.io/role: e2e` — so the pool wiring is correct; the wait target name was wrong.

## Fix

Discover the scan's remediations by the `compliance.openshift.io/scan-name` label instead of hard-coding a name, wait for whatever was actually generated to roll out, and unapply the same set on cleanup.

- Removes the ~30m timeout.
- Makes the test genuinely exercise the remediation apply/rollout path it claims to (previously it never waited on the real remediation).
- Version-agnostic: works whether the applied remediation is the base name or a suffixed variant.

Jira: https://redhat.atlassian.net/browse/CMP-4485

🤖 Generated with [Claude Code](https://claude.com/claude-code)
