### PR TITLE
 CMP-4599: Fix workloadNeedsUpdate to detect celContentFile changes

### DIFF
--- a/coverage-baseline.txt
+++ b/coverage-baseline.txt
@@ -11,7 +11,7 @@ github.com/ComplianceAsCode/compliance-operator/pkg/controller/compliancescan	40
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/compliancesuite	22.9
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/customrule	65.7
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/metrics	60.7
-github.com/ComplianceAsCode/compliance-operator/pkg/controller/profilebundle	5.1
+github.com/ComplianceAsCode/compliance-operator/pkg/controller/profilebundle	13.0
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/scansettingbinding	53.6
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/tailoredprofile	59.5
 github.com/ComplianceAsCode/compliance-operator/pkg/profileparser	78.2

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -12,6 +12,7 @@ import (
 
 	"fmt"
 	"path"
+	"strings"
 
 	compliancev1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/ComplianceAsCode/compliance-operator/pkg/controller/common"
@@ -192,7 +193,7 @@ func (r *ReconcileProfileBundle) Reconcile(ctx context.Context, request reconcil
 		return reconcile.Result{}, err
 	}
 
-	if workloadNeedsUpdate(effectiveImage, found) {
+	if workloadNeedsUpdate(instance, effectiveImage, found) {
 		pbCopy := instance.DeepCopy()
 		pbCopy.Status.DataStreamStatus = compliancev1alpha1.DataStreamPending
 		pbCopy.Status.ErrorMessage = ""
@@ -656,7 +657,7 @@ func profileparserCompleted(pod *corev1.Pod) bool {
 	return false
 }
 
-func workloadNeedsUpdate(image string, depl *appsv1.Deployment) bool {
+func workloadNeedsUpdate(pb *compliancev1alpha1.ProfileBundle, image string, depl *appsv1.Deployment) bool {
 	initContainers := depl.Spec.Template.Spec.InitContainers
 	if len(initContainers) != 2 {
 		// For some weird reason we don't have the amount of init containers we expect.
@@ -665,16 +666,23 @@ func workloadNeedsUpdate(image string, depl *appsv1.Deployment) bool {
 
 	isSameContentImage := false
 	isSaneProfileparserImage := false
+	isSameContentCommand := false
+	isSameParserCommand := false
+
+	expectedContentCmd := contentCopyCommand(pb)
+	expectedParserCmd := strings.Join(profileparserCommand(pb), "\x00")
 
 	for _, container := range initContainers {
 		if container.Name == "content-container" {
-			// we need an update if the image reference doesn't match.
 			isSameContentImage = container.Image == image
+			isSameContentCommand = len(container.Command) == 3 &&
+				container.Command[2] == expectedContentCmd
 		}
 		if container.Name == "profileparser" {
 			isSaneProfileparserImage = utils.GetComponentImage(utils.OPERATOR) == container.Image
+			isSameParserCommand = strings.Join(container.Command, "\x00") == expectedParserCmd
 		}
 	}
 
-	return !(isSameContentImage && isSaneProfileparserImage)
+	return !(isSameContentImage && isSaneProfileparserImage && isSameContentCommand && isSameParserCommand)
 }

--- a/pkg/controller/profilebundle/profilebundle_controller_test.go
+++ b/pkg/controller/profilebundle/profilebundle_controller_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	compliancev1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/ComplianceAsCode/compliance-operator/pkg/utils"
 )
 
 // TestNewWorkloadForBundleUsesRecreateStrategy guards against the profileparser
@@ -34,5 +36,52 @@ func TestNewWorkloadForBundleUsesRecreateStrategy(t *testing.T) {
 	if got := depl.Spec.Strategy.Type; got != appsv1.RecreateDeploymentStrategyType {
 		t.Errorf("expected profileparser Deployment to use %q strategy, got %q",
 			appsv1.RecreateDeploymentStrategyType, got)
+	}
+}
+
+func TestWorkloadNeedsUpdateDetectsCELContentFileChange(t *testing.T) {
+	image := "example.com/content:v1"
+	operatorImage := utils.GetComponentImage(utils.OPERATOR)
+
+	pbNoCEL := &compliancev1alpha1.ProfileBundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ocp4",
+			Namespace: "openshift-compliance",
+		},
+		Spec: compliancev1alpha1.ProfileBundleSpec{
+			ContentImage: image,
+			ContentFile:  "ssg-ocp4-ds.xml",
+		},
+	}
+	pbWithCEL := pbNoCEL.DeepCopy()
+	pbWithCEL.Spec.CELContentFile = "ocp4-cel-content.yaml"
+
+	deplFromNoCEL := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:    "content-container",
+							Image:   image,
+							Command: []string{"sh", "-c", contentCopyCommand(pbNoCEL)},
+						},
+						{
+							Name:    "profileparser",
+							Image:   operatorImage,
+							Command: profileparserCommand(pbNoCEL),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if workloadNeedsUpdate(pbNoCEL, image, deplFromNoCEL) {
+		t.Error("workloadNeedsUpdate should return false when spec matches deployment")
+	}
+
+	if !workloadNeedsUpdate(pbWithCEL, image, deplFromNoCEL) {
+		t.Error("workloadNeedsUpdate should return true when celContentFile was added but deployment still has old commands")
 	}
 }


### PR DESCRIPTION
`workloadNeedsUpdate` only compared container images when deciding whether to re-deploy the profileparser workload. This meant that adding or changing `spec.celContentFile` on an already-VALID ProfileBundle was silently ignored — the controller logged "Skip reconcile: Workload already up-to-date" because the content image hadn't changed, even though the init container commands needed to include the new --cel-path flag and the additional cp command for the CEL content file.

Without a re-deploy, the old parser pod kept running with the old commands (no `--cel-path`), so CEL profiles like cis-vm-extension were never created. The ProfileBundle status stayed VALID from the initial XCCDF-only parse, and any downstream consumer waiting for CEL profiles would fail with "profile not found".


Compare the content-container shell command and profileparser command arguments against what `contentCopyCommand` and `profileparserCommand` would produce for the current ProfileBundle spec. When `celContentFile` is added or changed, the commands differ, `workloadNeedsUpdate` returns true, and the existing re-deploy logic sets status to `PENDING`, updates the deployment, and the parser re-runs with the CEL content included.

Co-authored by Claude.
Related [PR](https://github.com/ComplianceAsCode/ocp4e2e/pull/83).