### PR TITLE
CMP-4603: Require compliance-sdk by its release tag v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ComplianceAsCode/compliance-operator
 go 1.25.11
 
 require (
-	github.com/ComplianceAsCode/compliance-sdk v0.0.0-20250930163558-59886979dd19
+	github.com/ComplianceAsCode/compliance-sdk v0.1.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.39.1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/Azure/ARO-RP v0.0.0-20260609191625-57f12dca64e6 h1:EJOfYTbAAawQY/2wtc9Vydg8paXYbBlfrViikIcHMmc=
 github.com/Azure/ARO-RP v0.0.0-20260609191625-57f12dca64e6/go.mod h1:Wt0ufpTDmyMm5etIfW/dTtgeaAmb2JT3iFGOFgm7mPc=
-github.com/ComplianceAsCode/compliance-sdk v0.0.0-20250930163558-59886979dd19 h1:THSSJvmtj7k+c9QKoUeHap14FiOMOUsAJH/ENH5KMC0=
-github.com/ComplianceAsCode/compliance-sdk v0.0.0-20250930163558-59886979dd19/go.mod h1:ZL0fSwQU1JuTiX3RgQZ3F4aRY6usqHV6ShrhvgFtPXA=
+github.com/ComplianceAsCode/compliance-sdk v0.1.1 h1:SeWsCIQXwUmGPy2VcLxG1jFNttqHe/rGnRhXMPAPiMw=
+github.com/ComplianceAsCode/compliance-sdk v0.1.1/go.mod h1:C3XFGaXUDLnryp6URL7R63BWVkIzMIT/BBiCF6tmsCE=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/ajeddeloh/go-json v0.0.0-20170920214419-6a2fe990e083/go.mod h1:otnto4/Icqn88WCcM4bhIJNSgsh9VLBuspyyCfvof9c=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -33,8 +33,8 @@ github.com/Azure/ARO-RP/pkg/operator/clientset/versioned
 github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/scheme
 github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/typed/aro.openshift.io/v1alpha1
 github.com/Azure/ARO-RP/pkg/operator/clientset/versioned/typed/preview.aro.openshift.io/v1alpha1
-# github.com/ComplianceAsCode/compliance-sdk v0.0.0-20250930163558-59886979dd19
-## explicit; go 1.23.0
+# github.com/ComplianceAsCode/compliance-sdk v0.1.1
+## explicit; go 1.25.11
 github.com/ComplianceAsCode/compliance-sdk/pkg/fetchers
 github.com/ComplianceAsCode/compliance-sdk/pkg/scanner
 # github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559


### PR DESCRIPTION
compliance-sdk now has real releases: [`v0.1.0`](https://github.com/ComplianceAsCode/compliance-sdk/releases/tag/v0.1.0) is the exact commit this repo pinned as a pseudo-version, and `v0.1.1` adds the Go 1.25.11 directive to match this repo. Requiring the tag ends the dependence on branch-head reachability that broke consumers when the sdk's `main` history was rewritten (today's stackrox `go mod tidy` incident — mitigated short-term by an archive tag at the orphaned commit).

Vendored source is byte-identical (same commit); the diff is version markers only (go.mod / go.sum / vendor/modules.txt, 5 lines).

(This was meant to ride #1351 but that merged first — re-landed on fresh master.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)