### PR TITLE
CMP-4637: Mark all files in `bundle/**` as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+bundle/** linguist-generated=true

--- a/bundle/manifests/compliance.openshift.io_customrules.yaml
+++ b/bundle/manifests/compliance.openshift.io_customrules.yaml
@@ -163,7 +163,7 @@ spec:
                 description: The title of the Rule
                 type: string
               warning:
-                description: A discretionary warning about the of the Rule
+                description: A discretionary warning about the Rule
                 type: string
             required:
             - id

--- a/bundle/manifests/compliance.openshift.io_rules.yaml
+++ b/bundle/manifests/compliance.openshift.io_rules.yaml
@@ -151,7 +151,7 @@ spec:
             description: The title of the Rule
             type: string
           warning:
-            description: A discretionary warning about the of the Rule
+            description: A discretionary warning about the Rule
             type: string
         required:
         - id

--- a/config/crd/bases/compliance.openshift.io_customrules.yaml
+++ b/config/crd/bases/compliance.openshift.io_customrules.yaml
@@ -163,7 +163,7 @@ spec:
                 description: The title of the Rule
                 type: string
               warning:
-                description: A discretionary warning about the of the Rule
+                description: A discretionary warning about the Rule
                 type: string
             required:
             - id

--- a/config/crd/bases/compliance.openshift.io_rules.yaml
+++ b/config/crd/bases/compliance.openshift.io_rules.yaml
@@ -151,7 +151,7 @@ spec:
             description: The title of the Rule
             type: string
           warning:
-            description: A discretionary warning about the of the Rule
+            description: A discretionary warning about the Rule
             type: string
         required:
         - id

--- a/config/helm/crds/compliance.openshift.io_rules_crd.yaml
+++ b/config/helm/crds/compliance.openshift.io_rules_crd.yaml
@@ -73,7 +73,7 @@ spec:
             description: The title of the Rule
             type: string
           warning:
-            description: A discretionary warning about the of the Rule
+            description: A discretionary warning about the Rule
             type: string
         required:
         - id

--- a/pkg/apis/compliance/v1alpha1/rule_types.go
+++ b/pkg/apis/compliance/v1alpha1/rule_types.go
@@ -37,7 +37,7 @@ type RulePayload struct {
 	Description string `json:"description,omitempty"`
 	// The rationale of the Rule
 	Rationale string `json:"rationale,omitempty"`
-	// A discretionary warning about the of the Rule
+	// A discretionary warning about the Rule
 	Warning string `json:"warning,omitempty"`
 	// The severity level
 	Severity string `json:"severity,omitempty"`


### PR DESCRIPTION
This is to avoid confusion when reviewing changes on GitHub.