### PR TITLE
CMP-4569: Create operand NetworkPolicies at runtime

### DIFF
--- a/cmd/manager/operator.go
+++ b/cmd/manager/operator.go
@@ -35,6 +35,7 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	kerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -273,7 +274,16 @@ func RunOperator(cmd *cobra.Command, args []string) {
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Cache:                  c,
+		Cache: c,
+		// Operand NetworkPolicies are read by name during reconcile. The
+		// operator's namespaced Role grants get/create/update/delete but not
+		// list/watch; reading NetworkPolicy through the informer cache would
+		// start a list+watch and fail, so read it directly from the API server.
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{&networkingv1.NetworkPolicy{}},
+			},
+		},
 		Scheme:                 operatorScheme,
 		Metrics:                metricsserver.Options{BindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort)},
 		WebhookServer:          webhook.NewServer(webhookServerOptions),

--- a/coverage-baseline.txt
+++ b/coverage-baseline.txt
@@ -7,11 +7,11 @@ github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1	7.5
 github.com/ComplianceAsCode/compliance-operator/pkg/celcontent	84.0
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/common	33.7
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/complianceremediation	53.2
-github.com/ComplianceAsCode/compliance-operator/pkg/controller/compliancescan	40.0
-github.com/ComplianceAsCode/compliance-operator/pkg/controller/compliancesuite	22.9
+github.com/ComplianceAsCode/compliance-operator/pkg/controller/compliancescan	43.8
+github.com/ComplianceAsCode/compliance-operator/pkg/controller/compliancesuite	23.7
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/customrule	65.7
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/metrics	60.7
-github.com/ComplianceAsCode/compliance-operator/pkg/controller/profilebundle	13.0
+github.com/ComplianceAsCode/compliance-operator/pkg/controller/profilebundle	14.5
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/scansettingbinding	53.6
 github.com/ComplianceAsCode/compliance-operator/pkg/controller/tailoredprofile	59.5
 github.com/ComplianceAsCode/compliance-operator/pkg/profileparser	78.2

--- a/pkg/apis/compliance/v1alpha1/compliancescan_types.go
+++ b/pkg/apis/compliance/v1alpha1/compliancescan_types.go
@@ -30,6 +30,13 @@ const ComplianceCheckCountAnnotation = "compliance.openshift.io/check-count"
 // owns the referenced object
 const ComplianceScanLabel = "compliance.openshift.io/scan-name"
 
+// NetworkPolicyOperandLabel marks operand pods that are governed by the
+// operator-managed NetworkPolicies. It is a presence marker: the value is
+// always the empty string, and the policies select pods carrying this key. It
+// is applied to every operand pod template so the default-deny and shared allow
+// policies select them.
+const NetworkPolicyOperandLabel = "compliance.openshift.io/netpol-managed"
+
 // ScriptLabel defines that the object is a script for a scan object
 const ScriptLabel = "complianceoperator.openshift.io/scan-script"
 

--- a/pkg/controller/compliancescan/aggregator.go
+++ b/pkg/controller/compliancescan/aggregator.go
@@ -25,8 +25,9 @@ func (r *ReconcileComplianceScan) newAggregatorPod(scanInstance *compv1alpha1.Co
 	podName := getAggregatorPodName(scanInstance.Name)
 
 	podLabels := map[string]string{
-		compv1alpha1.ComplianceScanLabel: scanInstance.Name,
-		"workload":                       "aggregator",
+		compv1alpha1.ComplianceScanLabel:       scanInstance.Name,
+		compv1alpha1.NetworkPolicyOperandLabel: "",
+		WorkloadLabel:                          WorkloadAggregator,
 	}
 
 	falseP := false

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -470,6 +470,13 @@ func (r *ReconcileComplianceScan) phaseLaunchingHandler(h scanTypeHandler, logge
 
 	scan := h.getScan()
 
+	// Ensure the operand NetworkPolicies exist before launching any operand
+	// pods, so the pods start with their network access already governed.
+	if err = r.reconcileNetworkPolicies(context.TODO(), logger); err != nil {
+		logger.Error(err, "Cannot reconcile operand NetworkPolicies")
+		return reconcile.Result{}, err
+	}
+
 	// check the scanner type of the scan
 	if scan.Spec.ScannerType == compv1alpha1.ScannerTypeOpenSCAP || scan.Spec.ScannerType == "" {
 		err = createConfigMaps(r, scriptCmForScan(scan), envCmForScan(scan), envCmForPlatformScan(scan), scan)

--- a/pkg/controller/compliancescan/config.go
+++ b/pkg/controller/compliancescan/config.go
@@ -54,6 +54,15 @@ const (
 
 	ResultServerPort = int32(8443)
 
+	// WorkloadLabel identifies which operand workload a pod belongs to. Its
+	// value is one of the Workload* constants below. NetworkPolicies select
+	// operands by this label, so the values must stay in sync with the pod
+	// templates that set them.
+	WorkloadLabel        = "workload"
+	WorkloadResultServer = "resultserver"
+	WorkloadScanner      = "scanner"
+	WorkloadAggregator   = "aggregator"
+
 	// Tailoring constants
 	OpenScapTailoringDir = "/tailoring"
 

--- a/pkg/controller/compliancescan/networkpolicy.go
+++ b/pkg/controller/compliancescan/networkpolicy.go
@@ -1,0 +1,164 @@
+package compliancescan
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/ComplianceAsCode/compliance-operator/pkg/controller/common"
+)
+
+const (
+	// Names of the operator-managed operand NetworkPolicies.
+	networkPolicyDefaultDeny         = "compliance-operator-operands-default-deny"
+	networkPolicyAllowEgress         = "compliance-operator-operands-allow-egress"
+	networkPolicyResultServerIngress = "compliance-operator-resultserver-allow-ingress"
+
+	// hostNetworkNamespaceLabel is the label OVN-Kubernetes places on the
+	// namespace that represents host-network traffic. Selecting it admits
+	// host-networked node-scan scanner pods to the result server, since
+	// NetworkPolicy cannot select host-network pods directly.
+	hostNetworkNamespaceLabel = "policy-group.network.openshift.io/host-network"
+)
+
+// operandPodSelector selects every operand pod carrying the NetworkPolicy
+// marker label.
+func operandPodSelector() metav1.LabelSelector {
+	return metav1.LabelSelector{
+		MatchLabels: map[string]string{compv1alpha1.NetworkPolicyOperandLabel: ""},
+	}
+}
+
+// defaultDenyNetworkPolicy denies all ingress and egress for operand pods. The
+// allow policies reopen only what the operands need.
+func defaultDenyNetworkPolicy(ns string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      networkPolicyDefaultDeny,
+			Namespace: ns,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: operandPodSelector(),
+			// With both policy types set and no rules below, this denies all
+			// ingress and egress; the allow policies add traffic back.
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			},
+		},
+	}
+}
+
+// allowEgressNetworkPolicy allows all egress from operand pods. Egress cannot be
+// meaningfully restricted here: the API server is not selectable by
+// NetworkPolicy, and scanner pods make arbitrary external egress when fetching
+// remote SCAP resources. A single empty egress rule allows all egress, which
+// also subsumes DNS.
+func allowEgressNetworkPolicy(ns string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      networkPolicyAllowEgress,
+			Namespace: ns,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: operandPodSelector(),
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+			Egress:      []networkingv1.NetworkPolicyEgressRule{{}},
+		},
+	}
+}
+
+// resultServerIngressNetworkPolicy allows scanner pods to reach the result
+// server on its listening port. Platform-scan scanners run on the pod network
+// and are selected directly; host-networked node-scan scanners are admitted via
+// the OVN host-network namespace, since NetworkPolicy cannot select host-network
+// pods. mTLS on the result server remains the real authentication boundary.
+func resultServerIngressNetworkPolicy(ns string) *networkingv1.NetworkPolicy {
+	tcp := corev1.ProtocolTCP
+	port := intstr.FromInt32(ResultServerPort)
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      networkPolicyResultServerIngress,
+			Namespace: ns,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{WorkloadLabel: WorkloadResultServer},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{WorkloadLabel: WorkloadScanner},
+							},
+						},
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{hostNetworkNamespaceLabel: ""},
+							},
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &tcp, Port: &port},
+					},
+				},
+			},
+		},
+	}
+}
+
+// operandNetworkPolicies returns the full set of operator-managed operand
+// NetworkPolicies for the given namespace.
+func operandNetworkPolicies(ns string) []*networkingv1.NetworkPolicy {
+	return []*networkingv1.NetworkPolicy{
+		defaultDenyNetworkPolicy(ns),
+		allowEgressNetworkPolicy(ns),
+		resultServerIngressNetworkPolicy(ns),
+	}
+}
+
+// reconcileNetworkPolicies ensures the operand NetworkPolicies exist and match
+// the desired spec. It uses get-then-create/update (no list or watch), matching
+// the operator's RBAC grant, and is idempotent and safe to call on every
+// reconcile.
+func (r *ReconcileComplianceScan) reconcileNetworkPolicies(ctx context.Context, logger logr.Logger) error {
+	ns := common.GetComplianceOperatorNamespace()
+	for _, desired := range operandNetworkPolicies(ns) {
+		if err := r.reconcileNetworkPolicy(ctx, desired, logger); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileComplianceScan) reconcileNetworkPolicy(ctx context.Context, desired *networkingv1.NetworkPolicy, logger logr.Logger) error {
+	found := &networkingv1.NetworkPolicy{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, found)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+		logger.Info("Creating operand NetworkPolicy", "NetworkPolicy.Name", desired.Name)
+		if createErr := r.Client.Create(ctx, desired); createErr != nil && !errors.IsAlreadyExists(createErr) {
+			return createErr
+		}
+		return nil
+	}
+
+	if reflect.DeepEqual(found.Spec, desired.Spec) {
+		return nil
+	}
+	logger.Info("Updating operand NetworkPolicy", "NetworkPolicy.Name", desired.Name)
+	found.Spec = desired.Spec
+	return r.Client.Update(ctx, found)
+}

--- a/pkg/controller/compliancescan/networkpolicy_test.go
+++ b/pkg/controller/compliancescan/networkpolicy_test.go
@@ -1,0 +1,224 @@
+package compliancescan
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/ComplianceAsCode/compliance-operator/pkg/controller/common"
+)
+
+func TestDefaultDenyNetworkPolicy(t *testing.T) {
+	np := defaultDenyNetworkPolicy("openshift-compliance")
+
+	if np.Name != networkPolicyDefaultDeny {
+		t.Errorf("unexpected name: got %q, want %q", np.Name, networkPolicyDefaultDeny)
+	}
+	if v, ok := np.Spec.PodSelector.MatchLabels[compv1alpha1.NetworkPolicyOperandLabel]; !ok || v != "" {
+		t.Errorf("expected operand marker in pod selector, got matchLabels %v", np.Spec.PodSelector.MatchLabels)
+	}
+	// Both policy types with no rules => deny ingress and egress.
+	if len(np.Spec.PolicyTypes) != 2 {
+		t.Errorf("expected Ingress+Egress policy types, got %v", np.Spec.PolicyTypes)
+	}
+	if len(np.Spec.Ingress) != 0 || len(np.Spec.Egress) != 0 {
+		t.Errorf("default-deny must have no ingress/egress rules, got ingress=%d egress=%d",
+			len(np.Spec.Ingress), len(np.Spec.Egress))
+	}
+}
+
+func TestAllowEgressNetworkPolicy(t *testing.T) {
+	np := allowEgressNetworkPolicy("openshift-compliance")
+
+	if np.Name != networkPolicyAllowEgress {
+		t.Errorf("unexpected name: got %q, want %q", np.Name, networkPolicyAllowEgress)
+	}
+	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeEgress {
+		t.Errorf("expected only Egress policy type, got %v", np.Spec.PolicyTypes)
+	}
+	// A single empty egress rule allows all egress.
+	if len(np.Spec.Egress) != 1 {
+		t.Fatalf("expected exactly one (allow-all) egress rule, got %d", len(np.Spec.Egress))
+	}
+	if len(np.Spec.Egress[0].To) != 0 || len(np.Spec.Egress[0].Ports) != 0 {
+		t.Errorf("allow-all egress rule must have no peers/ports, got to=%d ports=%d",
+			len(np.Spec.Egress[0].To), len(np.Spec.Egress[0].Ports))
+	}
+}
+
+func TestResultServerIngressNetworkPolicy(t *testing.T) {
+	np := resultServerIngressNetworkPolicy("openshift-compliance")
+
+	if np.Name != networkPolicyResultServerIngress {
+		t.Errorf("unexpected name: got %q, want %q", np.Name, networkPolicyResultServerIngress)
+	}
+	if got := np.Spec.PodSelector.MatchLabels[WorkloadLabel]; got != WorkloadResultServer {
+		t.Errorf("expected pod selector on result server, got %v", np.Spec.PodSelector.MatchLabels)
+	}
+	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeIngress {
+		t.Errorf("expected only Ingress policy type, got %v", np.Spec.PolicyTypes)
+	}
+	if len(np.Spec.Ingress) != 1 {
+		t.Fatalf("expected one ingress rule, got %d", len(np.Spec.Ingress))
+	}
+	rule := np.Spec.Ingress[0]
+
+	// Port: TCP on the result server port.
+	if len(rule.Ports) != 1 {
+		t.Fatalf("expected one ingress port, got %d", len(rule.Ports))
+	}
+	if rule.Ports[0].Protocol == nil || *rule.Ports[0].Protocol != corev1.ProtocolTCP {
+		t.Errorf("expected TCP ingress port, got %v", rule.Ports[0].Protocol)
+	}
+	if rule.Ports[0].Port == nil || rule.Ports[0].Port.IntVal != ResultServerPort {
+		t.Errorf("expected ingress port %d, got %v", ResultServerPort, rule.Ports[0].Port)
+	}
+
+	// Two peers: pod-network scanners and host-network node scanners.
+	if len(rule.From) != 2 {
+		t.Fatalf("expected two ingress peers (scanner podSelector + host-network ns), got %d", len(rule.From))
+	}
+	var haveScannerPod, haveHostNetworkNS bool
+	for _, peer := range rule.From {
+		if peer.PodSelector != nil && peer.PodSelector.MatchLabels[WorkloadLabel] == WorkloadScanner {
+			haveScannerPod = true
+		}
+		if peer.NamespaceSelector != nil {
+			if _, ok := peer.NamespaceSelector.MatchLabels[hostNetworkNamespaceLabel]; ok {
+				haveHostNetworkNS = true
+			}
+		}
+	}
+	if !haveScannerPod {
+		t.Error("missing scanner podSelector ingress peer")
+	}
+	if !haveHostNetworkNS {
+		t.Error("missing host-network namespaceSelector ingress peer")
+	}
+}
+
+// newNetworkPolicyTestReconciler returns a reconciler backed by an in-memory
+// fake client (no cluster / envtest needed).
+func newNetworkPolicyTestReconciler(objs ...*networkingv1.NetworkPolicy) *ReconcileComplianceScan {
+	builder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+	for _, o := range objs {
+		builder = builder.WithObjects(o)
+	}
+	return &ReconcileComplianceScan{Client: builder.Build()}
+}
+
+func listNetworkPolicies(t *testing.T, r *ReconcileComplianceScan) *networkingv1.NetworkPolicyList {
+	t.Helper()
+	list := &networkingv1.NetworkPolicyList{}
+	if err := r.Client.List(context.TODO(), list); err != nil {
+		t.Fatalf("listing network policies: %v", err)
+	}
+	return list
+}
+
+func TestReconcileNetworkPoliciesCreatesAll(t *testing.T) {
+	r := newNetworkPolicyTestReconciler()
+
+	if err := r.reconcileNetworkPolicies(context.TODO(), logr.Discard()); err != nil {
+		t.Fatalf("reconcileNetworkPolicies: %v", err)
+	}
+
+	ns := common.GetComplianceOperatorNamespace()
+	want := operandNetworkPolicies(ns)
+	list := listNetworkPolicies(t, r)
+	if len(list.Items) != len(want) {
+		t.Fatalf("expected %d network policies, got %d", len(want), len(list.Items))
+	}
+	for _, desired := range want {
+		found := &networkingv1.NetworkPolicy{}
+		key := types.NamespacedName{Name: desired.Name, Namespace: ns}
+		if err := r.Client.Get(context.TODO(), key, found); err != nil {
+			t.Errorf("policy %q not created: %v", desired.Name, err)
+		}
+	}
+}
+
+func TestReconcileNetworkPoliciesIdempotent(t *testing.T) {
+	r := newNetworkPolicyTestReconciler()
+
+	if err := r.reconcileNetworkPolicies(context.TODO(), logr.Discard()); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	first := listNetworkPolicies(t, r)
+
+	// A second reconcile must not error and must not create duplicates.
+	if err := r.reconcileNetworkPolicies(context.TODO(), logr.Discard()); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	second := listNetworkPolicies(t, r)
+
+	if len(second.Items) != len(first.Items) {
+		t.Fatalf("reconcile not idempotent: policy count changed from %d to %d",
+			len(first.Items), len(second.Items))
+	}
+}
+
+func assertHasNetworkPolicyMarker(t *testing.T, operand string, labels map[string]string) {
+	t.Helper()
+	if v, ok := labels[compv1alpha1.NetworkPolicyOperandLabel]; !ok || v != "" {
+		t.Errorf("%s pod template missing NetworkPolicy marker label (labels=%v)", operand, labels)
+	}
+}
+
+// TestOperandPodTemplatesCarryNetworkPolicyMarker verifies every operand pod
+// template built by this package carries the marker so the operand policies
+// select it, and that the marker does not leak into the immutable result-server
+// Deployment selector.
+func TestOperandPodTemplatesCarryNetworkPolicyMarker(t *testing.T) {
+	logger := logr.Discard()
+	r := &ReconcileComplianceScan{}
+	scan := &compv1alpha1.ComplianceScan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-scan",
+			Namespace: common.GetComplianceOperatorNamespace(),
+		},
+	}
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+
+	rs := resultServer(scan, getResultServerLabels(scan), 0, 0, logger)
+	assertHasNetworkPolicyMarker(t, "result server", rs.Spec.Template.ObjectMeta.Labels)
+	if _, ok := rs.Spec.Selector.MatchLabels[compv1alpha1.NetworkPolicyOperandLabel]; ok {
+		t.Error("result server Deployment selector must not carry the NetworkPolicy marker")
+	}
+
+	assertHasNetworkPolicyMarker(t, "node scanner", newScanPodForNode(scan, node, logger).Labels)
+	assertHasNetworkPolicyMarker(t, "platform scanner", r.newPlatformScanPod(scan, logger).Labels)
+	assertHasNetworkPolicyMarker(t, "aggregator", r.newAggregatorPod(scan, logger).Labels)
+}
+
+func TestReconcileNetworkPolicyCorrectsDrift(t *testing.T) {
+	ns := common.GetComplianceOperatorNamespace()
+
+	// Seed a default-deny policy with a drifted spec (wrong pod selector).
+	drifted := defaultDenyNetworkPolicy(ns)
+	drifted.Spec.PodSelector = metav1.LabelSelector{MatchLabels: map[string]string{"drifted": "true"}}
+	r := newNetworkPolicyTestReconciler(drifted)
+
+	if err := r.reconcileNetworkPolicies(context.TODO(), logr.Discard()); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	found := &networkingv1.NetworkPolicy{}
+	key := types.NamespacedName{Name: networkPolicyDefaultDeny, Namespace: ns}
+	if err := r.Client.Get(context.TODO(), key, found); err != nil {
+		t.Fatalf("get after reconcile: %v", err)
+	}
+	want := defaultDenyNetworkPolicy(ns)
+	if !reflect.DeepEqual(found.Spec, want.Spec) {
+		t.Errorf("drift not corrected:\n got  %+v\n want %+v", found.Spec, want.Spec)
+	}
+}

--- a/pkg/controller/compliancescan/resultserver.go
+++ b/pkg/controller/compliancescan/resultserver.go
@@ -126,7 +126,7 @@ func (r *ReconcileComplianceScan) deleteResultServer(instance *compv1alpha1.Comp
 func getResultServerLabels(instance *compv1alpha1.ComplianceScan) map[string]string {
 	return map[string]string{
 		compv1alpha1.ComplianceScanLabel: instance.Name,
-		"workload":                       "resultserver",
+		WorkloadLabel:                    WorkloadResultServer,
 	}
 }
 
@@ -170,6 +170,13 @@ func resultServer(scanInstance *compv1alpha1.ComplianceScan, labels map[string]s
 	podFSGroup, podUid int64, logger logr.Logger) *appsv1.Deployment {
 	falseP := false
 	trueP := true
+	// The operand NetworkPolicy marker is added to the pod template only, not to
+	// the immutable Deployment/Service selector.
+	podTemplateLabels := make(map[string]string, len(labels)+1)
+	for k, v := range labels {
+		podTemplateLabels[k] = v
+	}
+	podTemplateLabels[compv1alpha1.NetworkPolicyOperandLabel] = ""
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getResultServerName(scanInstance),
@@ -182,7 +189,7 @@ func resultServer(scanInstance *compv1alpha1.ComplianceScan, labels map[string]s
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels: podTemplateLabels,
 					Annotations: map[string]string{
 						"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
 					},

--- a/pkg/controller/compliancescan/scan.go
+++ b/pkg/controller/compliancescan/scan.go
@@ -92,9 +92,10 @@ func newScanPodForNode(scanInstance *compv1alpha1.ComplianceScan, node *corev1.N
 	podName := getPodForNodeName(scanInstance.Name, node.Name)
 	cmName := getConfigMapForNodeName(scanInstance.Name, node.Name)
 	podLabels := map[string]string{
-		compv1alpha1.ComplianceScanLabel: scanInstance.Name,
-		"targetNode":                     node.Name,
-		"workload":                       "scanner",
+		compv1alpha1.ComplianceScanLabel:       scanInstance.Name,
+		compv1alpha1.NetworkPolicyOperandLabel: "",
+		"targetNode":                           node.Name,
+		WorkloadLabel:                          WorkloadScanner,
 	}
 	falseP := false
 	trueP := true
@@ -470,8 +471,9 @@ func addScannerContainer(scanInstance *compv1alpha1.ComplianceScan, pod *corev1.
 func (r *ReconcileComplianceScan) newPlatformScanPod(scanInstance *compv1alpha1.ComplianceScan, logger logr.Logger) *corev1.Pod {
 	podName := getPodForNodeName(scanInstance.Name, PlatformScanName)
 	podLabels := map[string]string{
-		compv1alpha1.ComplianceScanLabel: scanInstance.Name,
-		"workload":                       "scanner",
+		compv1alpha1.ComplianceScanLabel:       scanInstance.Name,
+		compv1alpha1.NetworkPolicyOperandLabel: "",
+		WorkloadLabel:                          WorkloadScanner,
 	}
 	trueP := true
 	pod := &corev1.Pod{

--- a/pkg/controller/compliancesuite/suitererunner_cron_compat.go
+++ b/pkg/controller/compliancesuite/suitererunner_cron_compat.go
@@ -124,9 +124,10 @@ func (r *ReconcileComplianceSuite) getRerunnerPodTemplate(
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				compv1alpha1.SuiteLabel:       suite.Name,
-				compv1alpha1.SuiteScriptLabel: "",
-				"workload":                    "suitererunner",
+				compv1alpha1.SuiteLabel:                suite.Name,
+				compv1alpha1.SuiteScriptLabel:          "",
+				compv1alpha1.NetworkPolicyOperandLabel: "",
+				"workload":                             "suitererunner",
 			},
 			Annotations: map[string]string{
 				"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,

--- a/pkg/controller/compliancesuite/suitererunner_networkpolicy_test.go
+++ b/pkg/controller/compliancesuite/suitererunner_networkpolicy_test.go
@@ -1,0 +1,27 @@
+package compliancesuite
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+)
+
+// TestRerunnerPodTemplateCarriesNetworkPolicyMarker verifies the rerunner
+// CronJob pod template carries the operand NetworkPolicy marker so the operand
+// policies select it.
+func TestRerunnerPodTemplateCarriesNetworkPolicyMarker(t *testing.T) {
+	r := &ReconcileComplianceSuite{}
+	suite := &compv1alpha1.ComplianceSuite{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-suite",
+			Namespace: "openshift-compliance",
+		},
+	}
+
+	tmpl := r.getRerunnerPodTemplate(suite, "")
+	if v, ok := tmpl.ObjectMeta.Labels[compv1alpha1.NetworkPolicyOperandLabel]; !ok || v != "" {
+		t.Errorf("rerunner pod template missing NetworkPolicy marker (labels=%v)", tmpl.ObjectMeta.Labels)
+	}
+}

--- a/pkg/controller/profilebundle/profilebundle_controller.go
+++ b/pkg/controller/profilebundle/profilebundle_controller.go
@@ -464,6 +464,13 @@ func (r *ReconcileProfileBundle) newWorkloadForBundle(pb *compliancev1alpha1.Pro
 	falseP := false
 	trueP := true
 	labels := getWorkloadLabels(pb)
+	// The operand NetworkPolicy marker is added to the pod template only, not to
+	// the immutable Deployment selector.
+	podTemplateLabels := make(map[string]string, len(labels)+1)
+	for k, v := range labels {
+		podTemplateLabels[k] = v
+	}
+	podTemplateLabels[compliancev1alpha1.NetworkPolicyOperandLabel] = ""
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pb.Name + "-" + pb.Namespace + "-pp",
@@ -487,7 +494,7 @@ func (r *ReconcileProfileBundle) newWorkloadForBundle(pb *compliancev1alpha1.Pro
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels: podTemplateLabels,
 					Annotations: map[string]string{
 						"workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
 					},

--- a/pkg/controller/profilebundle/profilebundle_controller_test.go
+++ b/pkg/controller/profilebundle/profilebundle_controller_test.go
@@ -39,6 +39,32 @@ func TestNewWorkloadForBundleUsesRecreateStrategy(t *testing.T) {
 	}
 }
 
+// TestProfileParserPodTemplateCarriesNetworkPolicyMarker verifies the
+// profileparser pod template carries the operand NetworkPolicy marker, and that
+// the marker does not leak into the immutable Deployment selector.
+func TestProfileParserPodTemplateCarriesNetworkPolicyMarker(t *testing.T) {
+	r := &ReconcileProfileBundle{}
+	pb := &compliancev1alpha1.ProfileBundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pb",
+			Namespace: "openshift-compliance",
+		},
+		Spec: compliancev1alpha1.ProfileBundleSpec{
+			ContentImage: "example.com/content:v1",
+			ContentFile:  "ssg-ocp4-ds.xml",
+		},
+	}
+	depl := r.newWorkloadForBundle(pb, "example.com/content:v1")
+
+	if v, ok := depl.Spec.Template.ObjectMeta.Labels[compliancev1alpha1.NetworkPolicyOperandLabel]; !ok || v != "" {
+		t.Errorf("profileparser pod template missing NetworkPolicy marker (labels=%v)",
+			depl.Spec.Template.ObjectMeta.Labels)
+	}
+	if _, ok := depl.Spec.Selector.MatchLabels[compliancev1alpha1.NetworkPolicyOperandLabel]; ok {
+		t.Error("profileparser Deployment selector must not carry the NetworkPolicy marker")
+	}
+}
+
 func TestWorkloadNeedsUpdateDetectsCELContentFileChange(t *testing.T) {
 	image := "example.com/content:v1"
 	operatorImage := utils.GetComponentImage(utils.OPERATOR)

--- a/tests/e2e/deployment/networkpolicy_test.go
+++ b/tests/e2e/deployment/networkpolicy_test.go
@@ -1,0 +1,97 @@
+package deployment_e2e
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	compv1alpha1 "github.com/ComplianceAsCode/compliance-operator/pkg/apis/compliance/v1alpha1"
+	"github.com/ComplianceAsCode/compliance-operator/tests/e2e/framework"
+)
+
+// Names mirror the constants in pkg/controller/compliancescan/networkpolicy.go.
+// The e2e treats the operator as a black box, so they are duplicated here.
+const (
+	npDefaultDeny         = "compliance-operator-operands-default-deny"
+	npAllowEgress         = "compliance-operator-operands-allow-egress"
+	npResultServerIngress = "compliance-operator-resultserver-allow-ingress"
+)
+
+// TestOperandNetworkPoliciesAreReconciled verifies that running a scan causes the
+// operator to reconcile the operand NetworkPolicies, and that operands still
+// function with the policies in place. A node scan is used deliberately: its
+// host-networked scanner pods must reach the result server on 8443 through the
+// ingress policy, so the scan reaching Done exercises the host-network ingress
+// path end to end.
+func TestOperandNetworkPoliciesAreReconciled(t *testing.T) {
+	f := framework.Global
+
+	scanName := framework.GetObjNameFromTest(t)
+	testScan := &compv1alpha1.ComplianceScan{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scanName,
+			Namespace: f.OperatorNamespace,
+		},
+		Spec: compv1alpha1.ComplianceScanSpec{
+			Profile:      "xccdf_org.ssgproject.content_profile_moderate",
+			Content:      framework.RhcosContentFile,
+			ContentImage: contentImagePath,
+			// A single rule keeps the scan fast; we only care that operands run.
+			Rule: "xccdf_org.ssgproject.content_rule_no_netrc_files",
+			ComplianceScanSettings: compv1alpha1.ComplianceScanSettings{
+				Debug: true,
+			},
+		},
+	}
+	if err := f.Client.Create(context.TODO(), testScan, nil); err != nil {
+		t.Fatalf("failed to create scan %s: %s", scanName, err)
+	}
+	defer f.Client.Delete(context.TODO(), testScan)
+
+	// Reaching Done means the host-networked scanner delivered its results to the
+	// result server through the ingress policy: operands function with policies in
+	// place.
+	if err := f.WaitForScanStatus(f.OperatorNamespace, scanName, compv1alpha1.PhaseDone); err != nil {
+		t.Fatalf("scan %s did not complete with NetworkPolicies in place: %s", scanName, err)
+	}
+
+	// All three operand NetworkPolicies must exist.
+	for _, name := range []string{npDefaultDeny, npAllowEgress, npResultServerIngress} {
+		np, err := f.KubeClient.NetworkingV1().NetworkPolicies(f.OperatorNamespace).Get(
+			context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected NetworkPolicy %q to exist: %s", name, err)
+		}
+		if len(np.Spec.PolicyTypes) == 0 {
+			t.Errorf("NetworkPolicy %q has no policy types", name)
+		}
+	}
+
+	// default-deny must select operand pods and carry no allow rules.
+	dd, err := f.KubeClient.NetworkingV1().NetworkPolicies(f.OperatorNamespace).Get(
+		context.TODO(), npDefaultDeny, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := dd.Spec.PodSelector.MatchLabels[compv1alpha1.NetworkPolicyOperandLabel]; !ok {
+		t.Errorf("default-deny does not select operand pods: %v", dd.Spec.PodSelector.MatchLabels)
+	}
+	if len(dd.Spec.Ingress) != 0 || len(dd.Spec.Egress) != 0 {
+		t.Errorf("default-deny must have no allow rules, got ingress=%d egress=%d",
+			len(dd.Spec.Ingress), len(dd.Spec.Egress))
+	}
+
+	// result-server ingress must open the result server port.
+	rs, err := f.KubeClient.NetworkingV1().NetworkPolicies(f.OperatorNamespace).Get(
+		context.TODO(), npResultServerIngress, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rs.Spec.Ingress) != 1 || len(rs.Spec.Ingress[0].Ports) != 1 {
+		t.Fatalf("unexpected result-server ingress rule shape: %+v", rs.Spec.Ingress)
+	}
+	if p := rs.Spec.Ingress[0].Ports[0].Port; p == nil || p.IntVal != 8443 {
+		t.Errorf("result-server ingress should open port 8443, got %v", p)
+	}
+}


### PR DESCRIPTION
# CMP-4569: Create operand NetworkPolicies at runtime

> **Depends on #1313 (CMP-4496).** This PR consumes the `networking.k8s.io/networkpolicies`
> RBAC (`create`/`delete`/`get`/`update`) added there. Until #1313 merges, this PR's diff
> includes those two RBAC commits as its base; once #1313 merges they drop out on rebase.

# What

Per [HPSTRAT-104], layered operators must create NetworkPolicies for their operand pods.
This is the operand half of that work for the Compliance Operator (the RBAC half is #1313).
The operator now creates and reconciles label-scoped NetworkPolicies for **all** of its
operand pods, so operand traffic is governed at runtime instead of being unrestricted.

- Add a common marker label `compliance.openshift.io/netpol-managed: ""` to every operand
  pod template: node scanner, platform scanner, aggregator, result server, profileparser,
  and the suite rerunner CronJob.
  - For the two operand **Deployments** (result server, profileparser) the marker is added
    to the pod template **only**, never to the Deployment/Service selector, since a
    Deployment's `spec.selector` is immutable after creation.
- Add three named NetworkPolicies in the operator namespace, reconciled by the
  ComplianceScan controller (`pkg/controller/compliancescan/networkpolicy.go`):
  1. `compliance-operator-operands-default-deny` — selects operand pods; denies all ingress
     and egress (baseline).
  2. `compliance-operator-operands-allow-egress` — allows all egress from operand pods.
  3. `compliance-operator-resultserver-allow-ingress` — allows ingress to the result server
     on `8443/TCP` from pod-network scanners (`workload=scanner` podSelector) and from
     host-networked node scanners (the OVN `policy-group.network.openshift.io/host-network`
     namespaceSelector).
- Reconcile the policies at the start of the scan **launching** phase, before any operand
  pod is created, so operands start with their network access already governed. Reconcile
  is get-then-create/update (idempotent), with no `List` or `Watch` — matching the RBAC
  granted in #1313.
- Read `NetworkPolicy` directly from the API server (manager client
  `Cache.DisableFor: NetworkPolicy`); see **Cache bypass** below.
- Centralize the `workload` operand label key/values as constants (`config.go`) so the
  policy selectors stay in sync with the pod templates.
- Regenerate `coverage-baseline.txt` (the new tests raise coverage; `make build`/`test-unit`
  gates on the baseline).

# Why

Operand pods (scanners, result server, aggregator, profileparser, rerunner) previously ran
with no NetworkPolicy, so all ingress/egress was allowed. HPSTRAT-104 requires operators to
manage NetworkPolicies for their operands dynamically at runtime (not via the OLM bundle
manifest). This PR provides that: a default-deny baseline plus the minimal allow rules the
operands actually need.

# Cache bypass (why NetworkPolicy is read uncached)

controller-runtime's default client is cache-backed: a `Get` for a type the cache has not
seen lazily starts an **informer**, which performs a `list` + `watch`. The operand RBAC
(#1313) intentionally grants only `get`/`create`/`update`/`delete` — not `list`/`watch`.
Without intervention, the first `Get` of a NetworkPolicy starts an informer that fails with
`networkpolicies ... is forbidden: cannot list`, the reconcile errors, and scans hang in
`LAUNCHING`. The manager is therefore configured with:

```go
Client: client.Options{Cache: &client.CacheOptions{
    DisableFor: []client.Object{&networkingv1.NetworkPolicy{}},
}}
```

so NetworkPolicy reads go straight to the API server (`get` only; writes already bypass the
cache). This keeps the RBAC least-privilege (no `list`/`watch`) and requires no informer.

# Behavior notes (intended, worth knowing)

- **Scan launch is now fail-closed on NetworkPolicy reconciliation.** If policy reconcile
  fails (e.g., an admission/validating webhook rejects a NetworkPolicy, an API error, or a
  networkpolicies quota), the scan stays in `LAUNCHING` and requeues rather than launching
  operands ungoverned. Previously the scan path had no dependency on NetworkPolicy.
- **Policies are created lazily and self-heal only on scan launch.** They are created the
  first time a scan enters `LAUNCHING`. There is no controller `Watch`/`Owns` on
  NetworkPolicy (by design — no `list`/`watch` RBAC), so out-of-band deletion or edits are
  re-asserted on the next scan launch, not continuously.
- **Reconcile runs per scan.** The three policies are namespace-global but re-asserted on
  every scan's launching phase (idempotent; a few extra GETs).
- **Egress is intentionally allow-all.** The API server is not selectable by NetworkPolicy,
  and scanners make arbitrary external egress (`oscap --fetch-remote-resources` unless
  `NoExternalResources`). With a single operand bucket, the shared egress policy must
  accommodate the scanner, so egress is open; the enforced hardening here is on **ingress**.
- **New label on operand pods.** All operand pods now carry
  `compliance.openshift.io/netpol-managed=""`.
- **NetworkPolicy is read uncached operator-wide** (see above); no other operator code
  reads NetworkPolicy via the manager client, and the CEL/`api-resource-collector` content
  path is a separate binary/ServiceAccount and is unaffected.

# Known limitations / follow-ups

- **profileparser marker is applied on next redeploy after upgrade.** The profileparser
  Deployment is long-lived and `workloadNeedsUpdate` compares images/commands, not labels,
  so on operator upgrade an existing profileparser Deployment is not recreated solely to
  gain the marker — it stays outside default-deny (i.e., today's allow-all behavior) until a
  content/image change triggers a redeploy. The per-scan/per-suite operands (scanners,
  result server, aggregator, rerunner) pick up the marker on the next scan.
- **Drift comparison uses `reflect.DeepEqual` on `.Spec`.** If the API server ever defaults
  a NetworkPolicy field we don't set identically, reconcile could issue a redundant `Update`
  each pass. All spec fields we care about are set explicitly and no such churn was observed
  on-cluster; a follow-up could narrow the comparison to owned fields if it ever appears.
- **Result server ingress is scanner + host-network only.** Any future consumer that reaches
  the result server *over the network* on 8443 (rather than via the results PVC) would be
  denied. `oc compliance fetch-raw` reads the PVC via an extractor pod, so it is unaffected.

# Test plan

## Unit (local; in-memory fake client, no cluster/envtest)

```
make test-unit
# or the targeted packages:
go test ./pkg/controller/compliancescan/... ./pkg/controller/profilebundle/... ./pkg/controller/compliancesuite/...
```

Covers: policy builders (selectors, policy types, allow-all-egress shape, result-server
ingress port 8443 and both `from` peers); `reconcileNetworkPolicies` create / idempotent /
drift-correction (get/create/update only); and that every operand pod template carries the
marker while the result-server and profileparser Deployment selectors do not.

## E2E (requires OCP on OVN-Kubernetes)

`tests/e2e/deployment/networkpolicy_test.go` → `TestOperandNetworkPoliciesAreReconciled`:
runs a node ComplianceScan (host-networked scanner → result server on 8443, the critical
ingress path), waits for `DONE`, then asserts all three policies exist, default-deny selects
operands with no allow rules, and the result-server ingress opens 8443.

```
export TEST_OPERATOR_NAMESPACE=openshift-compliance
make image-to-cluster e2e-deployment \
  E2E_GO_TEST_FLAGS="-v -run TestOperandNetworkPoliciesAreReconciled -test.timeout 45m"
```

**Verified** on ClusterBot `openshift-e2e-aws 4.22` (RHEL-10, TechPreviewNoUpgrade, OVN):
the scan progressed `RUNNING → AGGREGATING → DONE` with policies in place, and all
assertions passed (`--- PASS: TestOperandNetworkPoliciesAreReconciled`).

Optional manual confirmation:
```
oc get networkpolicy -n openshift-compliance
# compliance-operator-operands-default-deny
# compliance-operator-operands-allow-egress
# compliance-operator-resultserver-allow-ingress
```

[HPSTRAT-104]: https://issues.redhat.com/browse/HPSTRAT-104
