### PR TITLE
CMP-4485: [experiment] Parallelize destructive serial e2e tests across per-worker pools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -621,8 +621,11 @@ e2e-deployment: e2e-set-image prep-e2e ## Run operator deployment end-to-end tes
 	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/deployment $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-deployment-test.log
 
 .PHONY: e2e-serial
-e2e-serial: e2e-set-image prep-e2e ## Run destructive end-to-end tests serially.
-	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) $(GO) test ./tests/e2e/serial $(E2E_GO_TEST_FLAGS) -args $(E2E_ARGS) | tee tests/e2e-serial.log
+# Number of isolated MachineConfigPool lanes the destructive/reboot tests run
+# across in parallel (one worker node per lane). Capped at the worker count.
+E2E_PARALLEL_POOLS?=3
+e2e-serial: e2e-set-image prep-e2e ## Run destructive end-to-end tests, sharded across E2E_PARALLEL_POOLS pools in parallel.
+	@CONTENT_IMAGE=$(E2E_CONTENT_IMAGE_PATH) BROKEN_CONTENT_IMAGE=$(E2E_BROKEN_CONTENT_IMAGE_PATH) E2E_PARALLEL_POOLS=$(E2E_PARALLEL_POOLS) $(GO) test ./tests/e2e/serial $(E2E_GO_TEST_FLAGS) -parallel $(E2E_PARALLEL_POOLS) -args $(E2E_ARGS) | tee tests/e2e-serial.log
 
 .PHONY: e2e-tailoring
 e2e-tailoring: e2e-set-image prep-e2e ## Run profile tailoring end-to-end tests.

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -659,6 +659,13 @@ func (f *Framework) updateScanSettingsForDebug() error {
 }
 
 func (f *Framework) ensureE2EScanSettings() error {
+	return f.ensureE2EScanSettingsForPool(TestPoolName)
+}
+
+// ensureE2EScanSettingsForPool creates a "<poolName>-default" and
+// "<poolName>-default-auto-apply" ScanSetting whose Roles target poolName, so
+// each parallel test lane scans/remediates only its own pool.
+func (f *Framework) ensureE2EScanSettingsForPool(poolName string) error {
 	if f.Platform == "rosa" {
 		fmt.Printf("bypassing ScanSettings test setup because it's not supported on %s\n", f.Platform)
 		return nil
@@ -672,11 +679,11 @@ func (f *Framework) ensureE2EScanSettings() error {
 
 		ssCopy := ss.DeepCopy()
 		ssCopy.ObjectMeta = metav1.ObjectMeta{
-			Name:      "e2e-" + ssName,
+			Name:      poolName + "-" + ssName,
 			Namespace: f.OperatorNamespace,
 		}
 		ssCopy.Roles = []string{
-			TestPoolName,
+			poolName,
 		}
 		ssCopy.Debug = true
 
@@ -706,12 +713,8 @@ func (f *Framework) deleteScanSettings(name string) error {
 	return nil
 }
 
-func (f *Framework) createMachineConfigPool(n string) error {
-	if f.Platform == "rosa" {
-		fmt.Printf("bypassing MachineConfigPool test setup because it's not supported on %s\n", f.Platform)
-		return nil
-	}
-	// get the worker pool
+// getWorkerNodes returns the nodes currently in the worker MachineConfigPool.
+func (f *Framework) getWorkerNodes() ([]corev1.Node, error) {
 	w := "worker"
 	p := &mcfgv1.MachineConfigPool{}
 	getErr := backoff.RetryNotify(
@@ -729,15 +732,42 @@ func (f *Framework) createMachineConfigPool(n string) error {
 			log.Printf("error while getting MachineConfig pool to create sub-pool from: %s. Retrying after %s", err, interval)
 		})
 	if getErr != nil {
-		return fmt.Errorf("failed to get Machine Config Pool %s to create sub-pool from: %w", w, getErr)
+		return nil, fmt.Errorf("failed to get Machine Config Pool %s to create sub-pool from: %w", w, getErr)
 	}
-
 	nodeList, err := f.getNodesForPool(p)
+	if err != nil {
+		return nil, err
+	}
+	return nodeList.Items, nil
+}
+
+func (f *Framework) createMachineConfigPool(n string) error {
+	if f.Platform == "rosa" {
+		fmt.Printf("bypassing MachineConfigPool test setup because it's not supported on %s\n", f.Platform)
+		return nil
+	}
+	nodes, err := f.getWorkerNodes()
 	if err != nil {
 		return err
 	}
+	if len(nodes) == 0 {
+		return fmt.Errorf("no worker nodes found to create Machine Config Pool %s from", n)
+	}
 	// pick the first node in the list so we only have a pool of one
-	node := nodeList.Items[0]
+	return f.createMachineConfigPoolFromNode(n, &nodes[0])
+}
+
+// createMachineConfigPoolFromNode creates a MachineConfigPool named n containing
+// exactly the given node (relabeled into the pool's role). This lets several
+// isolated pools be created from distinct worker nodes so destructive tests can
+// run in parallel, one node per pool.
+func (f *Framework) createMachineConfigPoolFromNode(n string, node *corev1.Node) error {
+	if f.Platform == "rosa" {
+		fmt.Printf("bypassing MachineConfigPool test setup because it's not supported on %s\n", f.Platform)
+		return nil
+	}
+	// the base pool the sub-pool inherits MachineConfigs from
+	w := "worker"
 
 	// create a new pool with a subset of the nodes
 	l := fmt.Sprintf("node-role.kubernetes.io/%s", n)
@@ -763,7 +793,7 @@ func (f *Framework) createMachineConfigPool(n string) error {
 	nodeLabel := make(map[string]string)
 	nodeLabel[l] = ""
 	poolLabels := make(map[string]string)
-	poolLabels["pools.operator.machineconfiguration.openshift.io/e2e"] = ""
+	poolLabels["pools.operator.machineconfiguration.openshift.io/"+n] = ""
 	newPool := &mcfgv1.MachineConfigPool{
 		ObjectMeta: metav1.ObjectMeta{Name: n, Labels: poolLabels},
 		Spec: mcfgv1.MachineConfigPoolSpec{
@@ -801,7 +831,7 @@ func (f *Framework) createMachineConfigPool(n string) error {
 	}
 
 	// wait for pool to come up
-	err = wait.PollImmediate(machineOperationRetryInterval, machineOperationTimeout, func() (bool, error) {
+	err := wait.PollImmediate(machineOperationRetryInterval, machineOperationTimeout, func() (bool, error) {
 		pool := mcfgv1.MachineConfigPool{}
 		err := f.Client.Get(context.TODO(), types.NamespacedName{Name: n}, &pool)
 		if err != nil {

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -62,6 +62,12 @@ type Framework struct {
 	WatchNamespace    string
 	Platform          string
 
+	// TestPools hands out isolated MachineConfigPool lanes to destructive tests
+	// that run in parallel (see testpools.go). testPoolNames tracks the lanes
+	// created during setup so they can be cleaned up on teardown.
+	TestPools     chan *TestPool
+	testPoolNames []string
+
 	restMapper *restmapper.DeferredDiscoveryRESTMapper
 
 	projectRoot       string

--- a/tests/e2e/framework/main_entry.go
+++ b/tests/e2e/framework/main_entry.go
@@ -116,14 +116,12 @@ func (f *Framework) SetUp() error {
 		return fmt.Errorf("failed to set scan setting bindings to debug: %w", err)
 	}
 
-	err = f.ensureE2EScanSettings()
+	// Create one isolated MachineConfigPool lane per worker node (plus matching
+	// ScanSettings) so the destructive/reboot tests can run in parallel, each
+	// against its own pool and node. See testpools.go.
+	err = f.setUpTestPools()
 	if err != nil {
-		return fmt.Errorf("failed to configure scan settings for tests: %w", err)
-	}
-
-	err = f.createMachineConfigPool("e2e")
-	if err != nil {
-		return fmt.Errorf("failed to create Machine Config Pool %s: %w", "e2e", err)
+		return fmt.Errorf("failed to set up test pools: %w", err)
 	}
 	err = f.createInvalidMachineConfigPool("e2e-invalid")
 	if err != nil {
@@ -162,20 +160,11 @@ func (f *Framework) TearDown() error {
 	if os.Getenv("SKIP_MCP_SETUP") != "" {
 		log.Println("SKIP_MCP_SETUP is set, skipping e2e ScanSettings and MachineConfigPool cleanup")
 	} else {
-		err = f.deleteScanSettings("e2e-default")
-		if err != nil {
-			return err
-		}
-		err = f.deleteScanSettings("e2e-default-auto-apply")
-		if err != nil {
-			return err
-		}
-		// unlabel nodes
-		err = f.restoreNodeLabelsForPool("e2e")
-		if err != nil {
-			return err
-		}
-		err = f.cleanUpMachineConfigPool("e2e")
+		// Clean up per-lane ScanSettings. We deliberately don't restore node
+		// labels or delete the lane MachineConfigPools here (see tearDownTestPools):
+		// that would reboot every lane node back to rendered-worker, and the CI
+		// cluster is torn down right after, so the work would be wasted.
+		err = f.tearDownTestPools()
 		if err != nil {
 			return err
 		}

--- a/tests/e2e/framework/testpools.go
+++ b/tests/e2e/framework/testpools.go
@@ -1,0 +1,130 @@
+package framework
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/ComplianceAsCode/compliance-operator/pkg/utils"
+)
+
+// TestPool is one isolated MachineConfigPool "lane" that a destructive serial
+// test runs against. Each lane owns a distinct worker node and its own pair of
+// ScanSettings, so the reboot-heavy tests can execute in parallel without
+// contending on a single shared pool/node.
+type TestPool struct {
+	Index                int
+	Name                 string
+	DefaultScanSetting   string
+	AutoApplyScanSetting string
+}
+
+// NodeRoleSelector returns the node selector matching this lane's single node.
+func (p *TestPool) NodeRoleSelector() map[string]string {
+	return utils.GetNodeRoleSelector(p.Name)
+}
+
+// testPoolCount is the number of parallel destructive lanes to set up. It
+// defaults to 1 (a single "e2e" pool, identical to the historical behavior, so
+// non-serial suites that share SetUp are unaffected) and is raised to N via
+// E2E_PARALLEL_POOLS - the serial suite's Makefile target sets it. setUpTestPools
+// caps it at the number of available worker nodes.
+func testPoolCount() int {
+	if v := os.Getenv("E2E_PARALLEL_POOLS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+		log.Printf("ignoring invalid E2E_PARALLEL_POOLS=%q; using default", v)
+	}
+	return 1
+}
+
+// setUpTestPools carves one MachineConfigPool lane per worker node (up to
+// testPoolCount) and creates a matching pair of ScanSettings for each. Lanes are
+// handed to tests via AcquireTestPool. We reuse the existing worker nodes rather
+// than scaling the cluster; when every worker becomes a lane the operator still
+// runs (nodes keep their worker label) but has no idle worker to fall back to
+// during simultaneous reboots.
+func (f *Framework) setUpTestPools() error {
+	if f.Platform == "rosa" {
+		fmt.Printf("bypassing test pool setup because MachineConfigPools are not supported on %s\n", f.Platform)
+		f.TestPools = make(chan *TestPool, 1)
+		return nil
+	}
+
+	nodes, err := f.getWorkerNodes()
+	if err != nil {
+		return fmt.Errorf("failed to list worker nodes for test pools: %w", err)
+	}
+
+	n := testPoolCount()
+	if n > len(nodes) {
+		log.Printf("E2E_PARALLEL_POOLS=%d exceeds available worker nodes (%d); capping to %d", n, len(nodes), len(nodes))
+		n = len(nodes)
+	}
+	if n < 1 {
+		return fmt.Errorf("no worker nodes available to create test pools")
+	}
+
+	f.TestPools = make(chan *TestPool, n)
+	f.testPoolNames = nil
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("%s-%d", TestPoolName, i)
+		if n == 1 {
+			// Preserve the historical single-pool name "e2e" (and "e2e-default"
+			// ScanSettings) when not sharding, so suites that share SetUp but
+			// don't run in parallel behave exactly as before.
+			name = TestPoolName
+		}
+		node := &nodes[i]
+		if err := f.createMachineConfigPoolFromNode(name, node); err != nil {
+			return fmt.Errorf("failed to create test pool %s: %w", name, err)
+		}
+		if err := f.ensureE2EScanSettingsForPool(name); err != nil {
+			return fmt.Errorf("failed to create scan settings for test pool %s: %w", name, err)
+		}
+		f.testPoolNames = append(f.testPoolNames, name)
+		f.TestPools <- &TestPool{
+			Index:                i,
+			Name:                 name,
+			DefaultScanSetting:   name + "-default",
+			AutoApplyScanSetting: name + "-default-auto-apply",
+		}
+		log.Printf("test pool lane %d ready on node %s: %s", i, node.Name, name)
+	}
+	return nil
+}
+
+// AcquireTestPool checks out an isolated pool lane for a destructive test,
+// blocking until one is free, and returns it when the test ends. Call
+// t.Parallel() before this so lanes are shared across concurrent tests.
+func (f *Framework) AcquireTestPool(t *testing.T) *TestPool {
+	t.Helper()
+	p := <-f.TestPools
+	t.Logf("acquired test pool lane %s", p.Name)
+	t.Cleanup(func() {
+		f.TestPools <- p
+		t.Logf("released test pool lane %s", p.Name)
+	})
+	return p
+}
+
+// tearDownTestPools deletes the per-lane ScanSettings. It intentionally does NOT
+// restore node labels or delete the MachineConfigPools: that would reboot every
+// lane node back to rendered-worker, and the CI cluster is destroyed right after
+// the run, so the work would be wasted.
+func (f *Framework) tearDownTestPools() error {
+	if f.Platform == "rosa" {
+		return nil
+	}
+	for _, name := range f.testPoolNames {
+		for _, suffix := range []string{"-default", "-default-auto-apply"} {
+			if err := f.deleteScanSettings(name + suffix); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/tests/e2e/serial/main_test.go
+++ b/tests/e2e/serial/main_test.go
@@ -754,10 +754,12 @@ func TestTolerations(t *testing.T) {
 }
 
 func TestAutoRemediate(t *testing.T) {
+	t.Parallel()
 	f := framework.Global
+	pool := f.AcquireTestPool(t)
 	// FIXME, maybe have a func that returns a struct with suite name and scan names?
 	suiteName := "test-remediate"
-	scanName := fmt.Sprintf("%s-e2e", suiteName)
+	scanName := fmt.Sprintf("%s-%s", suiteName, pool.Name)
 
 	tp := &compv1alpha1.TailoredProfile{
 		ObjectMeta: metav1.ObjectMeta{
@@ -800,7 +802,7 @@ func TestAutoRemediate(t *testing.T) {
 		SettingsRef: &compv1alpha1.NamedObjectReference{
 			APIGroup: "compliance.openshift.io/v1alpha1",
 			Kind:     "ScanSetting",
-			Name:     "e2e-default-auto-apply",
+			Name:     pool.AutoApplyScanSetting,
 		},
 	}
 	err := f.Client.Create(context.TODO(), ssb, nil)
@@ -812,7 +814,7 @@ func TestAutoRemediate(t *testing.T) {
 	// Get the MachineConfigPool before a scan or remediation has been applied
 	// This way, we can check that it changed without race-conditions
 	poolBeforeRemediation := &mcfgv1.MachineConfigPool{}
-	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: framework.TestPoolName}, poolBeforeRemediation)
+	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: pool.Name}, poolBeforeRemediation)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -901,7 +903,7 @@ func TestAutoRemediate(t *testing.T) {
 	}
 
 	// We need to wait for both the pool to update..
-	err = f.WaitForMachinePoolUpdate(framework.TestPoolName, dummyAction, poolHasNoMc, nil)
+	err = f.WaitForMachinePoolUpdate(pool.Name, dummyAction, poolHasNoMc, nil)
 	if err != nil {
 		t.Fatalf("failed waiting for workers to come back up after deleting MachineConfig: %s", err)
 	}
@@ -911,7 +913,9 @@ func TestAutoRemediate(t *testing.T) {
 }
 
 func TestUnapplyRemediation(t *testing.T) {
+	t.Parallel()
 	f := framework.Global
+	pool := f.AcquireTestPool(t)
 	// FIXME, maybe have a func that returns a struct with suite name and scan names?
 	suiteName := "test-unapply-remediation"
 
@@ -932,7 +936,7 @@ func TestUnapplyRemediation(t *testing.T) {
 						ContentImage: contentImagePath,
 						Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 						Content:      framework.RhcosContentFile,
-						NodeSelector: framework.GetPoolNodeRoleSelector(),
+						NodeSelector: pool.NodeRoleSelector(),
 						ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 							Debug: true,
 						},
@@ -956,28 +960,28 @@ func TestUnapplyRemediation(t *testing.T) {
 	}
 
 	// Pause the MC so that we have only one reboot
-	err = f.PauseMachinePool(framework.TestPoolName)
+	err = f.PauseMachinePool(pool.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Apply both remediations
 	workersNoRootLoginsRemName := fmt.Sprintf("%s-no-direct-root-logins", workerScanName)
-	err = f.ApplyRemediationAndCheck(f.OperatorNamespace, workersNoRootLoginsRemName, framework.TestPoolName)
+	err = f.ApplyRemediationAndCheck(f.OperatorNamespace, workersNoRootLoginsRemName, pool.Name)
 	if err != nil {
 		log.Printf("WARNING: Got an error while applying remediation '%s': %v\n", workersNoRootLoginsRemName, err)
 	}
 	log.Printf("remediation %s applied", workersNoRootLoginsRemName)
 
 	workersNoEmptyPassRemName := fmt.Sprintf("%s-no-empty-passwords", workerScanName)
-	err = f.ApplyRemediationAndCheck(f.OperatorNamespace, workersNoEmptyPassRemName, framework.TestPoolName)
+	err = f.ApplyRemediationAndCheck(f.OperatorNamespace, workersNoEmptyPassRemName, pool.Name)
 	if err != nil {
 		log.Printf("WARNING: Got an error while applying remediation '%s': %v\n", workersNoEmptyPassRemName, err)
 	}
 	log.Printf("remediation %s applied", workersNoEmptyPassRemName)
 
 	// resume the MCP so that the remediation gets applied
-	f.ResumeMachinePool(framework.TestPoolName)
+	f.ResumeMachinePool(pool.Name)
 
 	err = f.WaitForNodesToBeReady()
 	if err != nil {
@@ -996,7 +1000,7 @@ func TestUnapplyRemediation(t *testing.T) {
 
 	// Revert one remediation. The MC should stay, but its generation should bump
 	log.Printf("reverting remediation %s\n", workersNoEmptyPassRemName)
-	err = f.UnApplyRemediationAndCheck(f.OperatorNamespace, workersNoEmptyPassRemName, framework.TestPoolName)
+	err = f.UnApplyRemediationAndCheck(f.OperatorNamespace, workersNoEmptyPassRemName, pool.Name)
 	if err != nil {
 		log.Printf("WARNING: Got an error while unapplying remediation '%s': %v\n", workersNoEmptyPassRemName, err)
 	}
@@ -1004,7 +1008,7 @@ func TestUnapplyRemediation(t *testing.T) {
 
 	// When we unapply the second remediation, the MC should be deleted, too
 	log.Printf("reverting remediation %s", workersNoRootLoginsRemName)
-	err = f.UnApplyRemediationAndCheck(f.OperatorNamespace, workersNoRootLoginsRemName, framework.TestPoolName)
+	err = f.UnApplyRemediationAndCheck(f.OperatorNamespace, workersNoRootLoginsRemName, pool.Name)
 	if err != nil {
 		log.Printf("WARNING: Got an error while unapplying remediation '%s': %v\n", workersNoEmptyPassRemName, err)
 	}
@@ -1351,7 +1355,9 @@ func TestPlatformAndNodeSuiteScan(t *testing.T) {
 }
 
 func TestUpdateRemediation(t *testing.T) {
+	t.Parallel()
 	f := framework.Global
+	pool := f.AcquireTestPool(t)
 	origSuiteName := "test-update-remediation"
 	workerScanName := fmt.Sprintf("%s-e2e-scan", origSuiteName)
 
@@ -1397,7 +1403,7 @@ func TestUpdateRemediation(t *testing.T) {
 						Profile:      "xccdf_org.ssgproject.content_profile_moderate",
 						Rule:         "xccdf_org.ssgproject.content_rule_no_empty_passwords",
 						Content:      framework.RhcosContentFile,
-						NodeSelector: framework.GetPoolNodeRoleSelector(),
+						NodeSelector: pool.NodeRoleSelector(),
 						ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 							Debug: true,
 						},
@@ -1421,7 +1427,7 @@ func TestUpdateRemediation(t *testing.T) {
 	}
 
 	workersNoEmptyPassRemName := fmt.Sprintf("%s-no-empty-passwords", workerScanName)
-	err = f.ApplyRemediationAndCheck(f.OperatorNamespace, workersNoEmptyPassRemName, framework.TestPoolName)
+	err = f.ApplyRemediationAndCheck(f.OperatorNamespace, workersNoEmptyPassRemName, pool.Name)
 	if err != nil {
 		log.Printf("WARNING: Got an error while applying remediation '%s': %v", workersNoEmptyPassRemName, err)
 	}
@@ -1456,7 +1462,7 @@ func TestUpdateRemediation(t *testing.T) {
 
 	log.Printf("will remove obsolete data from remediation\n")
 	renderedMcName := fmt.Sprintf("75-%s", workersNoEmptyPassRemName)
-	err = f.RemoveObsoleteRemediationAndCheck(f.OperatorNamespace, workersNoEmptyPassRemName, renderedMcName, framework.TestPoolName)
+	err = f.RemoveObsoleteRemediationAndCheck(f.OperatorNamespace, workersNoEmptyPassRemName, renderedMcName, pool.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1473,7 +1479,7 @@ func TestUpdateRemediation(t *testing.T) {
 	}
 
 	// Finally clean up by removing the remediation and waiting for the nodes to reboot one more time
-	err = f.UnApplyRemediationAndCheck(f.OperatorNamespace, workersNoEmptyPassRemName, framework.TestPoolName)
+	err = f.UnApplyRemediationAndCheck(f.OperatorNamespace, workersNoEmptyPassRemName, pool.Name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1699,7 +1705,9 @@ func TestVariableTemplate(t *testing.T) {
 }
 
 func TestKubeletConfigRemediation(t *testing.T) {
+	t.Parallel()
 	f := framework.Global
+	pool := f.AcquireTestPool(t)
 	var baselineImage = fmt.Sprintf("%s:%s", brokenContentImagePath, "new_kubeletconfig")
 	const requiredRule = "kubelet-enable-streaming-connections"
 	pbName := framework.GetObjNameFromTest(t)
@@ -1768,7 +1776,7 @@ func TestKubeletConfigRemediation(t *testing.T) {
 		SettingsRef: &compv1alpha1.NamedObjectReference{
 			APIGroup: "compliance.openshift.io/v1alpha1",
 			Kind:     "ScanSetting",
-			Name:     "e2e-default-auto-apply",
+			Name:     pool.AutoApplyScanSetting,
 		},
 	}
 
@@ -1784,7 +1792,7 @@ func TestKubeletConfigRemediation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	scanName := suiteName + "-" + framework.TestPoolName
+	scanName := suiteName + "-" + pool.Name
 
 	// We need to check that the remediation is auto-applied and save
 	// the object so we can delete it later
@@ -2482,7 +2490,9 @@ func TestScanTailoredProfileExtendsDeprecated(t *testing.T) {
 }
 
 func TestRuntimeSSHConfigWithRemediation(t *testing.T) {
+	t.Parallel()
 	f := framework.Global
+	pool := f.AcquireTestPool(t)
 
 	baselineImage := fmt.Sprintf("%s:%s", brokenContentImagePath, "runtime_sshd")
 	pbName := framework.GetObjNameFromTest(t)
@@ -2516,7 +2526,7 @@ func TestRuntimeSSHConfigWithRemediation(t *testing.T) {
 						Profile:      "xccdf_org.ssgproject.content_profile_e8",
 						Rule:         "xccdf_org.ssgproject.content_rule_sshd_disable_gssapi_auth",
 						Content:      framework.RhcosContentFile,
-						NodeSelector: framework.GetPoolNodeRoleSelector(),
+						NodeSelector: pool.NodeRoleSelector(),
 						ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
 							Debug: true,
 						},
@@ -2534,7 +2544,7 @@ func TestRuntimeSSHConfigWithRemediation(t *testing.T) {
 
 	// Get the MachineConfigPool before remediation
 	poolBeforeRemediation := &mcfgv1.MachineConfigPool{}
-	if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: framework.TestPoolName}, poolBeforeRemediation); err != nil {
+	if err := f.Client.Get(context.TODO(), types.NamespacedName{Name: pool.Name}, poolBeforeRemediation); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2611,7 +2621,7 @@ func TestRuntimeSSHConfigWithRemediation(t *testing.T) {
 			continue
 		}
 		// Unapply the remediation
-		if err := f.UnApplyRemediationAndCheck(f.OperatorNamespace, remName, framework.TestPoolName); err != nil {
+		if err := f.UnApplyRemediationAndCheck(f.OperatorNamespace, remName, pool.Name); err != nil {
 			t.Logf("Could not unapply remediation %s: %v", remName, err)
 		}
 


### PR DESCRIPTION
**Experimental — measuring whether the destructive serial e2e tests are faster when run in parallel.** Opening this to let CI time it and to see whether concurrent node reboots are stable. Not necessarily for merge as-is.

## Motivation
The e2e-aws-serial suite is ~97 min of test wall-clock, and the 5 reboot/remediation tests dominate it because they each apply a MachineConfig to the single shared `e2e` pool and wait for a node reboot — strictly one after another.

## What this does
Give each destructive test its own isolated `MachineConfigPool` lane so they run concurrently:

- `framework/testpools.go` (new): `TestPool` lane + `f.AcquireTestPool(t)` allocator (buffered channel — blocks/queues when all lanes are busy, releases via `t.Cleanup`). `setUpTestPools()` carves **one pool per existing worker node** (no cluster scaling — reuses what's available) with matching per-lane ScanSettings.
- `framework/common.go`: split `createMachineConfigPool` into `getWorkerNodes()` + `createMachineConfigPoolFromNode()`; generalized `ensureE2EScanSettings` → `…ForPool(name)`.
- The 5 remediation tests (`TestAutoRemediate`, `TestUnapplyRemediation`, `TestUpdateRemediation`, `TestKubeletConfigRemediation`, `TestRuntimeSSHConfigWithRemediation`) now `t.Parallel()` and target their acquired lane.
- Distinct MachineConfigPools reboot **independently** (MCO parallelizes across pools), so lanes proceed at the same time.

Also includes the **CMP-4485 SSH remediation fix** (label-based remediation discovery) as the first commit.

## Safety / scoping
- Lane count **defaults to 1** (legacy single `e2e` pool) so the other e2e suites that share `SetUp` are **unaffected**. The `e2e-serial` Makefile target raises it to **3** via `E2E_PARALLEL_POOLS` (+ `-parallel 3`).
- Teardown deletes per-lane ScanSettings but **skips** the node-label restore / pool deletion (those would reboot every lane node back to `rendered-worker`, wasted since the CI cluster is torn down right after).

## Known risk this experiment is testing
With 3 lanes on a 3-worker cluster, **every** worker is a reboot target, so the compliance-operator pod has no idle worker to fall back to during simultaneous reboots. It should survive (MCO drives the reboots; tests poll with long timeouts), but if it flakes/wedges, set `E2E_PARALLEL_POOLS=2` to keep one baseline worker (2 lanes).

## Expected result
Reboot block ~37 min (post-SSH-fix) → ~13–15 min at 3 lanes. CI timing on this PR is the real measurement.

Jira: https://redhat.atlassian.net/browse/CMP-4485

🤖 Generated with [Claude Code](https://claude.com/claude-code)
