### PR TITLE
CMP-4455: Make bundle - update all files with specified version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,8 +388,20 @@ endif
 
 .PHONY: update-version-numbers
 update-version-numbers: check-operator-version ## Set skip range and version numbers in manifests.
+	@CURRENT_VERSION=$$(grep '^VERSION?=' version.Makefile | cut -d= -f2); \
+	if [ "$(VERSION)" != "$$CURRENT_VERSION" ]; then \
+		sed -i "s/^ARG CO_OLD_VERSION=.*/ARG CO_OLD_VERSION=\"$$CURRENT_VERSION\"/" bundle.openshift.Dockerfile; \
+		sed -i 's/^ARG CO_NEW_VERSION=.*/ARG CO_NEW_VERSION="$(VERSION)"/' bundle.openshift.Dockerfile; \
+		sed -i "s/^PREVIOUS_VERSION?=.*/PREVIOUS_VERSION?=$$CURRENT_VERSION/" version.Makefile; \
+	fi
+	sed -i 's/^VERSION?=.*/VERSION?=$(VERSION)/' version.Makefile
+	sed -i 's/Version = ".*"/Version = "$(VERSION)"/' version/version.go
+	sed -i 's/version=.*/version=$(VERSION)/' images/operator/Dockerfile
+	sed -i 's/version=.*/version=$(VERSION)/' images/openscap/Containerfile
+	sed -i 's/version=.*/version=$(VERSION)/' images/must-gather/Containerfile
 	sed -i "s/\(^  version: \).*/\1$(VERSION)/" config/manifests/bases/compliance-operator.clusterserviceversion.yaml
-	sed -i "s/\(^  replaces: compliance-operator.v\).*/\1$(PREVIOUS_VERSION)/" config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+	@PREV=$$(grep '^PREVIOUS_VERSION?=' version.Makefile | cut -d= -f2); \
+	sed -i "s/\(^  replaces: compliance-operator.v\).*/\1$$PREV/" config/manifests/bases/compliance-operator.clusterserviceversion.yaml
 	sed -i "s/\(olm.skipRange: '>=.*\)<.*'/\1<$(VERSION)'/" config/manifests/bases/compliance-operator.clusterserviceversion.yaml
 	sed -i "s/\(\"name\": \"compliance-operator.v\).*\"/\1$(VERSION)\"/" catalog/preamble.json
 	sed -i "s/\(\"skipRange\": \">=.*\)<.*\"/\1<$(VERSION)\"/" catalog/preamble.json


### PR DESCRIPTION
Now, running `make bundle VERSION=x.y.z` bumps all the required files.
Running `make bundle` just regenerates the bundles while keeping the current version.

Files updated automatically when VERSION differs from the current version:
- `version.Makefile` — `VERSION`, `PREVIOUS_VERSION`
- `version/version.go` — `Version`
- `bundle.openshift.Dockerfile` — `CO_OLD_VERSION`, `CO_NEW_VERSION`
- `images/operator/Dockerfile` — `version` label
- `images/openscap/Containerfile` — `version` label
- `images/must-gather/Containerfile` — `version` label
- `config/manifests/bases/compliance-operator.clusterserviceversion.yaml` — `version`, `replaces`, `skipRange`
- `catalog/preamble.json` — `name`, `skipRange`

Modeled after #1322 and openshift/file-integrity-operator#1038.