### PR TITLE
CMP-4716: Bump Go to 1.25.14 to fix stdlib CVEs

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # Step one: build compliance-operator
-FROM golang:1.25.11 AS builder
+FROM golang:1.25.14 AS builder
 
 WORKDIR /go/src/github.com/openshift/compliance-operator
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ComplianceAsCode/compliance-operator
 
-go 1.25.11
+go 1.25.14
 
 require (
 	github.com/ComplianceAsCode/compliance-sdk v0.0.0-20250930163558-59886979dd19

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.11 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.14-202609021839.p0.gedd1cdd.assembly.stream.el9 as builder
 
 WORKDIR /go/src/github.com/ComplianceAsCode/compliance-operator
 


### PR DESCRIPTION
## Description

Compliance Operator 1.9.x is built with Go 1.25.11, which predates the Go 1.25.13 security release. Trivy on the release-1.9 operator image (the "Security scan for Compliance Operator image" check, see #1363) reports 8 HIGH stdlib CVEs in `usr/local/bin/compliance-operator`.

This bumps the toolchain to Go 1.25.14 in the three places that must stay in sync:

- `go.mod`: `go 1.25.14`
- `build/Dockerfile`: `golang:1.25.14` (the image the Trivy scan workflow builds)
- `images/operator/Dockerfile`: `openshift-golang-builder` pinned to `v1.25.14-202609021839.p0.gedd1cdd.assembly.stream.el9` (Konflux)

The Konflux builder is pinned to the el9 NVR tag on purpose: the floating `v1.25.14` and `v1.25` tags on brew currently resolve to the RHEL 8 build (`golang-1.25.14-1.el8_10`), while the `v1.25.11` we build with today is el9. There is no `v1.25.13` builder; 1.25.14 is the first patch on the 1.25 line that carries the fixes.

CVEs fixed (all Go standard library, fixed in Go 1.25.13): CVE-2026-56860 (net/url), CVE-2026-56859 (encoding/xml), CVE-2026-56853 (net/http), CVE-2026-56858 (html/template), CVE-2026-56862 (crypto/tls), CVE-2026-33818 (encoding/asn1), CVE-2026-39821 (net/http, x/net idna), CVE-2026-39822 (os).

Jira: CMP-4716 (trackers CMP-4580, CMP-4582, CMP-4585, CMP-4588, CMP-4591, CMP-4594, CMP-4387, CMP-4388).

## Testing

- `go mod tidy` and `go mod vendor` with Go 1.25.14: no changes.
- `go build`, `go vet ./...` and `make test-unit` with Go 1.25.14: pass (15 packages).
- `govulncheck -mode binary` on the operator binary: 8 findings with 1.25.11 (7 stdlib plus coreos/ignition), 1 with 1.25.14 (only GO-2022-0451 in `github.com/coreos/ignition@v0.35.0`, unrelated to the toolchain).
- Trivy with the workflow's settings (`--severity CRITICAL,HIGH --ignore-unfixed`) on the operator binary: 8 HIGH with 1.25.11, the same list as the failing check on #1363; 0 with 1.25.14.
- `go build -tags strictfipsruntime` inside the pinned el9 builder image (`go1.25.14 (Red Hat 1.25.14-1.el9)`, `CGO_ENABLED=1`): builds and the binary runs.
- Not addressed here: the "Security scan for git repo" check flags dependency CVEs in `golang.org/x/crypto`, `golang.org/x/mod` and `google.golang.org/grpc`. Those need dependency bumps and are out of scope for the toolchain change.

Follow-ups: the same change is needed on `release-1.10` and `master`. `master` additionally needs the Prow `build_root` in openshift/release moved from `rhel-9-golang-1.25-openshift-4.21` (Go 1.25.12, `GOTOOLCHAIN=local`) to `rhel-9-golang-1.25-openshift-4.22` (Go 1.25.14) first, otherwise the unit/verify jobs fail on the go directive.

Generated with [Claude Code](https://claude.com/claude-code)
