### PR TITLE
CMP-4610: Fix scan name collision in TestTimeoutDisabledWithZeroValue

### DIFF
--- a/tests/e2e/parallel/main_test.go
+++ b/tests/e2e/parallel/main_test.go
@@ -5882,7 +5882,7 @@ func TestTimeoutDisabledWithZeroValue(t *testing.T) {
 		},
 		Profiles: []compv1alpha1.NamedObjectReference{
 			{
-				Name:     "ocp4-cis",
+				Name:     "ocp4-moderate",
 				Kind:     "Profile",
 				APIGroup: "compliance.openshift.io/v1alpha1",
 			},


### PR DESCRIPTION
TestTimeoutDisabledWithZeroValue and TestScanSettingBindingUsesDefaultScanSetting both create ScanSettingBindings referencing the ocp4-cis Profile, causing the operator to create ComplianceScans with the same name in the same namespace. When running in parallel, the faster test's cleanup deletes the shared scan, causing the slower test to fail with "ocp4-cis not found".

Use ocp4-moderate instead since this test only validates timeout behavior and does not depend on any CIS-specific checks.