### PR TITLE
CMP-4455: Bump version to v1.9.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,8 +386,20 @@ endif
 
 .PHONY: update-version-numbers
 update-version-numbers: check-operator-version ## Set skip range and version numbers in manifests.
+	@CURRENT_VERSION=$$(grep '^VERSION?=' version.Makefile | cut -d= -f2); \
+	if [ "$(VERSION)" != "$$CURRENT_VERSION" ]; then \
+		sed -i "s/^ARG CO_OLD_VERSION=.*/ARG CO_OLD_VERSION=\"$$CURRENT_VERSION\"/" bundle.openshift.Dockerfile; \
+		sed -i 's/^ARG CO_NEW_VERSION=.*/ARG CO_NEW_VERSION="$(VERSION)"/' bundle.openshift.Dockerfile; \
+		sed -i "s/^PREVIOUS_VERSION?=.*/PREVIOUS_VERSION?=$$CURRENT_VERSION/" version.Makefile; \
+	fi
+	sed -i 's/^VERSION?=.*/VERSION?=$(VERSION)/' version.Makefile
+	sed -i 's/Version = ".*"/Version = "$(VERSION)"/' version/version.go
+	sed -i 's/version=.*/version=$(VERSION)/' images/operator/Dockerfile
+	sed -i 's/version=.*/version=$(VERSION)/' images/openscap/Containerfile
+	sed -i 's/version=.*/version=$(VERSION)/' images/must-gather/Containerfile
 	sed -i "s/\(^  version: \).*/\1$(VERSION)/" config/manifests/bases/compliance-operator.clusterserviceversion.yaml
-	sed -i "s/\(^  replaces: compliance-operator.v\).*/\1$(PREVIOUS_VERSION)/" config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+	@PREV=$$(grep '^PREVIOUS_VERSION?=' version.Makefile | cut -d= -f2); \
+	sed -i "s/\(^  replaces: compliance-operator.v\).*/\1$$PREV/" config/manifests/bases/compliance-operator.clusterserviceversion.yaml
 	sed -i "s/\(olm.skipRange: '>=.*\)<.*'/\1<$(VERSION)'/" config/manifests/bases/compliance-operator.clusterserviceversion.yaml
 	sed -i "s/\(\"name\": \"compliance-operator.v\).*\"/\1$(VERSION)\"/" catalog/preamble.json
 	sed -i "s/\(\"skipRange\": \">=.*\)<.*\"/\1<$(VERSION)\"/" catalog/preamble.json

--- a/bundle.openshift.Dockerfile
+++ b/bundle.openshift.Dockerfile
@@ -1,5 +1,5 @@
-ARG CO_OLD_VERSION="1.9.0"
-ARG CO_NEW_VERSION="1.9.1"
+ARG CO_OLD_VERSION="1.9.1"
+ARG CO_NEW_VERSION="1.9.2"
 
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25 as builder
 

--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -160,9 +160,9 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
-    createdAt: "2026-06-11T13:25:22Z"
+    createdAt: "2026-08-06T09:33:37Z"
     must-gather-image: ghcr.io/complianceascode/must-gather-ocp:latest
-    olm.skipRange: '>=0.1.17 <1.9.1'
+    olm.skipRange: '>=0.1.17 <1.9.2'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
@@ -177,7 +177,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: compliance-operator.v1.9.1
+  name: compliance-operator.v1.9.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1745,5 +1745,5 @@ spec:
     name: operator
   - image: ghcr.io/complianceascode/k8scontent:latest
     name: profile
-  replaces: compliance-operator.v1.9.0
-  version: 1.9.1
+  replaces: compliance-operator.v1.9.1
+  version: 1.9.2

--- a/catalog/preamble.json
+++ b/catalog/preamble.json
@@ -13,8 +13,8 @@
     "package": "compliance-operator",
     "entries": [
         {
-            "name": "compliance-operator.v1.9.1",
-            "skipRange": ">=0.1.17 <1.9.1"
+            "name": "compliance-operator.v1.9.2",
+            "skipRange": ">=0.1.17 <1.9.2"
         }
     ]
 }

--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -161,7 +161,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
     must-gather-image: ghcr.io/complianceascode/must-gather-ocp:latest
-    olm.skipRange: '>=0.1.17 <1.9.1'
+    olm.skipRange: '>=0.1.17 <1.9.2'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
@@ -1589,5 +1589,5 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  replaces: compliance-operator.v1.9.0
-  version: 1.9.1
+  replaces: compliance-operator.v1.9.1
+  version: 1.9.2

--- a/images/must-gather/Containerfile
+++ b/images/must-gather/Containerfile
@@ -14,7 +14,7 @@ LABEL \
         com.redhat.component="openshift-compliance-must-gather-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Compliance Operator" \
-        version=1.9.1
+        version=1.9.2
 
 # Install openshift-clients, jq, tar, and rsync, which are required for
 # must-gather.

--- a/images/openscap/Containerfile
+++ b/images/openscap/Containerfile
@@ -15,7 +15,7 @@ LABEL \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Compliance Operator" \
         run="podman run --privileged -v /:/host  -eHOSTROOT=/host -ePROFILE=xccdf_org.ssgproject.content_profile_coreos-fedramp -eCONTENT=ssg-rhcos4-ds.xml -eREPORT_DIR=/reports -eRULE=xccdf_org.ssgproject.content_rule_selinux_state" \
-        version=1.9.1
+        version=1.9.2
 
 RUN microdnf -y update glibc
 RUN microdnf -y install openscap openscap-scanner

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -27,7 +27,7 @@ LABEL \
         com.redhat.component="openshift-compliance-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Compliance Operator" \
-        version=1.9.1
+        version=1.9.2
 
 WORKDIR /
 

--- a/version.Makefile
+++ b/version.Makefile
@@ -2,5 +2,5 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 
-PREVIOUS_VERSION?=1.9.0
-VERSION?=1.9.1
+PREVIOUS_VERSION?=1.9.1
+VERSION?=1.9.2

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.9.1"
+	Version = "1.9.2"
 )


### PR DESCRIPTION
## What
Bump operator version from 1.9.1 to 1.9.2 and automate the `make bundle` version update process.

## Version bump
Running `make bundle VERSION=1.9.2` now bumps all required files automatically.

**Files updated (9 total):**
- `version.Makefile` — `VERSION=1.9.2`, `PREVIOUS_VERSION=1.9.1`
- `version/version.go` — `Version = "1.9.2"`
- `bundle.openshift.Dockerfile` — `CO_OLD_VERSION="1.9.1"`, `CO_NEW_VERSION="1.9.2"`
- `images/operator/Dockerfile` — `version=1.9.2`
- `images/openscap/Containerfile` — `version=1.9.2`
- `images/must-gather/Containerfile` — `version=1.9.2`
- `config/manifests/bases/compliance-operator.clusterserviceversion.yaml` — generated
- `bundle/manifests/compliance-operator.clusterserviceversion.yaml` — generated
- `catalog/preamble.json` — generated

**CSV verification:**
- `name: compliance-operator.v1.9.2`
- `version: 1.9.2`
- `replaces: compliance-operator.v1.9.1`
- `olm.skipRange: '>=0.1.17 <1.9.2'`

## Makefile improvement
The `update-version-numbers` target now handles all 6 previously-manual files
in addition to the 3 it already managed. Running `make bundle VERSION=x.y.z`
bumps everything; running `make bundle` without VERSION regenerates bundles
while keeping the current version.

Modeled after openshift/file-integrity-operator#1038.