### PR TITLE
Keep OPENSCAP_IMAGE defaulting to the manifest image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ DEFAULT_OPENSCAP_TAG=latest
 OPENSCAP_TAG?=$(DEFAULT_OPENSCAP_TAG)
 OPENSCAP_DOCKER_FILE=./images/openscap/Containerfile
 DEFAULT_OPENSCAP_IMAGE=$(DEFAULT_KONFLUX_REPO)/$(APP_NAME)-openscap-dev:$(DEFAULT_KONFLUX_TAG)
-OPENSCAP_IMAGE?=$(DEFAULT_REPO)/$(OPENSCAP_NAME):$(OPENSCAP_TAG)
+OPENSCAP_IMAGE?=$(DEFAULT_OPENSCAP_IMAGE)
 
 # Image path to use. Set this if you want to use a specific path for building
 # or your e2e tests. This is overwritten if we build the image and push it to


### PR DESCRIPTION
## Summary

One-line follow-up to #1295: `OPENSCAP_IMAGE` still defaulted to the ghcr `openscap-ocp` image, whose publisher #1295 removed - the tag is now frozen at its final build. Since the deploy targets substitute `DEFAULT_OPENSCAP_IMAGE` -> `OPENSCAP_IMAGE` in the rendered manifests, a plain `make deploy`/e2e deploy silently swapped the fresh Konflux `openscap-dev:master` image out for the permanently-frozen ghcr one - the same slow-rot failure mode as the frozen k8scontent image.

Restoring `OPENSCAP_IMAGE?=$(DEFAULT_OPENSCAP_IMAGE)` makes the substitution a no-op unless a developer explicitly overrides (e.g. `make e2e OPENSCAP_IMAGE=my-scanner:test`, which is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)