### PR TITLE
parallel test fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ TEST_DEPLOY=$(TEST_SETUP_DIR)/deploy_rbac.yaml
 # Pass extra flags to the e2e test run.
 # e.g. to run a specific test in the e2e test suite, do:
 # 	make e2e E2E_GO_TEST_FLAGS="-v -run TestE2E/Parallel_tests/TestScanWithNodeSelectorFiltersCorrectly"
-E2E_GO_TEST_FLAGS?=-v -test.timeout 120m
+E2E_GO_TEST_FLAGS?=-v -test.timeout 120m -parallel 15
 
 # By default we run all tests; available options: all, parallel, deployment, config, serial
 E2E_TEST_TYPE?=all

--- a/tests/e2e/framework/common.go
+++ b/tests/e2e/framework/common.go
@@ -2287,8 +2287,7 @@ func CheckPodPriorityClass(c kubernetes.Interface, podName, namespace, priorityC
 		}
 
 		if pod.Spec.PriorityClassName != priorityClass {
-			log.Printf("pod %s has priority class %s, expected %s\n", podName, pod.Spec.PriorityClassName, priorityClass)
-			return true, nil
+			return true, fmt.Errorf("pod %s has priority class %q, expected %q", podName, pod.Spec.PriorityClassName, priorityClass)
 		}
 
 		return true, nil
@@ -2354,7 +2353,7 @@ func CheckPodLimit(c kubernetes.Interface, podName, namespace, cpuLimit, memLimi
 			}
 
 			if cnt.Resources.Limits.Memory().String() != memLimit {
-				return false, fmt.Errorf("container %s in pod %s has memory limit %s, expected %s", cnt.Name, podName, cnt.Resources.Limits.Cpu().String(), cpuLimit)
+				return false, fmt.Errorf("container %s in pod %s has memory limit %s, expected %s", cnt.Name, podName, cnt.Resources.Limits.Memory().String(), memLimit)
 			}
 		}
 

--- a/tests/e2e/framework/utils.go
+++ b/tests/e2e/framework/utils.go
@@ -506,7 +506,7 @@ func (f *Framework) WaitForPrometheusMetricTargets() ([]PrometheusTarget, error)
 			"run", "--rm", "-i", "--restart=Never", "--image=" + FedoraTestImage,
 			"-n", namespace,
 			"--overrides=" + podOverrides,
-			"metrics-test",
+			fmt.Sprintf("metrics-test-%d", time.Now().UnixNano()),
 		})
 
 		if err != nil {

--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -2362,19 +2362,23 @@ func TestScheduledSuitePriorityClass(t *testing.T) {
 	}
 	defer f.Client.Delete(context.TODO(), testSuite)
 
-	podList := &corev1.PodList{}
-	err = f.Client.List(context.TODO(), podList, client.InNamespace(f.OperatorNamespace), client.MatchingLabels(map[string]string{
-		"workload": "scanner",
-	}))
+	// Wait for the scan to reach running phase so scanner pods exist
+	err = f.WaitForScanStatus(f.OperatorNamespace, workerScanName, compv1alpha1.PhaseRunning)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// check if the scanning pod has properly been created and has priority class set
-	for _, pod := range podList.Items {
-		if strings.Contains(pod.Name, workerScanName) {
-			if err := framework.WaitForPod(framework.CheckPodPriorityClass(f.KubeClient, pod.Name, f.OperatorNamespace, "e2e-compliance-suite-high-priority")); err != nil {
-				t.Fatal(err)
-			}
+
+	// Get pods specifically for this scan and check priority class directly
+	pods, err := f.GetPodsForScan(workerScanName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pods) == 0 {
+		t.Fatal("No scanner pods found for scan " + workerScanName)
+	}
+	for _, pod := range pods {
+		if pod.Spec.PriorityClassName != "e2e-compliance-suite-high-priority" {
+			t.Fatalf("pod %s has priority class %q, expected %q", pod.Name, pod.Spec.PriorityClassName, "e2e-compliance-suite-high-priority")
 		}
 	}
 
@@ -2560,21 +2564,26 @@ func TestScheduledSuiteInvalidPriorityClass(t *testing.T) {
 	}
 	defer f.Client.Delete(context.TODO(), testSuite)
 
-	podList := &corev1.PodList{}
-	err = f.Client.List(context.TODO(), podList, client.InNamespace(f.OperatorNamespace), client.MatchingLabels(map[string]string{
-		"workload": "scanner",
-	}))
+	// Wait for the scan to reach running phase so scanner pods exist
+	err = f.WaitForScanStatus(f.OperatorNamespace, workerScanName, compv1alpha1.PhaseRunning)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// check if the scanning pod has properly been created and has priority class set
-	for _, pod := range podList.Items {
-		if strings.Contains(pod.Name, workerScanName) {
-			if err := framework.WaitForPod(framework.CheckPodPriorityClass(f.KubeClient, pod.Name, f.OperatorNamespace, "")); err != nil {
-				t.Fatal(err)
-			}
+
+	// Get pods specifically for this scan and check priority class directly
+	pods, err := f.GetPodsForScan(workerScanName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pods) == 0 {
+		t.Fatal("No scanner pods found for scan " + workerScanName)
+	}
+	for _, pod := range pods {
+		if pod.Spec.PriorityClassName != "" {
+			t.Fatalf("pod %s has priority class %q, expected none", pod.Name, pod.Spec.PriorityClassName)
 		}
 	}
+
 	// Ensure that all the scans in the suite have finished and are marked as Done
 	err = f.WaitForSuiteScansStatus(f.OperatorNamespace, suiteName, compv1alpha1.PhaseDone, compv1alpha1.ResultCompliant)
 	if err != nil {
@@ -4310,66 +4319,50 @@ func TestScanSettingBinding(t *testing.T) {
 	}
 	defer f.Client.Delete(context.TODO(), &scanSettingBinding)
 
-	// Wait until the suite finishes, thus verifying the suite exists
+	scanNames := []string{
+		rhcos4e8profile.Name + "-master",
+		rhcos4e8profile.Name + "-worker",
+		rhcos4moderateprofile.Name + "-master",
+		rhcos4moderateprofile.Name + "-worker",
+	}
+
+	for _, scanName := range scanNames {
+		scan := &compv1alpha1.ComplianceScan{}
+		if err := f.Client.Get(context.TODO(), types.NamespacedName{Namespace: f.OperatorNamespace, Name: scanName}, scan); err != nil {
+			t.Fatal(err)
+		}
+		if scan.Spec.Debug != true {
+			t.Fatalf("Expected that the settings set debug to true in scan %s", scanName)
+		}
+
+		// Wait for the scan to reach running phase so scanner pods exist
+		if err := f.WaitForScanStatus(f.OperatorNamespace, scanName, compv1alpha1.PhaseRunning); err != nil {
+			t.Fatal(err)
+		}
+		pods, err := f.GetPodsForScan(scanName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, pod := range pods {
+			for i := range pod.Spec.Containers {
+				cnt := &pod.Spec.Containers[i]
+				if cnt.Name != "api-resource-collector" && cnt.Name != "scanner" {
+					continue
+				}
+				if cnt.Resources.Limits.Cpu().String() != defaultCpuLimit {
+					t.Fatalf("container %s in pod %s has cpu limit %s, expected %s", cnt.Name, pod.Name, cnt.Resources.Limits.Cpu().String(), defaultCpuLimit)
+				}
+				if cnt.Resources.Limits.Memory().String() != testMemoryLimit {
+					t.Fatalf("container %s in pod %s has memory limit %s, expected %s", cnt.Name, pod.Name, cnt.Resources.Limits.Memory().String(), testMemoryLimit)
+				}
+			}
+		}
+	}
+
+	// Wait until the suite finishes
 	err = f.WaitForSuiteScansStatus(f.OperatorNamespace, scanSettingBindingName, compv1alpha1.PhaseDone, compv1alpha1.ResultNonCompliant)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	masterScanKey := types.NamespacedName{Namespace: f.OperatorNamespace, Name: rhcos4e8profile.Name + "-master"}
-	masterScan := &compv1alpha1.ComplianceScan{}
-	if err := f.Client.Get(context.TODO(), masterScanKey, masterScan); err != nil {
-		t.Fatal(err)
-	}
-
-	if masterScan.Spec.Debug != true {
-		t.Fatal("Expected that the settings set debug to true in master scan")
-	}
-
-	workerScanKey := types.NamespacedName{Namespace: f.OperatorNamespace, Name: rhcos4e8profile.Name + "-worker"}
-	workerScan := &compv1alpha1.ComplianceScan{}
-	if err := f.Client.Get(context.TODO(), workerScanKey, workerScan); err != nil {
-		t.Fatal(err)
-	}
-
-	if workerScan.Spec.Debug != true {
-		t.Fatal("Expected that the settings set debug to true in workers scan")
-	}
-
-	moderateMasterScanKey := types.NamespacedName{Namespace: f.OperatorNamespace, Name: rhcos4moderateprofile.Name + "-master"}
-	moderateMasterScan := &compv1alpha1.ComplianceScan{}
-	if err := f.Client.Get(context.TODO(), moderateMasterScanKey, moderateMasterScan); err != nil {
-		t.Fatal(err)
-	}
-
-	if moderateMasterScan.Spec.Debug != true {
-		t.Fatal("Expected that the settings set debug to true in moderate master scan")
-	}
-
-	moderateWorkerScanKey := types.NamespacedName{Namespace: f.OperatorNamespace, Name: rhcos4moderateprofile.Name + "-worker"}
-	moderateWorkerScan := &compv1alpha1.ComplianceScan{}
-	if err := f.Client.Get(context.TODO(), moderateWorkerScanKey, moderateWorkerScan); err != nil {
-		t.Fatal(err)
-	}
-
-	if moderateWorkerScan.Spec.Debug != true {
-		t.Fatal("Expected that the settings set debug to true in moderate worker scan")
-	}
-
-	podList := &corev1.PodList{}
-	if err := f.Client.List(context.TODO(), podList, client.InNamespace(f.OperatorNamespace), client.MatchingLabels(map[string]string{
-		"workload": "scanner",
-	})); err != nil {
-		t.Fatal(err)
-	}
-	// check if the scanning pod has properly been created and has limits set
-	for _, pod := range podList.Items {
-		if strings.Contains(pod.Name, masterScan.Name) || strings.Contains(pod.Name, workerScan.Name) ||
-			strings.Contains(pod.Name, moderateMasterScan.Name) || strings.Contains(pod.Name, moderateWorkerScan.Name) {
-			if err := framework.WaitForPod(framework.CheckPodLimit(f.KubeClient, pod.Name, f.OperatorNamespace, defaultCpuLimit, testMemoryLimit)); err != nil {
-				t.Fatal(err)
-			}
-		}
 	}
 
 }


### PR DESCRIPTION
Fix race conditions and silent failures in parallel e2e tests

  Several parallel e2e tests are flaky due to race conditions from shared
  namespace resource contention and bugs in the test framework helpers.

  Framework fixes:

  - CheckPodPriorityClass silently passed when the priority class didn't match —
  it logged the mismatch but returned success. It now returns an error so tests
  actually fail on unexpected priority class values.
  - CheckPodLimit had a copy-paste bug where the memory limit mismatch error
  message reported CPU values instead of memory values.
  - WaitForPrometheusMetricTargets used a hardcoded "metrics-test" pod name,
  causing oc run collisions when multiple tests invoke it concurrently. Changed
  to a unique timestamp-based name, matching the fix already applied to
  AssertMetricsEndpointUsesHTTPVersion and getMetricResults.

  Test race condition fixes:

  TestScheduledSuitePriorityClass, TestScheduledSuiteInvalidPriorityClass, and
  TestScanSettingBinding all listed scanner pods using the broad "workload": 
  "scanner" label, which matches pods from any concurrent test in the namespace.
  Two of them also listed pods before the scan had started, so the list was
  often empty and the checks were silently skipped. The third listed pods after
  PhaseDone, when pods may have already been garbage collected.

  All three now wait for PhaseRunning to ensure scanner pods exist, then use
  GetPodsForScan() to list only pods belonging to the specific scan under test.