### PR TITLE
Fix workshop install troubleshooting: use installplans, not ip

### DIFF
--- a/doc/tutorials/workshop/content/exercises/02-installation.md
+++ b/doc/tutorials/workshop/content/exercises/02-installation.md
@@ -115,7 +115,7 @@ compliance-operator.v1.2.0    Compliance Operator   1.2.0                Succeed
 ```
 
 ```bash
-oc get ip -nopenshift-compliance
+oc get installplans -nopenshift-compliance
 ```
 
 ```


### PR DESCRIPTION
## Summary

- Change `oc get ip -nopenshift-compliance` to `oc get installplans -nopenshift-compliance` in the install exercise troubleshooting section.

## Why

The install exercise shows sample `InstallPlan` output (`NAME`, `CSV`, `APPROVAL`, `APPROVED`), but the command uses `oc get ip`.

On current OpenShift/kubectl, `ip` is a short name for **`IPAddress`** (`networking.k8s.io/v1`), not OLM `InstallPlan`. Running `oc get ip` lists cluster **service IP allocations**, for example:

```
NAME             PARENTREF
172.30.0.1       services/default/kubernetes
172.30.0.10      services/openshift-dns/dns-default
...
```

`InstallPlan` also has short name `ip` (`operators.coreos.com/v1alpha1`), but it is lower priority, so `oc get ip` resolves to `IPAddress` and may warn that `ip` could also match installplans.

For OLM install troubleshooting, the intended resource is **`InstallPlan`** in `openshift-compliance`. Using the full resource name avoids the ambiguity.

## Test plan

- [x] Verified `oc explain ip` documents `IPAddress` (networking.k8s.io/v1)
- [x] Verified `oc explain installplans` documents OLM InstallPlan with the expected columns


Made with [Cursor](https://cursor.com)