### PR TITLE
CMP-4571: Switch production base images to ubi9-minimal-pqc for PQC support

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -10,7 +10,7 @@ COPY . .
 RUN make manager
 
 # Step two: containerize compliance-operator
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 ENV OPERATOR=/usr/local/bin/compliance-operator
 

--- a/images/must-gather/Containerfile
+++ b/images/must-gather/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 LABEL \
         io.k8s.display-name="must-gather cli for compliance-operator" \

--- a/images/openscap/Containerfile
+++ b/images/openscap/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 LABEL \
         io.k8s.display-name="OpenSCAP scanner for compliance-operator" \

--- a/images/openscap/Dockerfile.ci
+++ b/images/openscap/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 LABEL \
     name="openscap-ocp" \

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -19,7 +19,7 @@ RUN expected=$(awk '/^go / { print $2 }' go.mod) && \
 
 RUN make manager
 
-FROM registry.redhat.io/ubi9/ubi-minimal:latest
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 RUN microdnf install -y --setopt=tsflags=nodocs tar
 RUN microdnf clean all && rm -rf /var/cache/*


### PR DESCRIPTION
## What

Switch production and CI container base images to `registry.redhat.io/ubi9/ubi-minimal-pqc` to enable Post-Quantum Cryptography (PQC) support via the `DEFAULT:PQ` crypto policy in OpenSSL.

## Why

Required by [OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113): all OCP and layered-product images must ship with `DEFAULT:PQ` crypto policy so the release pipeline check finds it. The PQC base images (`ubi-minimal-pqc`) are now GA ([announcement](https://redhat.atlassian.net/browse/OCPSTRAT-3113?focusedCommentId=17887631)).

The `ubi-minimal-pqc` image is identical to `ubi-minimal` except it ships with the `DEFAULT:PQ` crypto policy pre-configured, enabling ML-KEM (post-quantum key encapsulation) in OpenSSL on RHEL 9. On FIPS-mode clusters the FIPS-140 regulation is properly observed and PQC is disabled.

## Changes

| File | Old base image | New base image |
|------|---------------|---------------|
| `images/operator/Dockerfile` | `registry.redhat.io/ubi9/ubi-minimal` | `registry.redhat.io/ubi9/ubi-minimal-pqc` |
| `images/openscap/Containerfile` | `registry.redhat.io/ubi9/ubi-minimal` | `registry.redhat.io/ubi9/ubi-minimal-pqc` |
| `images/must-gather/Containerfile` | `registry.redhat.io/ubi9/ubi-minimal` | `registry.redhat.io/ubi9/ubi-minimal-pqc` |
| `Dockerfile.ci` | `registry.access.redhat.com/ubi9/ubi-micro` | `registry.redhat.io/ubi9/ubi-minimal-pqc` |
| `images/openscap/Dockerfile.ci` | `registry.access.redhat.com/ubi8/ubi-minimal` | `registry.redhat.io/ubi9/ubi-minimal-pqc` |

Upstream community Dockerfiles (`build/Dockerfile`, `images/openscap/Dockerfile`, `images/testcontent/broken-content.Dockerfile`) are not changed because they are built by GitHub Actions which cannot authenticate to `registry.redhat.io`, and they are not checked by the OCP release pipeline.

## Testing

1. Built operator image locally using `make image` -- build succeeded.
2. Verified `DEFAULT:PQ` crypto policy inside the built image.
3. Deployed to OCP 4.22 cluster, verified operator runs with `DEFAULT:PQ` and ran a CIS compliance scan to completion.
4. Ran full e2e parallel suite (73 tests) -- all passed.

Fixes: CMP-4571

[OCPSTRAT-3113]: https://redhat.atlassian.net/browse/OCPSTRAT-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ