### PR TITLE
CMP-4496: Add NetworkPolicy RBAC for operands to operator Role and CSV

### DIFF
--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -1590,6 +1590,15 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - update
         serviceAccountName: compliance-operator
       - rules:
         - apiGroups:

--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -1412,6 +1412,15 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - update
         serviceAccountName: compliance-operator
       - rules:
         - apiGroups:

--- a/config/rbac/operator_role.yaml
+++ b/config/rbac/operator_role.yaml
@@ -137,3 +137,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - update

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -124,6 +124,7 @@ type ReconcileComplianceScan struct {
 //+kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get,list,watch,create,delete,update
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=deletecollection
 //+kubebuilder:rbac:groups=image.openshift.io,resources=imagestreamtags,verbs=get,list,watch
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create,delete,get,update
 //+kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=get,list,watch
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=get,list,watch
 //+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get,list,watch


### PR DESCRIPTION
# What
- Adds `networking.k8s.io/networkpolicies` RBAC rule (verbs: `create`, `delete`, `get`, `update`) to the operator Role (`config/rbac/operator_role.yaml`)
- Adds matching entry in the CSV namespace-scoped permissions (`config/manifests/bases/compliance-operator.clusterserviceversion.yaml`) under the `compliance-operator` service account
- Adds kubebuilder RBAC marker in `compliancescan_controller.go` to keep the three RBAC sources of truth in sync
- Regenerates the bundle CSV via `make bundle`


# Why
The Conforma policy `olm.required_network_policy_rbac_for_operands` requires the CSV to declare RBAC permissions for `networking.k8s.io/networkpolicies `with verbs `create`, `delete`, and `update` (or `patch`). 

# Test plan
## Prerequisites

- Access to an OpenShift cluster (Tested on OCP 4.22)
- podman installed and logged into registry (e.g.,quay.io)
- A quay.io org with repos for `compliance-operator,` `compliance-operator-bundle`, and `compliance-operator-catalog`

### 1. Build and push images
```
# Set your quay org
export IMAGE_REPO=quay.io/<your-quay-org>

# Generate bundle (regenerates bundle/manifests/compliance-operator.clusterserviceversion.yaml)
make bundle VERSION=1.8.0-dev

# Build operator image
make image

# Push operator image
podman tag ghcr.io/complianceascode/compliance-operator:latest ${IMAGE_REPO}/compliance-operator:latest
podman push ${IMAGE_REPO}/compliance-operator:latest

# Build and push bundle image
make bundle-image VERSION=1.8.0-dev
make bundle-push

# Build and push catalog image
make catalog
```

### 2. Deploy via OLM

```
# Deploy CatalogSource, OperatorGroup, and Subscription
make catalog-deploy
oc get csv -n openshift-compliance
NAME                             DISPLAY               VERSION     REPLACES   PHASE
compliance-operator.v1.8.0-dev   Compliance Operator   1.8.0-dev              Succeeded
```

### 3.Verify OLM installation is complete
```
# CSV is Succeeded
oc get csv -n openshift-compliance
# NAME                             DISPLAY               VERSION     PHASE
# compliance-operator.v1.8.0-dev   Compliance Operator   1.8.0-dev   Succeeded

# Subscription exists
oc get subscription -n openshift-compliance
# NAME                      PACKAGE               SOURCE                CHANNEL
# compliance-operator-sub   compliance-operator   compliance-operator   alpha

# InstallPlan completed
oc get installplan -n openshift-compliance
# NAME            CSV                              APPROVAL    APPROVED
# install-cdt2v   compliance-operator.v1.8.0-dev   Automatic   true

# Operator pod is running
oc get pods -n openshift-compliance
# NAME                                   READY   STATUS    RESTARTS   AGE
# compliance-operator-7d8b6779b6-mn7gs   1/1     Running   0          4m

```
### 4. Verify NetworkPolicy RBAC in the OLM-created Role

Check the OLM-created Role contains the networkpolicies rule
`oc get roles -n openshift-compliance -o yaml | grep -B 2 -A 6 networkpolicies`
Expected output:
```
  - networking.k8s.io
  resources:
  - networkpolicies
  verbs:
  - create
  - delete
  - get
  - update
```

### 5. Verify the CSV permissions section
Expected output should show `networkpolicies` with verbs `create`, `delete`, `get`, `update` under the `permissions` (namespace-scoped) section.

### 6. Verify SA has the permissions
```
oc auth can-i create networkpolicies --as=system:serviceaccount:openshift-compliance:compliance-operator -n openshift-compliance
yes

oc auth can-i delete networkpolicies --as=system:serviceaccount:openshift-compliance:compliance-operator -n openshift-compliance
yes

oc auth can-i get networkpolicies --as=system:serviceaccount:openshift-compliance:compliance-operator -n openshift-compliance
yes

oc auth can-i update networkpolicies --as=system:serviceaccount:openshift-compliance:compliance-operator -n openshift-compliance
yes
```

