### PR TITLE
Update operator version from 1.10.0-dev to 1.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,10 @@ endif
 .PHONY: update-version-numbers
 update-version-numbers: check-operator-version ## Set skip range and version numbers in manifests.
 	@CURRENT_VERSION=$$(grep '^VERSION?=' version.Makefile | cut -d= -f2); \
-	if [ "$(VERSION)" != "$$CURRENT_VERSION" ]; then \
+	if [ "$$CURRENT_VERSION" = "$(VERSION)-dev" ]; then \
+		echo "Releasing dev version $$CURRENT_VERSION as $(VERSION); removing -dev suffix"; \
+		sed -i 's/^ARG CO_NEW_VERSION=.*/ARG CO_NEW_VERSION="$(VERSION)"/' bundle.openshift.Dockerfile; \
+	elif [ "$(VERSION)" != "$$CURRENT_VERSION" ]; then \
 		sed -i "s/^ARG CO_OLD_VERSION=.*/ARG CO_OLD_VERSION=\"$$CURRENT_VERSION\"/" bundle.openshift.Dockerfile; \
 		sed -i 's/^ARG CO_NEW_VERSION=.*/ARG CO_NEW_VERSION="$(VERSION)"/' bundle.openshift.Dockerfile; \
 		sed -i "s/^PREVIOUS_VERSION?=.*/PREVIOUS_VERSION?=$$CURRENT_VERSION/" version.Makefile; \

--- a/bundle.openshift.Dockerfile
+++ b/bundle.openshift.Dockerfile
@@ -1,5 +1,5 @@
 ARG CO_OLD_VERSION="1.9.2"
-ARG CO_NEW_VERSION="1.10.0-dev"
+ARG CO_NEW_VERSION="1.10.0"
 
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25 as builder
 

--- a/bundle/manifests/compliance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/compliance-operator.clusterserviceversion.yaml
@@ -161,7 +161,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
     must-gather-image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-must-gather-dev:master
-    olm.skipRange: '>=0.1.17 <1.10.0-dev'
+    olm.skipRange: '>=0.1.17 <1.10.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
@@ -176,7 +176,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: compliance-operator.v1.10.0-dev
+  name: compliance-operator.v1.10.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1809,4 +1809,4 @@ spec:
   - image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-content-dev:master
     name: profile
   replaces: compliance-operator.v1.9.2
-  version: 1.10.0-dev
+  version: 1.10.0

--- a/catalog/preamble.json
+++ b/catalog/preamble.json
@@ -13,8 +13,8 @@
     "package": "compliance-operator",
     "entries": [
         {
-            "name": "compliance-operator.v1.10.0-dev",
-            "skipRange": ">=0.1.17 <1.10.0-dev"
+            "name": "compliance-operator.v1.10.0",
+            "skipRange": ">=0.1.17 <1.10.0"
         }
     ]
 }

--- a/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/compliance-operator.clusterserviceversion.yaml
@@ -161,7 +161,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring,Security
     must-gather-image: quay.io/redhat-user-workloads/ocp-isc-tenant/compliance-operator-must-gather-dev:master
-    olm.skipRange: '>=0.1.17 <1.10.0-dev'
+    olm.skipRange: '>=0.1.17 <1.10.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-compliance
     operators.openshift.io/infrastructure-features: '["disconnected", "fips", "proxy-aware"]'
@@ -174,7 +174,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: compliance-operator.v1.8.0-dev
+  name: compliance-operator.v1.10.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1596,4 +1596,4 @@ spec:
     name: Red Hat Inc.
     url: www.redhat.com
   replaces: compliance-operator.v1.9.2
-  version: 1.10.0-dev
+  version: 1.10.0

--- a/images/must-gather/Containerfile
+++ b/images/must-gather/Containerfile
@@ -14,7 +14,7 @@ LABEL \
         com.redhat.component="openshift-compliance-must-gather-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Compliance Operator" \
-        version=1.10.0-dev
+        version=1.10.0
 
 # Install openshift-clients, jq, tar, and rsync, which are required for
 # must-gather.

--- a/images/openscap/Containerfile
+++ b/images/openscap/Containerfile
@@ -15,7 +15,7 @@ LABEL \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Compliance Operator" \
         run="podman run --privileged -v /:/host  -eHOSTROOT=/host -ePROFILE=xccdf_org.ssgproject.content_profile_coreos-fedramp -eCONTENT=ssg-rhcos4-ds.xml -eREPORT_DIR=/reports -eRULE=xccdf_org.ssgproject.content_rule_selinux_state" \
-        version=1.10.0-dev
+        version=1.10.0
 
 RUN microdnf -y update glibc
 RUN microdnf -y install openscap openscap-scanner

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -38,7 +38,7 @@ LABEL \
         com.redhat.component="openshift-compliance-operator-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Compliance Operator" \
-        version=1.10.0-dev
+        version=1.10.0
 
 WORKDIR /
 

--- a/version.Makefile
+++ b/version.Makefile
@@ -3,4 +3,4 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 
 PREVIOUS_VERSION?=1.9.2
-VERSION?=1.10.0-dev
+VERSION?=1.10.0

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.10.0-dev"
+	Version = "1.10.0"
 )


### PR DESCRIPTION
Updated `make bundle` to handle the "-dev" suffix.
`make bundle VERSION=1.10.0`  now just removes the "-dev" suffix from the version and keeps the previous version.