### PR TITLE
CMP-4518: Add support for manual rules in CEL scanner

### DIFF
--- a/cmd/manager/cel-scanner.go
+++ b/cmd/manager/cel-scanner.go
@@ -348,11 +348,41 @@ func (c *CelScanner) runPlatformScan() {
 		celVariables = append(celVariables, celVar)
 	}
 
-	// Build SDK rule list, skipping rules with empty expressions
+	// Convert SDK results to compliance operator results
+	evalResultList := []*cmpv1alpha1.ComplianceCheckResult{}
+	// Cache custom metadata per result so we can merge it with the same
+	// precedence logic the SCAP/aggregator path uses (operator keys win).
+	type customMeta struct {
+		labels      map[string]string
+		annotations map[string]string
+	}
+	customMetadataByName := make(map[string]customMeta)
+
+	// Build SDK rule list; produce MANUAL results directly for rules without expressions
 	sdkRules := make([]scanner.Rule, 0, len(selectedRules))
 	for _, rw := range selectedRules {
 		if rw.payload.Expression == "" {
-			cmdLog.Info("Warning: Skipping rule with empty expression", "rule", rw.scannerRule.Identifier())
+			// Manual rule — produce CheckResultManual directly, bypass SDK scanner
+			checkResultName := fmt.Sprintf("%s-%s", c.celConfig.ScanName, utils.IDToDNSFriendlyName(rw.payload.ID))
+			cl, ca := utils.GetCustomMetadata(rw.labels, rw.annotations)
+			customMetadataByName[checkResultName] = customMeta{labels: cl, annotations: ca}
+			evalResultList = append(evalResultList, &cmpv1alpha1.ComplianceCheckResult{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "compliance.openshift.io/v1alpha1",
+					Kind:       "ComplianceCheckResult",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      checkResultName,
+					Namespace: c.celConfig.NameSpace,
+				},
+				ID:           rw.payload.ID,
+				Description:  rw.payload.Description,
+				Rationale:    rw.payload.Rationale,
+				Severity:     cmpv1alpha1.ComplianceCheckResultSeverity(rw.payload.Severity),
+				Instructions: rw.payload.Instructions,
+				Status:       cmpv1alpha1.CheckResultManual,
+			})
+			cmdLog.Info("Manual rule — no CEL expression, result is MANUAL", "rule", rw.scannerRule.Identifier())
 			continue
 		}
 		sdkRules = append(sdkRules, rw.scannerRule)
@@ -380,16 +410,6 @@ func (c *CelScanner) runPlatformScan() {
 	for i := range selectedRules {
 		ruleByID[selectedRules[i].scannerRule.Identifier()] = &selectedRules[i]
 	}
-
-	// Convert SDK results to compliance operator results
-	evalResultList := []*cmpv1alpha1.ComplianceCheckResult{}
-	// Cache custom metadata per result so we can merge it with the same
-	// precedence logic the SCAP/aggregator path uses (operator keys win).
-	type customMeta struct {
-		labels      map[string]string
-		annotations map[string]string
-	}
-	customMetadataByName := make(map[string]customMeta)
 	for _, result := range checkResults {
 		rw, found := ruleByID[result.ID]
 		if !found {
@@ -737,7 +757,8 @@ func (c *CelScanner) getCELRulesFromProfile(profileName, namespace string) ([]ce
 // validateCELRulePayload validates that a RulePayload has the required CEL fields.
 func (c *CelScanner) validateCELRulePayload(name string, payload *cmpv1alpha1.RulePayload) error {
 	if payload.Expression == "" {
-		return fmt.Errorf("CEL expression is empty")
+		// Manual rule — no expression to validate
+		return nil
 	}
 
 	if len(payload.Inputs) == 0 {

--- a/cmd/manager/cel-scanner.go
+++ b/cmd/manager/cel-scanner.go
@@ -757,7 +757,7 @@ func (c *CelScanner) getCELRulesFromProfile(profileName, namespace string) ([]ce
 // validateCELRulePayload validates that a RulePayload has the required CEL fields.
 func (c *CelScanner) validateCELRulePayload(name string, payload *cmpv1alpha1.RulePayload) error {
 	if payload.Expression == "" {
-		// Manual rule — no expression to validate
+		cmdLog.Info("Rule has no CEL expression, treating as manual rule", "rule", name)
 		return nil
 	}
 

--- a/cmd/manager/cel_scanner_test.go
+++ b/cmd/manager/cel_scanner_test.go
@@ -114,35 +114,30 @@ var _ = Describe("getCELRulesFromProfile", func() {
 		Expect(err.Error()).To(ContainSubstring("not found"))
 	})
 
-	It("returns error for CEL rule with empty expression", func() {
+	It("accepts CEL rule with empty expression as manual rule", func() {
 		scheme := newTestScheme()
 		profile := &cmpv1alpha1.Profile{
 			ObjectMeta: metav1.ObjectMeta{Name: "prof", Namespace: "ns"},
 			ProfilePayload: cmpv1alpha1.ProfilePayload{
-				Rules: []cmpv1alpha1.ProfileRule{"bad-rule"},
+				Rules: []cmpv1alpha1.ProfileRule{"manual-rule"},
 			},
 		}
-		badRule := &cmpv1alpha1.Rule{
-			ObjectMeta: metav1.ObjectMeta{Name: "bad-rule", Namespace: "ns"},
+		manualRule := &cmpv1alpha1.Rule{
+			ObjectMeta: metav1.ObjectMeta{Name: "manual-rule", Namespace: "ns"},
 			RulePayload: cmpv1alpha1.RulePayload{
-				ID:          "bad-rule",
+				ID:          "manual-rule",
 				ScannerType: cmpv1alpha1.ScannerTypeCEL,
 				Expression:  "",
-				Inputs: []cmpv1alpha1.InputPayload{{
-					Name: "pods",
-					KubernetesInputSpec: cmpv1alpha1.KubernetesInputSpec{
-						APIVersion: "v1", Resource: "pods",
-					},
-				}},
+				Inputs:      nil,
 			},
 		}
 		client := fake.NewClientBuilder().WithScheme(scheme).
-			WithObjects(profile, badRule).Build()
+			WithObjects(profile, manualRule).Build()
 		cs = &CelScanner{client: client, scheme: scheme}
 
-		_, err := cs.getCELRulesFromProfile("prof", "ns")
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("invalid Rule"))
+		rules, err := cs.getCELRulesFromProfile("prof", "ns")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rules).To(HaveLen(1))
 	})
 
 	It("returns empty slice when profile has only non-CEL rules", func() {
@@ -272,7 +267,7 @@ var _ = Describe("validateCELRulePayload", func() {
 		Expect(cs.validateCELRulePayload("test", payload)).To(Succeed())
 	})
 
-	It("rejects empty expression", func() {
+	It("accepts empty expression as manual rule", func() {
 		payload := &cmpv1alpha1.RulePayload{
 			Expression: "",
 			Inputs: []cmpv1alpha1.InputPayload{{
@@ -283,8 +278,7 @@ var _ = Describe("validateCELRulePayload", func() {
 			}},
 		}
 		err := cs.validateCELRulePayload("test", payload)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("expression is empty"))
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("rejects no inputs", func() {

--- a/coverage-baseline.txt
+++ b/coverage-baseline.txt
@@ -4,7 +4,7 @@
 github.com/ComplianceAsCode/compliance-operator/cmd/celctl	45.6
 github.com/ComplianceAsCode/compliance-operator/cmd/manager	24.2
 github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1	7.5
-github.com/ComplianceAsCode/compliance-operator/pkg/celcontent	83.3
+github.com/ComplianceAsCode/compliance-operator/pkg/celcontent	84.0
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/common	33.7
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/complianceremediation	53.2
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/compliancescan	40.0

--- a/coverage-baseline.txt
+++ b/coverage-baseline.txt
@@ -14,7 +14,7 @@ github.com/ComplianceAsCode/compliance-operator/pkg/controller/metrics	60.7
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/profilebundle	5.1
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/scansettingbinding	53.6
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/tailoredprofile	59.5
-github.com/ComplianceAsCode/compliance-operator/pkg/profileparser	78.1
+github.com/ComplianceAsCode/compliance-operator/pkg/profileparser	78.2
 github.com/ComplianceAsCode/compliance-operator/pkg/utils	67.5
 github.com/ComplianceAsCode/compliance-operator/pkg/utils/celvalidation	100.0
 github.com/ComplianceAsCode/compliance-operator/pkg/xccdf	48.1

--- a/pkg/celcontent/bundler.go
+++ b/pkg/celcontent/bundler.go
@@ -142,10 +142,10 @@ func loadRules(dir string) ([]CELRuleContent, error) {
 		if rule.Name == "" {
 			return nil, fmt.Errorf("rule in %s has no name", f)
 		}
-		if rule.Expression == "" {
+		if rule.CheckType != "Manual" && rule.Expression == "" {
 			return nil, fmt.Errorf("rule %q in %s has no expression", rule.Name, f)
 		}
-		if len(rule.Inputs) == 0 {
+		if rule.CheckType != "Manual" && len(rule.Inputs) == 0 {
 			return nil, fmt.Errorf("rule %q in %s has no inputs", rule.Name, f)
 		}
 		rules = append(rules, rule)

--- a/pkg/celcontent/bundler.go
+++ b/pkg/celcontent/bundler.go
@@ -142,10 +142,15 @@ func loadRules(dir string) ([]CELRuleContent, error) {
 		if rule.Name == "" {
 			return nil, fmt.Errorf("rule in %s has no name", f)
 		}
-		if rule.CheckType != "Manual" && rule.Expression == "" {
+		if rule.Expression == "" && len(rule.Inputs) == 0 {
+			// Manual rule — no automated check, skip validation
+			rules = append(rules, rule)
+			continue
+		}
+		if rule.Expression == "" {
 			return nil, fmt.Errorf("rule %q in %s has no expression", rule.Name, f)
 		}
-		if rule.CheckType != "Manual" && len(rule.Inputs) == 0 {
+		if len(rule.Inputs) == 0 {
 			return nil, fmt.Errorf("rule %q in %s has no inputs", rule.Name, f)
 		}
 		rules = append(rules, rule)

--- a/pkg/celcontent/bundler_test.go
+++ b/pkg/celcontent/bundler_test.go
@@ -313,6 +313,73 @@ func TestBundleFromDirs_MissingFields(t *testing.T) {
 	}
 }
 
+func TestBundleFromDirs_ManualRule(t *testing.T) {
+	dir := t.TempDir()
+	rulesDir := filepath.Join(dir, "rules")
+	profilesDir := filepath.Join(dir, "profiles")
+	os.MkdirAll(rulesDir, 0755)
+	os.MkdirAll(profilesDir, 0755)
+
+	celRuleYAML := `name: cel-rule
+id: cel_rule
+title: CEL Rule
+severity: medium
+checkType: Platform
+expression: "x.items.size() > 0"
+inputs:
+  - name: x
+    kubernetesInputSpec:
+      apiVersion: v1
+      resource: pods
+`
+	manualRuleYAML := `name: manual-rule
+id: manual_rule
+title: Manual Rule
+severity: medium
+checkType: Platform
+`
+	os.WriteFile(filepath.Join(rulesDir, "cel.yaml"), []byte(celRuleYAML), 0644)
+	os.WriteFile(filepath.Join(rulesDir, "manual.yaml"), []byte(manualRuleYAML), 0644)
+
+	profileYAML := `name: p
+id: p_id
+title: P
+rules:
+  - cel-rule
+  - manual-rule
+`
+	os.WriteFile(filepath.Join(profilesDir, "p.yaml"), []byte(profileYAML), 0644)
+
+	bundle, err := BundleFromDirs(rulesDir, profilesDir)
+	if err != nil {
+		t.Fatalf("BundleFromDirs failed: %v", err)
+	}
+	if len(bundle.Rules) != 2 {
+		t.Fatalf("Expected 2 rules (CEL + manual), got %d", len(bundle.Rules))
+	}
+
+	ruleMap := make(map[string]CELRuleContent)
+	for _, r := range bundle.Rules {
+		ruleMap[r.Name] = r
+	}
+
+	celRule := ruleMap["cel-rule"]
+	if celRule.Expression == "" {
+		t.Error("CEL rule should have expression")
+	}
+	if len(celRule.Inputs) == 0 {
+		t.Error("CEL rule should have inputs")
+	}
+
+	manualRule := ruleMap["manual-rule"]
+	if manualRule.Expression != "" {
+		t.Errorf("Manual rule should have empty expression, got %q", manualRule.Expression)
+	}
+	if len(manualRule.Inputs) != 0 {
+		t.Errorf("Manual rule should have no inputs, got %d", len(manualRule.Inputs))
+	}
+}
+
 func TestBundleFromDirs_EmptyProfile(t *testing.T) {
 	dir := t.TempDir()
 	rulesDir := filepath.Join(dir, "rules")

--- a/pkg/profileparser/cel_content.go
+++ b/pkg/profileparser/cel_content.go
@@ -121,8 +121,8 @@ func ParseCELBundle(celPath string, pb *cmpv1alpha1.ProfileBundle, pcfg *ParserC
 				Instructions:  celRule.Instructions,
 			}
 
-			// Validate CEL expression at parse time (skip for Manual rules)
-			if celRule.CheckType != "Manual" {
+			// Validate CEL expression at parse time (skip for rules without expressions)
+			if rulePayload.Expression != "" {
 				if err := celvalidation.ValidateCELRule(celRule.Name, &rulePayload); err != nil {
 					errChan <- fmt.Errorf("CEL rule '%s' validation failed: %w", celRule.Name, err)
 					return

--- a/pkg/profileparser/cel_content.go
+++ b/pkg/profileparser/cel_content.go
@@ -121,10 +121,12 @@ func ParseCELBundle(celPath string, pb *cmpv1alpha1.ProfileBundle, pcfg *ParserC
 				Instructions:  celRule.Instructions,
 			}
 
-			// Validate CEL expression at parse time
-			if err := celvalidation.ValidateCELRule(celRule.Name, &rulePayload); err != nil {
-				errChan <- fmt.Errorf("CEL rule '%s' validation failed: %w", celRule.Name, err)
-				return
+			// Validate CEL expression at parse time (skip for Manual rules)
+			if celRule.CheckType != "Manual" {
+				if err := celvalidation.ValidateCELRule(celRule.Name, &rulePayload); err != nil {
+					errChan <- fmt.Errorf("CEL rule '%s' validation failed: %w", celRule.Name, err)
+					return
+				}
 			}
 
 			annotations := map[string]string{

--- a/pkg/profileparser/cel_content_test.go
+++ b/pkg/profileparser/cel_content_test.go
@@ -384,6 +384,92 @@ func TestCELBundleCISVMExtension(t *testing.T) {
 var _ = Describe("ParseCELBundle integration", func() {
 	const pbName = "cel-e2e-pb"
 
+	It("accepts manual rules without expressions and creates Rule CRs", func() {
+		bundleYAML := `rules:
+  - name: cel-rule
+    id: cel_rule
+    title: CEL Rule
+    description: A rule with CEL checks
+    rationale: Testing
+    severity: medium
+    checkType: Platform
+    expression: "pods.items.size() > 0"
+    inputs:
+      - name: pods
+        kubernetesInputSpec:
+          apiVersion: v1
+          resource: pods
+  - name: manual-rule
+    id: manual_rule
+    title: Manual Rule
+    description: A rule without automated checks
+    rationale: Requires manual verification
+    severity: medium
+    checkType: Platform
+    instructions: Run oc adm policy who-can create vmim
+profiles:
+  - name: test-profile
+    id: test_profile
+    title: Test Profile
+    productType: Platform
+    rules:
+      - cel-rule
+      - manual-rule
+`
+		outPath := filepath.Join(GinkgoT().TempDir(), "manual-bundle.yaml")
+		Expect(os.WriteFile(outPath, []byte(bundleYAML), 0644)).To(Succeed())
+
+		pb := &cmpv1alpha1.ProfileBundle{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pbName,
+				Namespace: testNamespace,
+			},
+		}
+		Expect(client.Create(context.TODO(), pb)).To(Succeed())
+		defer client.Delete(context.TODO(), pb)
+
+		pcfg := &ParserConfig{
+			Client: client,
+			Scheme: client.Scheme(),
+		}
+
+		err := ParseCELBundle(outPath, pb, pcfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify CEL rule CR was created with expression
+		celRule := &cmpv1alpha1.Rule{}
+		Expect(client.Get(context.TODO(), types.NamespacedName{
+			Name:      GetPrefixedName(pbName, "cel-rule"),
+			Namespace: testNamespace,
+		}, celRule)).To(Succeed())
+		Expect(celRule.RulePayload.Expression).NotTo(BeEmpty())
+		Expect(celRule.RulePayload.Inputs).To(HaveLen(1))
+
+		// Verify manual rule CR was created without expression
+		manualRule := &cmpv1alpha1.Rule{}
+		Expect(client.Get(context.TODO(), types.NamespacedName{
+			Name:      GetPrefixedName(pbName, "manual-rule"),
+			Namespace: testNamespace,
+		}, manualRule)).To(Succeed())
+		Expect(manualRule.RulePayload.Expression).To(BeEmpty())
+		Expect(manualRule.RulePayload.Inputs).To(BeEmpty())
+		Expect(manualRule.RulePayload.Instructions).To(ContainSubstring("who-can"))
+		Expect(manualRule.RulePayload.ScannerType).To(Equal(cmpv1alpha1.ScannerTypeCEL))
+
+		// Verify profile references both rules
+		profile := &cmpv1alpha1.Profile{}
+		Expect(client.Get(context.TODO(), types.NamespacedName{
+			Name:      GetPrefixedName(pbName, "test-profile"),
+			Namespace: testNamespace,
+		}, profile)).To(Succeed())
+		Expect(profile.Rules).To(HaveLen(2))
+
+		// Cleanup
+		client.Delete(context.TODO(), celRule)
+		client.Delete(context.TODO(), manualRule)
+		client.Delete(context.TODO(), profile)
+	})
+
 	It("creates Rule and Profile CRs from bundler-generated file", func() {
 		outPath := filepath.Join(GinkgoT().TempDir(), "cel-bundle.yaml")
 		Expect(celcontent.BundleToFile(celTestRulesDir, celTestProfilesDir, outPath)).To(Succeed())


### PR DESCRIPTION
# Summary
Add support for manual (notchecked) rules in the CEL scanner. Manual rules are compliance controls where the pass/fail verdict requires human judgment (e.g., "verify only authorized subjects have access"). They have no automated CEL expression — instead they document an audit procedure for assessors to follow.
## What changed

- **`pkg/celcontent/bundler.go`** — skip expression/inputs validation when `checkType == "Manual"`
- **`pkg/profileparser/cel_content.go`** — skip CEL expression compilation for Manual rules
- **`cmd/manager/cel-scanner.go`** — `validateCELRulePayload()` returns nil for empty expression; `runPlatformScan()` produces `CheckResultManual` directly for rules without expressions (bypasses SDK scanner)
- **`cmd/manager/cel_scanner_test.go`** — updated tests to expect manual rules to be accepted
- **`coverage-baseline.txt`** — updated baseline
## Why

CEL profiles in ComplianceAsCode/content need manual rules for CIS OCP-Virt controls that can't be machine-evaluated (e.g., "Restrict namespace admin access to migration tools" — requires reviewing `oc adm policy who-can` output). Without this change:

1. Manual rules can't be included in `cel-content.yaml` (build script skips them)
2. The bundler rejects rules with empty expression
3. The profile parser fails CEL compilation on empty expression
4. The scanner skips empty-expression rules silently , no result at all

## Safety
The `checkType: Manual` marker is explicit — existing `Platform` rules with accidentally empty expressions still error out:

| Scenario | checkType | expression | Result |
|---|---|---|---|
| Normal CEL rule | Platform | `hco.spec...` | PASS/FAIL (SDK scanner) |
| Accidentally empty | Platform | `""` | **Error** (catches content bugs) |
| Manual rule | Manual | `""` | **MANUAL** (intentional) |

This mirrors the existing XCCDF path where `notchecked` → `CheckResultManual` (`parse_arf_result.go:808`). The `CheckResultManual` constant already existed — no new types needed.

ComplianceAsCode/content PR #[14920](https://github.com/ComplianceAsCode/content/pull/14920/changes/72672a7c5fd81d8a741ea906ccf14574aed3e649) updates `build_cel_content.py` to emit manual rules into `cel-content.yaml` with `checkType: Manual` (no expression, no inputs).


## Test plan

Tested end-to-end on OCP 4.22 cluster with CNV installed:

1. Built custom operator image with these changes
2. Built content image with manual rule in `cel-content.yaml`
3. Created ProfileBundle with `celContentFile` — **VALID** (previously INVALID due to empty expression compilation)
4. Verified manual rule appears as a `Rule` CR:


```
oc get compliancecheckresults -n openshift-complianceNAME                                                                         STATUS   SEVERITY
upstream-ocp4-cis-vm-extension-kubevirt-enforce-trusted-tls-registries       PASS     medium
upstream-ocp4-cis-vm-extension-kubevirt-no-permitted-host-devices            PASS     medium
upstream-ocp4-cis-vm-extension-kubevirt-no-vms-overcommitting-guest-memory   FAIL     medium
upstream-ocp4-cis-vm-extension-kubevirt-nonroot-feature-gate-is-enabled      FAIL     medium
upstream-ocp4-cis-vm-extension-kubevirt-persistent-reservation-disabled      PASS     medium
upstream-ocp4-cis-vm-extension-kubevirt-restrict-migration-tools-access      MANUAL   medium
```

```
oc get ssb/cis-vm-cel-test -n openshift-compliance -o yaml
apiVersion: compliance.openshift.io/v1alpha1
kind: ScanSettingBinding
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"compliance.openshift.io/v1alpha1","kind":"ScanSettingBinding","metadata":{"annotations":{},"name":"cis-vm-cel-test","namespace":"openshift-compliance"},"profiles":[{"apiGroup":"compliance.openshift.io/v1alpha1","kind":"Profile","name":"upstream-ocp4-cis-vm-extension"}],"settingsRef":{"apiGroup":"compliance.openshift.io/v1alpha1","kind":"ScanSetting","name":"default"}}
  creationTimestamp: "2026-07-31T09:46:55Z"
  generation: 1
  name: cis-vm-cel-test
  namespace: openshift-compliance
  resourceVersion: "69339"
  uid: 6b71a3e3-9622-4489-a645-db3793051023
profiles:
- apiGroup: compliance.openshift.io/v1alpha1
  kind: Profile
  name: upstream-ocp4-cis-vm-extension
settingsRef:
  apiGroup: compliance.openshift.io/v1alpha1
  kind: ScanSetting
  name: default
status:
  conditions:
  - lastTransitionTime: "2026-07-31T09:46:55Z"
    message: The scan setting binding was successfully processed
    reason: Processed
    status: "True"
    type: Ready
  outputRef:
    apiGroup: compliance.openshift.io
    kind: ComplianceSuite
    name: cis-vm-cel-test
  phase: READY
```
```
oc get hyperconverged kubevirt-hyperconverged -n openshift-cnv -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null
True
```

```
oc describe compliancescans.compliance.openshift.io -n openshift-compliance 
Name:         upstream-ocp4-cis-vm-extension
Namespace:    openshift-compliance
Labels:       compliance.openshift.io/profile-guid=f96429dc-9bde-5ee4-9782-cc2fe4625c58
              compliance.openshift.io/suite=cis-vm-cel-test
Annotations:  compliance.openshift.io/check-count: 6
API Version:  compliance.openshift.io/v1alpha1
Kind:         ComplianceScan
Metadata:
  Creation Timestamp:  2026-07-31T09:46:55Z
  Finalizers:
    scan.finalizers.compliance.openshift.io
  Generation:  1
  Owner References:
    API Version:           compliance.openshift.io/v1alpha1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  ComplianceSuite
    Name:                  cis-vm-cel-test
    UID:                   98fa7f70-d9f6-4435-9b7e-26ce83ea82dd
  Resource Version:        69579
  UID:                     c9cdeea7-f5f8-4b04-af4c-79970892e53f
Spec:
  Max Retry On Timeout:  3
  Profile:               upstream-ocp4-cis-vm-extension
  Raw Result Storage:
    Enabled:  true
    Node Selector:
      node-role.kubernetes.io/master:  
    Pv Access Modes:
      ReadWriteOnce
    Rotation:  3
    Size:      1Gi
    Tolerations:
      Effect:              NoSchedule
      Key:                 node-role.kubernetes.io/master
      Operator:            Exists
      Effect:              NoExecute
      Key:                 node.kubernetes.io/not-ready
      Operator:            Exists
      Toleration Seconds:  300
      Effect:              NoExecute
      Key:                 node.kubernetes.io/unreachable
      Operator:            Exists
      Toleration Seconds:  300
      Effect:              NoSchedule
      Key:                 node.kubernetes.io/memory-pressure
      Operator:            Exists
  Scan Tolerations:
    Operator:           Exists
  Scan Type:            Platform
  Scanner Type:         CEL
  Show Not Applicable:  false
  Strict Node Scan:     true
  Timeout:              30m
Status:
  Conditions:
    Last Transition Time:  2026-07-31T09:47:06Z
    Message:               Compliance scan run is done running the scans
    Reason:                NotRunning
    Status:                False
    Type:                  Processing
    Last Transition Time:  2026-07-31T09:47:06Z
    Message:               Compliance scan run is done and has results
    Reason:                Done
    Status:                True
    Type:                  Ready
  End Timestamp:           2026-07-31T09:47:06Z
  Phase:                   DONE
  Remaining Retries:       3
  Result:                  NON-COMPLIANT
  Results Storage:
  Start Timestamp:  2026-07-31T09:46:55Z
Events:
  Type    Reason           Age   From      Message
  ----    ------           ----  ----      -------
  Normal  ResultAvailable  10m   scanctrl  ComplianceScan's result is: NON-COMPLIANT
```
## Reviewer testing

To test with the pre-built images (no local build needed):

### 1. Install compliance-operator

```bash
# Install from OperatorHub (or use your preferred method)
# Then patch to use the custom operator image:

oc patch csv $(oc get csv -n openshift-compliance -o jsonpath='{.items[0].metadata.name}') \
  -n openshift-compliance --type='json' -p='[
    {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/image","value":"quay.io/rh-ee-thafeez/compliance-operator:cmp-4518"},
    {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/4/value","value":"quay.io/rh-ee-thafeez/compliance-operator:cmp-4518"}
  ]'
```
### Wait for rollout
```
oc rollout status deployment/compliance-operator -n openshift-compliance
```
 ### Create ProfileBundle with content image
```
 oc apply -n openshift-compliance -f - <<EOF
apiVersion: compliance.openshift.io/v1alpha1
kind: ProfileBundle
metadata:
  name: upstream-ocp4
spec:
  contentImage: quay.io/rh-ee-thafeez/compliance-operator-content:cmp-4435-manual
  contentFile: ssg-ocp4-ds.xml
  celContentFile: ocp4-cel-content.yaml
EOF
```
### Wait for VALID
```
oc get profilebundle upstream-ocp4 -n openshift-compliance
NAME            CONTENTIMAGE                                                        CONTENTFILE       CELCONTENTFILE          STATUS
upstream-ocp4   quay.io/rh-ee-thafeez/compliance-operator-content:cmp-4435-manual   ssg-ocp4-ds.xml   ocp4-cel-content.yaml   VALID
```
### Ensure rule exists 
```
oc get rules.compliance -n openshift-compliance | grep migration
upstream-ocp4-kubevirt-restrict-migration-tools-access                              64m
 ```
### Run Scan 
```
oc apply -n openshift-compliance -f - <<EOF
apiVersion: compliance.openshift.io/v1alpha1
kind: ScanSettingBinding
metadata:
  name: cis-vm-cel-test
profiles:
  - name: upstream-ocp4-cis-vm-extension
    kind: Profile
    apiGroup: compliance.openshift.io/v1alpha1
settingsRef:
  name: default
  kind: ScanSetting
  apiGroup: compliance.openshift.io/v1alpha1
EOF
```

### Check Scan 
```
oc get compliancescan -n openshift-compliance
NAME                             PHASE   RESULT
upstream-ocp4-cis-vm-extension   DONE    NON-COMPLIANT
```
### Check Result
```
oc get compliancecheckresults -n openshift-compliance
NAME                                                                         STATUS   SEVERITY
upstream-ocp4-cis-vm-extension-kubevirt-enforce-trusted-tls-registries       PASS     medium
upstream-ocp4-cis-vm-extension-kubevirt-no-permitted-host-devices            PASS     medium
upstream-ocp4-cis-vm-extension-kubevirt-no-vms-overcommitting-guest-memory   FAIL     medium
upstream-ocp4-cis-vm-extension-kubevirt-nonroot-feature-gate-is-enabled      FAIL     medium
upstream-ocp4-cis-vm-extension-kubevirt-persistent-reservation-disabled      PASS     medium
upstream-ocp4-cis-vm-extension-kubevirt-restrict-migration-tools-access      MANUAL   medium
```

### Last check to verify which image was used

```
 oc get pod -n openshift-compliance -l name=compliance-operator -o jsonpath='{.items[0].spec.containers[0].env}' | jq '.[] | select(.name | contains("IMAGE"))'
{
  "name": "RELATED_IMAGE_OPENSCAP",
  "value": "ghcr.io/complianceascode/openscap-ocp:latest"
}
{
  "name": "RELATED_IMAGE_OPERATOR",
  "value": "quay.io/rh-ee-thafeez/compliance-operator:cmp-4518"
}
{
  "name": "RELATED_IMAGE_PROFILE",
  "value": "ghcr.io/complianceascode/k8scontent:latest"
}
```

Co-authored: Claude