### PR TITLE
CMP-4600: konflux: apply the branch tag to openscap push builds

### DIFF
--- a/.tekton/compliance-operator-openscap-dev-push.yaml
+++ b/.tekton/compliance-operator-openscap-dev-push.yaml
@@ -493,6 +493,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - '{{ target_branch }}'
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
The operator, bundle, and must-gather push pipelines pass `ADDITIONAL_TAGS: ['{{ target_branch }}']` to the `apply-tags` task, so each master build re-points the `:master` tag. The openscap pipeline is the only one that never did — so `compliance-operator-openscap-dev:master` doesn't exist despite regular builds (latest: 2026-08-15), and every default reference to it is unpullable:

- `Makefile` `DEFAULT_OPENSCAP_IMAGE`
- the `RELATED_IMAGE_OPENSCAP` fallback in `pkg/utils/images.go`
- the deploy manifests (`config/manager/deployment.yaml`)

Effect: plain `make deploy` and local `make e2e-*` runs hang with every scanner pod in ImagePullBackOff (prow was hit by the same missing tag until #1255 restored the `OPENSCAP_IMAGE_FROM_CI` mapping).

Merging this PR itself triggers an openscap master build (the pipeline file is in its own `on-cel` path filter), which applies the tag immediately — no other action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)