### PR TITLE
CMP-4602: Update version to 1.10.0-dev in Makefile and manifests for development

### DIFF
--- a/bundle.openshift.Dockerfile
+++ b/bundle.openshift.Dockerfile
@@ -1,5 +1,5 @@
-ARG CO_OLD_VERSION="1.7.1"
-ARG CO_NEW_VERSION="1.8.0-dev"
+ARG CO_OLD_VERSION="1.9.2"
+ARG CO_NEW_VERSION="1.10.0-dev"
 
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25 as builder
 

--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -161,7 +161,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
     must-gather-image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-must-gather-dev:master
-    olm.skipRange: '>=0.1.17 <1.8.0-dev'
+    olm.skipRange: '>=0.1.17 <1.10.0-dev'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
@@ -176,7 +176,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: compliance-operator.v1.8.0-dev
+  name: compliance-operator.v1.10.0-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1784,5 +1784,5 @@ spec:
     name: operator
   - image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master
     name: profile
-  replaces: compliance-operator.v1.7.1
-  version: 1.8.0-dev
+  replaces: compliance-operator.v1.9.2
+  version: 1.10.0-dev

--- a/catalog/preamble.json
+++ b/catalog/preamble.json
@@ -13,8 +13,8 @@
     "package": "compliance-operator",
     "entries": [
         {
-            "name": "compliance-operator.v1.8.0-dev",
-            "skipRange": ">=0.1.17 <1.8.0-dev"
+            "name": "compliance-operator.v1.10.0-dev",
+            "skipRange": ">=0.1.17 <1.10.0-dev"
         }
     ]
 }

--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -161,7 +161,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
     must-gather-image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-must-gather-dev:master
-    olm.skipRange: '>=0.1.17 <1.8.0-dev'
+    olm.skipRange: '>=0.1.17 <1.10.0-dev'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
@@ -1586,5 +1586,5 @@ spec:
   provider:
     name: Red Hat Inc.
     url: www.redhat.com
-  replaces: compliance-operator.v1.7.1
-  version: 1.8.0-dev
+  replaces: compliance-operator.v1.9.2
+  version: 1.10.0-dev

--- a/images/must-gather/Containerfile
+++ b/images/must-gather/Containerfile
@@ -14,7 +14,7 @@ LABEL \
         com.redhat.component="openshift-compliance-must-gather-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Compliance Operator" \
-        version=1.7.1
+        version=1.10.0-dev
 
 # Install openshift-clients, jq, tar, and rsync, which are required for
 # must-gather.

--- a/images/openscap/Containerfile
+++ b/images/openscap/Containerfile
@@ -15,7 +15,7 @@ LABEL \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Compliance Operator" \
         run="podman run --privileged -v /:/host  -eHOSTROOT=/host -ePROFILE=xccdf_org.ssgproject.content_profile_coreos-fedramp -eCONTENT=ssg-rhcos4-ds.xml -eREPORT_DIR=/reports -eRULE=xccdf_org.ssgproject.content_rule_selinux_state" \
-        version=1.7.1
+        version=1.10.0-dev
 
 RUN microdnf -y update glibc
 RUN microdnf -y install openscap openscap-scanner

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -38,7 +38,7 @@ LABEL \
         com.redhat.component="openshift-compliance-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Compliance Operator" \
-        version=1.7.1
+        version=1.10.0-dev
 
 WORKDIR /
 

--- a/version.Makefile
+++ b/version.Makefile
@@ -2,5 +2,5 @@
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 
-PREVIOUS_VERSION?=1.7.1
-VERSION?=1.8.0-dev
+PREVIOUS_VERSION?=1.9.2
+VERSION?=1.10.0-dev

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.8.0-dev"
+	Version = "1.10.0-dev"
 )


### PR DESCRIPTION
Master's version metadata sat at **1.8.0-dev** (previous **1.7.1**) through the entire 1.9 cycle — the dev bundle's CSV still said `replaces: compliance-operator.v1.7.1`, so upgrade metadata against the actual 1.9.x releases was stale.

Following the release-1.9 recipe (`Bump version to v1.9.2`, using the #1325 `make update-version-numbers` automation):

- `VERSION=1.10.0-dev` (master convention: `<next>.0-dev`, cf. `Update version to 1.8.0-dev...` after 1.7.1) across version.Makefile, version/version.go, image labels (operator label was still `1.7.1`), base CSV, catalog preamble, `bundle.openshift.Dockerfile` (`CO_NEW_VERSION`)
- `PREVIOUS_VERSION=1.9.2` → `replaces: compliance-operator.v1.9.2`, `CO_OLD_VERSION=1.9.2` — one manual correction on top of the automation, which would have chained to the never-released 1.8.0-dev
- `make bundle` regenerated; operator-sdk bundle validation passes; every hunk is a pure version string

🤖 Generated with [Claude Code](https://claude.com/claude-code)