### PR TITLE
CMP-4491: Fix false-positive audit_error_alert_exists on empty PrometheusRule spec

### DIFF
--- a/cmd/manager/scap.go
+++ b/cmd/manager/scap.go
@@ -539,30 +539,46 @@ func fetch(ctx context.Context, streamDispatcher streamerDispatcherFn, rfClients
 	return results, warnings, nil
 }
 
-func filter(ctx context.Context, rawobj []byte, filter string) ([]byte, error) {
-	fltr, fltrErr := gojq.Parse(filter)
-	if fltrErr != nil {
-		return nil, fmt.Errorf("could not create filter '%s': %w", filter, fltrErr)
+func execFilter(ctx context.Context, obj map[string]interface{}, filterExpr string) (interface{}, gojq.Iter, error) {
+	fltr, err := gojq.Parse(filterExpr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not create filter '%s': %w", filterExpr, err)
 	}
+	iter := fltr.RunWithContext(ctx, obj)
+	v, ok := iter.Next()
+	if !ok {
+		return nil, nil, fmt.Errorf("couldn't get filtered object")
+	}
+	if err, ok := v.(error); ok {
+		return nil, nil, err
+	}
+	return v, iter, nil
+}
+
+func filter(ctx context.Context, rawobj []byte, filterExpr string) ([]byte, error) {
 	obj := map[string]interface{}{}
 	unmarshallErr := json.Unmarshal(rawobj, &obj)
 	if unmarshallErr != nil {
 		return nil, fmt.Errorf("Error unmarshalling json: %w", unmarshallErr)
 	}
-	iter := fltr.RunWithContext(ctx, obj)
-	v, ok := iter.Next()
-	if !ok {
-		DBG("No result from filter. This is an issue and an error will be returned.")
-		return nil, fmt.Errorf("couldn't get filtered object")
-	}
-	if err, ok := v.(error); ok {
-		DBG("Error while filtering: %s", err)
-		// gojq may return a diverse set of internal errors caused by null values.
-		// These errors are happen when a piped filter ends up acting on a null value.
-		if strings.HasSuffix(err.Error(), ": null") {
-			return nil, fmt.Errorf("Skipping empty filter result from '%s': %w", filter, NullValErr)
+
+	v, iter, execErr := execFilter(ctx, obj, filterExpr)
+	if execErr != nil {
+		DBG("Error while filtering: %s", execErr)
+		if strings.HasSuffix(execErr.Error(), ": null") {
+			// Retry with optional iteration to gracefully skip null values
+			// instead of failing the entire filter.
+			optFilter := strings.ReplaceAll(filterExpr, "[]", "[]?")
+			if optFilter != filterExpr {
+				DBG("Retrying with optional iteration: '%s'", optFilter)
+				v, iter, execErr = execFilter(ctx, obj, optFilter)
+			}
+			if execErr != nil {
+				return nil, fmt.Errorf("Skipping empty filter result from '%s': %w", filterExpr, NullValErr)
+			}
+		} else {
+			return nil, execErr
 		}
-		return nil, err
 	}
 
 	var out []byte
@@ -591,7 +607,7 @@ func filter(ctx context.Context, rawobj []byte, filter string) ([]byte, error) {
 	_, isNotEOF := iter.Next()
 	if isNotEOF {
 		DBG("No more results should have come from the filter. This is an issue with the content.")
-		return out, fmt.Errorf("Skipping extra results from filter '%s': %w", filter, MoreThanOneObjErr)
+		return out, fmt.Errorf("Skipping extra results from filter '%s': %w", filterExpr, MoreThanOneObjErr)
 	}
 	return out, nil
 }

--- a/cmd/manager/scap_test.go
+++ b/cmd/manager/scap_test.go
@@ -325,9 +325,40 @@ var _ = Describe("Testing filtering", func() {
 				rawmc, readErr = io.ReadAll(nsFile)
 				Expect(readErr).To(BeNil())
 			})
-			It("skips filter piping errors", func() {
-				_, filterErr := filter(context.TODO(), rawmc, `[.items[] | select(.metadata.name | test("^rendered-worker-[0-9a-z]+$|^rendered-master-[0-9a-z]+$"))] | map(.spec.fips == true)`)
-				Expect(filterErr).Should(MatchError(NullValErr))
+			It("retries with optional iteration on null items", func() {
+				filteredOut, filterErr := filter(context.TODO(), rawmc, `[.items[] | select(.metadata.name | test("^rendered-worker-[0-9a-z]+$|^rendered-master-[0-9a-z]+$"))] | map(.spec.fips == true)`)
+				Expect(filterErr).To(BeNil())
+				Expect(string(filteredOut)).To(Equal("[]"))
+			})
+		})
+		Context("PrometheusRule with empty spec", func() {
+			var rawpr []byte
+			BeforeEach(func() {
+				prFile, err := os.Open("../../tests/data/prometheusrules_mixed.json")
+				Expect(err).To(BeNil())
+				var readErr error
+				rawpr, readErr = io.ReadAll(prFile)
+				Expect(readErr).To(BeNil())
+			})
+			It("retries with optional iteration and preserves valid data", func() {
+				filteredOut, filterErr := filter(context.TODO(), rawpr,
+					`[.items[].spec.groups[].rules[].expr]`)
+				Expect(filterErr).To(BeNil())
+				var exprArr []interface{}
+				unmErr := json.Unmarshal(filteredOut, &exprArr)
+				Expect(unmErr).To(BeNil())
+				Expect(exprArr).To(HaveLen(1))
+				Expect(exprArr[0]).To(Equal("apiserver_audit_error_total / apiserver_audit_event_total > 0"))
+			})
+			It("succeeds directly with optional iterator", func() {
+				filteredOut, filterErr := filter(context.TODO(), rawpr,
+					`[.items[]?.spec.groups[]?.rules[]?.expr]`)
+				Expect(filterErr).To(BeNil())
+				var exprArr []interface{}
+				unmErr := json.Unmarshal(filteredOut, &exprArr)
+				Expect(unmErr).To(BeNil())
+				Expect(exprArr).To(HaveLen(1))
+				Expect(exprArr[0]).To(Equal("apiserver_audit_error_total / apiserver_audit_event_total > 0"))
 			})
 		})
 	})

--- a/images/testcontent/cel_content/ssg-ocp4-ds.xml
+++ b/images/testcontent/cel_content/ssg-ocp4-ds.xml
@@ -13350,7 +13350,7 @@ For more information, consult the
 Therefore, you need to use a tool that can query the OCP API, retrieve the following:
 <html:ul><html:li><html:code class="ocp-api-endpoint" id="5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7">/apis/monitoring.coreos.com/v1/prometheusrules</html:code>
     API endpoint, filter with with the <html:code>jq</html:code> utility using the following filter
-    <html:code class="ocp-api-filter" id="filter-5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7">[.items[].spec.groups[].rules[].expr]</html:code>
+    <html:code class="ocp-api-filter" id="filter-5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7">[.items[]?.spec.groups[]?.rules[]?.expr]</html:code>
     and persist it to the local
     <html:code class="ocp-dump-location" id="dump-5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7"><xccdf-1.2:sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy"/>/apis/monitoring.coreos.com/v1/prometheusrules#5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7</html:code>
     file.
@@ -39366,7 +39366,7 @@ openvswitch
         </ocil:boolean_question>
         <ocil:boolean_question id="ocil:ssg-audit_error_alert_exists_question:question:1">
           <ocil:question_text>Run the following command:
-$ oc get --all-namespaces prometheusrules -o json | jq '[.items[].spec.groups[].rules[].expr]' | grep apiserver_audit
+$ oc get --all-namespaces prometheusrules -o json | jq '[.items[]?.spec.groups[]?.rules[]?.expr]' | grep apiserver_audit
 Make sure that there's a prometheus rule that verifies the apiserver_audit_error_total and 
 apiserver_audit_event_total metrics and will alert based on an error threshold.
       Is it the case that Audit log errors do not generate an alert?

--- a/images/testcontent/deprecated_profile/ssg-ocp4-ds.xml
+++ b/images/testcontent/deprecated_profile/ssg-ocp4-ds.xml
@@ -13350,7 +13350,7 @@ For more information, consult the
 Therefore, you need to use a tool that can query the OCP API, retrieve the following:
 <html:ul><html:li><html:code class="ocp-api-endpoint" id="5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7">/apis/monitoring.coreos.com/v1/prometheusrules</html:code>
     API endpoint, filter with with the <html:code>jq</html:code> utility using the following filter
-    <html:code class="ocp-api-filter" id="filter-5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7">[.items[].spec.groups[].rules[].expr]</html:code>
+    <html:code class="ocp-api-filter" id="filter-5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7">[.items[]?.spec.groups[]?.rules[]?.expr]</html:code>
     and persist it to the local
     <html:code class="ocp-dump-location" id="dump-5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7"><xccdf-1.2:sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy"/>/apis/monitoring.coreos.com/v1/prometheusrules#5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7</html:code>
     file.
@@ -39366,7 +39366,7 @@ openvswitch
         </ocil:boolean_question>
         <ocil:boolean_question id="ocil:ssg-audit_error_alert_exists_question:question:1">
           <ocil:question_text>Run the following command:
-$ oc get --all-namespaces prometheusrules -o json | jq '[.items[].spec.groups[].rules[].expr]' | grep apiserver_audit
+$ oc get --all-namespaces prometheusrules -o json | jq '[.items[]?.spec.groups[]?.rules[]?.expr]' | grep apiserver_audit
 Make sure that there's a prometheus rule that verifies the apiserver_audit_error_total and 
 apiserver_audit_event_total metrics and will alert based on an error threshold.
       Is it the case that Audit log errors do not generate an alert?

--- a/images/testcontent/from/ssg-ocp4-ds.xml
+++ b/images/testcontent/from/ssg-ocp4-ds.xml
@@ -15697,7 +15697,7 @@ and make sure it outputs a value.
         </ocil:boolean_question>
         <ocil:boolean_question id="ocil:ssg-audit_error_alert_exists_question:question:1">
           <ocil:question_text>Run the following command:
-oc get  prometheusrules instances -o json | jq '[.items[].spec.groups[].rules[].expr]'
+oc get  prometheusrules instances -o json | jq '[.items[]?.spec.groups[]?.rules[]?.expr]'
 The output should return a list of URL entries with https:// or tls:// transport.
       Is it the case that Audit log errors do not generate an alert?
       </ocil:question_text>
@@ -23385,7 +23385,7 @@ For more information, consult the
 Therefore, you need to use a tool that can query the OCP API, retrieve the following:
 <html:ul><html:li><html:code class="ocp-api-endpoint" id="0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">/apis/monitoring.coreos.com/v1/prometheusrules?limit=500</html:code>
     API endpoint, filter with with the <html:code>jq</html:code> utility using the following filter
-    <html:code class="ocp-api-filter" id="filter-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">[.items[].spec.groups[].rules[].expr]</html:code>
+    <html:code class="ocp-api-filter" id="filter-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">[.items[]?.spec.groups[]?.rules[]?.expr]</html:code>
     and persist it to the local
     <html:code class="ocp-dump-location" id="dump-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464"><xccdf-1.2:sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy"/>/apis/monitoring.coreos.com/v1/prometheusrules?limit=500#0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464</html:code>
     file.

--- a/images/testcontent/hide_rule/ssg-ocp4-ds.xml
+++ b/images/testcontent/hide_rule/ssg-ocp4-ds.xml
@@ -12935,7 +12935,7 @@ For more information, consult the
 Therefore, you need to use a tool that can query the OCP API, retrieve the following:
 <html:ul><html:li><html:code class="ocp-api-endpoint" id="72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6">/apis/monitoring.coreos.com/v1/prometheusrules?limit=500</html:code>
     API endpoint, filter with with the <html:code>jq</html:code> utility using the following filter
-    <html:code class="ocp-api-filter" id="filter-72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6">[.items[].spec.groups[].rules[].expr]</html:code>
+    <html:code class="ocp-api-filter" id="filter-72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6">[.items[]?.spec.groups[]?.rules[]?.expr]</html:code>
     and persist it to the local
     <html:code class="ocp-dump-location" id="dump-72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6"><xccdf-1.2:sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy"/>/apis/monitoring.coreos.com/v1/prometheusrules?limit=500#72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6</html:code>
     file.
@@ -40075,7 +40075,7 @@ and make sure it outputs 0.
         </ocil:boolean_question>
         <ocil:boolean_question id="ocil:ssg-audit_error_alert_exists_question:question:1">
           <ocil:question_text>Run the following command:
-oc get --all-namespaces prometheusrules -o json | jq '[.items[].spec.groups[].rules[].expr]' | grep apiserver_audit
+oc get --all-namespaces prometheusrules -o json | jq '[.items[]?.spec.groups[]?.rules[]?.expr]' | grep apiserver_audit
 Make sure that there's a prometheus rule that verifies the apiserver_audit_error_total and 
 apiserver_audit_event_total metrics and will alert based on an error threshold.
       Is it the case that Audit log errors do not generate an alert?

--- a/images/testcontent/kubelet_default/ssg-ocp4-ds.xml
+++ b/images/testcontent/kubelet_default/ssg-ocp4-ds.xml
@@ -13064,7 +13064,7 @@ For more information, consult the
 Therefore, you need to use a tool that can query the OCP API, retrieve the following:
 <html:ul><html:li><html:code class="ocp-api-endpoint" id="72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6">/apis/monitoring.coreos.com/v1/prometheusrules?limit=500</html:code>
     API endpoint, filter with with the <html:code>jq</html:code> utility using the following filter
-    <html:code class="ocp-api-filter" id="filter-72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6">[.items[].spec.groups[].rules[].expr]</html:code>
+    <html:code class="ocp-api-filter" id="filter-72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6">[.items[]?.spec.groups[]?.rules[]?.expr]</html:code>
     and persist it to the local
     <html:code class="ocp-dump-location" id="dump-72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6"><xccdf-1.2:sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy"/>/apis/monitoring.coreos.com/v1/prometheusrules?limit=500#72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6</html:code>
     file.
@@ -40387,7 +40387,7 @@ TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
         </ocil:boolean_question>
         <ocil:boolean_question id="ocil:ssg-audit_error_alert_exists_question:question:1">
           <ocil:question_text>Run the following command:
-oc get --all-namespaces prometheusrules -o json | jq '[.items[].spec.groups[].rules[].expr]' | grep apiserver_audit
+oc get --all-namespaces prometheusrules -o json | jq '[.items[]?.spec.groups[]?.rules[]?.expr]' | grep apiserver_audit
 Make sure that there's a prometheus rule that verifies the apiserver_audit_error_total and 
 apiserver_audit_event_total metrics and will alert based on an error threshold.
       Is it the case that Audit log errors do not generate an alert?

--- a/images/testcontent/kubeletconfig/ssg-ocp4-ds.xml
+++ b/images/testcontent/kubeletconfig/ssg-ocp4-ds.xml
@@ -15657,7 +15657,7 @@ and make sure it outputs a value.
         </ocil:boolean_question>
         <ocil:boolean_question id="ocil:ssg-audit_error_alert_exists_question:question:1">
           <ocil:question_text>Run the following command:
-oc get  prometheusrules instances -o json | jq '[.items[].spec.groups[].rules[].expr]'
+oc get  prometheusrules instances -o json | jq '[.items[]?.spec.groups[]?.rules[]?.expr]'
 The output should return a list of URL entries with https:// or tls:// transport.
       Is it the case that Audit log errors do not generate an alert?
       </ocil:question_text>
@@ -23297,7 +23297,7 @@ For more information, consult the
 Therefore, you need to use a tool that can query the OCP API, retrieve the following:
 <html:ul><html:li><html:code class="ocp-api-endpoint" id="0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">/apis/monitoring.coreos.com/v1/prometheusrules?limit=500</html:code>
     API endpoint, filter with with the <html:code>jq</html:code> utility using the following filter
-    <html:code class="ocp-api-filter" id="filter-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">[.items[].spec.groups[].rules[].expr]</html:code>
+    <html:code class="ocp-api-filter" id="filter-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">[.items[]?.spec.groups[]?.rules[]?.expr]</html:code>
     and persist it to the local
     <html:code class="ocp-dump-location" id="dump-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464"><xccdf-1.2:sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy"/>/apis/monitoring.coreos.com/v1/prometheusrules?limit=500#0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464</html:code>
     file.

--- a/images/testcontent/new_kubeletconfig/ssg-ocp4-ds.xml
+++ b/images/testcontent/new_kubeletconfig/ssg-ocp4-ds.xml
@@ -10270,7 +10270,7 @@ For more information, consult the
 Therefore, you need to use a tool that can query the OCP API, retrieve the following:
 <html:ul><html:li><html:code class="ocp-api-endpoint" id="5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7">/apis/monitoring.coreos.com/v1/prometheusrules</html:code>
     API endpoint, filter with with the <html:code>jq</html:code> utility using the following filter
-    <html:code class="ocp-api-filter" id="filter-5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7">[.items[].spec.groups[].rules[].expr]</html:code>
+    <html:code class="ocp-api-filter" id="filter-5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7">[.items[]?.spec.groups[]?.rules[]?.expr]</html:code>
     and persist it to the local
     <html:code class="ocp-dump-location" id="dump-5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7"><xccdf-1.2:sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy"/>/apis/monitoring.coreos.com/v1/prometheusrules#5fd5244e3dcae63319f7e86b918cb8ea6ce1b4124670ccb43750d7a75ca03cb7</html:code>
     file.
@@ -36063,7 +36063,7 @@ and make sure it outputs 0.
         </ocil:boolean_question>
         <ocil:boolean_question id="ocil:ssg-audit_error_alert_exists_question:question:1">
           <ocil:question_text>Run the following command:
-oc get --all-namespaces prometheusrules -o json | jq '[.items[].spec.groups[].rules[].expr]' | grep apiserver_audit
+oc get --all-namespaces prometheusrules -o json | jq '[.items[]?.spec.groups[]?.rules[]?.expr]' | grep apiserver_audit
 Make sure that there's a prometheus rule that verifies the apiserver_audit_error_total and 
 apiserver_audit_event_total metrics and will alert based on an error threshold.
       Is it the case that Audit log errors do not generate an alert?

--- a/images/testcontent/to/ssg-ocp4-ds.xml
+++ b/images/testcontent/to/ssg-ocp4-ds.xml
@@ -15697,7 +15697,7 @@ and make sure it outputs a value.
         </ocil:boolean_question>
         <ocil:boolean_question id="ocil:ssg-audit_error_alert_exists_question:question:1">
           <ocil:question_text>Run the following command:
-oc get  prometheusrules instances -o json | jq '[.items[].spec.groups[].rules[].expr]'
+oc get  prometheusrules instances -o json | jq '[.items[]?.spec.groups[]?.rules[]?.expr]'
 The output should return a list of URL entries with https:// or tls:// transport.
       Is it the case that Audit log errors do not generate an alert?
       </ocil:question_text>
@@ -23386,7 +23386,7 @@ For more information, consult the
 Therefore, you need to use a tool that can query the OCP API, retrieve the following:
 <html:ul><html:li><html:code class="ocp-api-endpoint" id="0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">/apis/monitoring.coreos.com/v1/prometheusrules?limit=500</html:code>
     API endpoint, filter with with the <html:code>jq</html:code> utility using the following filter
-    <html:code class="ocp-api-filter" id="filter-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">[.items[].spec.groups[].rules[].expr]</html:code>
+    <html:code class="ocp-api-filter" id="filter-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">[.items[]?.spec.groups[]?.rules[]?.expr]</html:code>
     and persist it to the local
     <html:code class="ocp-dump-location" id="dump-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464"><xccdf-1.2:sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy"/>/apis/monitoring.coreos.com/v1/prometheusrules?limit=500#0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464</html:code>
     file.

--- a/images/testcontent/unexistent_resource/ssg-ocp4-ds.xml
+++ b/images/testcontent/unexistent_resource/ssg-ocp4-ds.xml
@@ -15697,7 +15697,7 @@ and make sure it outputs a value.
         </ocil:boolean_question>
         <ocil:boolean_question id="ocil:ssg-audit_error_alert_exists_question:question:1">
           <ocil:question_text>Run the following command:
-oc get  prometheusrules instances -o json | jq '[.items[].spec.groups[].rules[].expr]'
+oc get  prometheusrules instances -o json | jq '[.items[]?.spec.groups[]?.rules[]?.expr]'
 The output should return a list of URL entries with https:// or tls:// transport.
       Is it the case that Audit log errors do not generate an alert?
       </ocil:question_text>
@@ -23386,7 +23386,7 @@ For more information, consult the
 Therefore, you need to use a tool that can query the OCP API, retrieve the following:
 <html:ul><html:li><html:code class="ocp-api-endpoint" id="0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">/apis/monitoring.coreos.com/v1/prometheusrules?limit=500</html:code>
     API endpoint, filter with with the <html:code>jq</html:code> utility using the following filter
-    <html:code class="ocp-api-filter" id="filter-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">[.items[].spec.groups[].rules[].expr]</html:code>
+    <html:code class="ocp-api-filter" id="filter-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">[.items[]?.spec.groups[]?.rules[]?.expr]</html:code>
     and persist it to the local
     <html:code class="ocp-dump-location" id="dump-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464"><xccdf-1.2:sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy"/>/apis/monitoring.coreos.com/v1/prometheusrules?limit=500#0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464</html:code>
     file.

--- a/images/testcontent/variabletemplate/ssg-ocp4-ds.xml
+++ b/images/testcontent/variabletemplate/ssg-ocp4-ds.xml
@@ -15778,7 +15778,7 @@ and make sure it outputs a value.
         </ocil:boolean_question>
         <ocil:boolean_question id="ocil:ssg-audit_error_alert_exists_question:question:1">
           <ocil:question_text>Run the following command:
-oc get  prometheusrules instances -o json | jq '[.items[].spec.groups[].rules[].expr]'
+oc get  prometheusrules instances -o json | jq '[.items[]?.spec.groups[]?.rules[]?.expr]'
 The output should return a list of URL entries with https:// or tls:// transport.
       Is it the case that Audit log errors do not generate an alert?
       </ocil:question_text>
@@ -23545,7 +23545,7 @@ For more information, consult the
 Therefore, you need to use a tool that can query the OCP API, retrieve the following:
 <html:ul><html:li><html:code class="ocp-api-endpoint" id="0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">/apis/monitoring.coreos.com/v1/prometheusrules?limit=500</html:code>
     API endpoint, filter with with the <html:code>jq</html:code> utility using the following filter
-    <html:code class="ocp-api-filter" id="filter-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">[.items[].spec.groups[].rules[].expr]</html:code>
+    <html:code class="ocp-api-filter" id="filter-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464">[.items[]?.spec.groups[]?.rules[]?.expr]</html:code>
     and persist it to the local
     <html:code class="ocp-dump-location" id="dump-0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464"><xccdf-1.2:sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy"/>/apis/monitoring.coreos.com/v1/prometheusrules?limit=500#0fd94c224732cf855db0ac2a1e214959fdf670d9066fb8ae5485ec5ab748f464</html:code>
     file.

--- a/tests/data/prometheusrules_mixed.json
+++ b/tests/data/prometheusrules_mixed.json
@@ -1,0 +1,36 @@
+{
+  "apiVersion": "monitoring.coreos.com/v1",
+  "kind": "PrometheusRuleList",
+  "items": [
+    {
+      "apiVersion": "monitoring.coreos.com/v1",
+      "kind": "PrometheusRule",
+      "metadata": {
+        "name": "audit-errors",
+        "namespace": "openshift-kube-apiserver"
+      },
+      "spec": {
+        "groups": [
+          {
+            "name": "apiserver-audit",
+            "rules": [
+              {
+                "alert": "AuditLogError",
+                "expr": "apiserver_audit_error_total / apiserver_audit_event_total > 0"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "monitoring.coreos.com/v1",
+      "kind": "PrometheusRule",
+      "metadata": {
+        "name": "empty-rule",
+        "namespace": "default"
+      },
+      "spec": {}
+    }
+  ]
+}

--- a/tests/data/ssg-ocp4-ds-suppressed.xml
+++ b/tests/data/ssg-ocp4-ds-suppressed.xml
@@ -13275,7 +13275,7 @@ For more information, consult the
 Therefore, you need to use a tool that can query the OCP API, retrieve the following:
 <html:ul><html:li><html:code class="ocp-api-endpoint" id="72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6">/apis/monitoring.coreos.com/v1/prometheusrules?limit=500</html:code>
     API endpoint, filter with with the <html:code>jq</html:code> utility using the following filter
-    <html:code class="ocp-api-filter" id="filter-72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6">[.items[].spec.groups[].rules[].expr]</html:code>
+    <html:code class="ocp-api-filter" id="filter-72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6">[.items[]?.spec.groups[]?.rules[]?.expr]</html:code>
     and persist it to the local
     <html:code class="ocp-dump-location" id="dump-72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6"><xccdf-1.2:sub idref="xccdf_org.ssgproject.content_value_ocp_data_root" use="legacy"/>/apis/monitoring.coreos.com/v1/prometheusrules?limit=500#72e9ad360bb6bdf4ad9e43217cd0ec9cb90e7c3b08d4fbe0edf087ad899e05a6</html:code>
     file.
@@ -41229,7 +41229,7 @@ and make sure it outputs 0.
         </ocil:boolean_question>
         <ocil:boolean_question id="ocil:ssg-audit_error_alert_exists_question:question:1">
           <ocil:question_text>Run the following command:
-oc get --all-namespaces prometheusrules -o json | jq '[.items[].spec.groups[].rules[].expr]' | grep apiserver_audit
+oc get --all-namespaces prometheusrules -o json | jq '[.items[]?.spec.groups[]?.rules[]?.expr]' | grep apiserver_audit
 Make sure that there's a prometheus rule that verifies the apiserver_audit_error_total and 
 apiserver_audit_event_total metrics and will alert based on an error threshold.
       Is it the case that Audit log errors do not generate an alert?


### PR DESCRIPTION
### **Problem**
The Compliance Operator evaluates the audit_error_alert_exists rule by fetching all PrometheusRules across the cluster and running a jq filter to extract alert expressions:


[.items[].spec.groups[].rules[].expr]
This filter iterates through the hierarchy: spec → groups[] → rules[] → expr. The [] operator in jq means "iterate over this array" — but if the value is null (not an array), it crashes.

When any PrometheusRule on the cluster has an empty spec (spec: {}), the .spec.groups field is null. The [] iterator on null crashes the gojq library with:

`cannot iterate over: null`
The operator's existing error handler catches this (since the error string ends with : null), but returns nil data to OpenSCAP. OpenSCAP then evaluates against empty data and reports the check as _FAIL_ — even when the legitimate audit-errors PrometheusRule exists and is perfectly valid.

This is a false positive — the cluster IS compliant, but one unrelated empty PrometheusRule anywhere on the cluster (in any namespace) poisons the entire check.

### **Why It Matters**
Severity: High — audit_error_alert_exists is a high-severity compliance rule present in NIST 800-53 Moderate, PCI-DSS 4.0, STIG, and NERC-CIP profiles
Blast radius — any empty PrometheusRule in any namespace (e.g., a placeholder from a Helm chart, a leftover from testing) triggers this on every scan

### **Steps to Reproduce**
Create an empty PrometheusRule:

```
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: empty-rule
  namespace: default
spec: {}
```
Run a compliance scan with any profile containing `audit_error_alert_exists` (e.g., `ocp4-moderate`)

The check reports FAIL despite the legitimate audit-errors rule existing in `openshift-kube-apiserver`

### Fix
Operator-side defense (cmd/manager/scap.go)
Extracted the jq parse-and-execute logic into a new execFilter() helper. When the filter() function encounters a null iteration error, it now retries with [] replaced by []? (jq's optional iterator). The ? means "if there's nothing here, skip it instead of crashing."

This preserves valid data from other PrometheusRules while gracefully skipping empty ones. Simply returning an empty array []byte("[]") would NOT work — it would mean "no expressions found" and the OVAL check would still report FAIL.

Content fix (11 XML datastream files)
Updated the jq filter in all test content files from:


`[.items[].spec.groups[].rules[].expr]`
to:


`[.items[]?.spec.groups[]?.rules[]?.expr]`
### **Bug Reproduction**
1. Empty PrometheusRule created, jq query crashes:


```
$ oc get prometheusrules -A -o json | jq '[.items[].spec.groups[].rules[].expr]'
jq: error (at <stdin>:6086): Cannot iterate over null (null)
```
2. Compliance scan reports FAIL:


```
$ oc get compliancecheckresult ocp4-moderate-audit-error-alert-exists -n openshift-compliance -o jsonpath='Rule: {.id}{"\n"}Status: {.status}{"\n"}Severity: {.severity}{"\n"}'
Rule: xccdf_org.ssgproject.content_rule_audit_error_alert_exists
Status: FAIL
Severity: high
```
3. Scan warnings capture the exact null filter error:


```
$ oc get compliancescan ocp4-moderate -n openshift-compliance -o jsonpath='{.status.warnings}' | grep -oE "Skipping empty filter result[^\"]*"
Skipping empty filter result from '[.items[].spec.groups[].rules[].expr]': no value was returned from the filter
```
4. The legitimate rule exists — proving it's a false positive:


```
$ oc get prometheusrule audit-errors -n openshift-kube-apiserver -o jsonpath='Name: {.metadata.name}{"\n"}Namespace: {.metadata.namespace}{"\n"}Alert: {.spec.groups[0].rules[0].alert}{"\n"}Expr: {.spec.groups[0].rules[0].expr}{"\n"}'
Name: audit-errors
Namespace: openshift-kube-apiserver
Alert: AuditLogError
Expr: sum by (apiserver,instance)(rate(apiserver_audit_error_total{apiserver=~".+-apiserver"}[5m])) / sum by (apiserver,instance) (rate(apiserver_audit_event_total{apiserver=~".+-apiserver"}[5m])) > 0
```
### Fix Verified on OCP 4.22
1. Built and deployed fixed operator:


1. Deploy this PR
2. Empty PrometheusRule present on cluster:

```
$ oc get prometheusrule empty-rule -n default -o jsonpath='Name: {.metadata.name}{"\n"}Spec: {.spec}{"\n"}'
Name: empty-rule
Spec: {}
```
3. Scan now reports PASS:


```
$ oc get compliancecheckresult ocp4-moderate-audit-error-alert-exists -n openshift-compliance -o jsonpath='Rule: {.id}{"\n"}Status: {.status}{"\n"}Severity: {.severity}{"\n"}'
Rule: xccdf_org.ssgproject.content_rule_audit_error_alert_exists
Status: PASS
Severity: high
```
4. No null filter warnings:

`$ oc get compliancescan ocp4-moderate -n openshift-compliance -o jsonpath='{.status.warnings}' | grep -oE "Skipping empty filter result[^\"]*"`
(no output — no null filter errors)
Unit Tests
59/59 tests pass
New test: verifies filter() retries with []? and preserves valid data when encountering mixed PrometheusRules (valid + empty spec)
New test: verifies the []? filter succeeds directly on mixed data
Updated existing piped filtering test to expect success via retry instead of NullValErr. 

Co-authored by: Claude